### PR TITLE
PG-253 Tooltip now shows on hover over any part of context

### DIFF
--- a/Glyssen/Controls/ScriptBlocksViewer.Designer.cs
+++ b/Glyssen/Controls/ScriptBlocksViewer.Designer.cs
@@ -32,7 +32,7 @@
 			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
 			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
 			this.m_panel = new System.Windows.Forms.Panel();
-			this.m_dataGridViewBlocks = new Controls.ScriptBlocksGridView();
+			this.m_dataGridViewBlocks = new Glyssen.Controls.ScriptBlocksGridView();
 			this.colReference = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.colCharacter = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.colDelivery = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -154,7 +154,6 @@
 			this.m_blocksDisplayBrowser.Size = new System.Drawing.Size(250, 326);
 			this.m_blocksDisplayBrowser.TabIndex = 0;
 			this.m_blocksDisplayBrowser.OnMouseOver += new System.EventHandler<Gecko.DomMouseEventArgs>(this.OnMouseOver);
-			this.m_blocksDisplayBrowser.OnMouseOut += new System.EventHandler<Gecko.DomMouseEventArgs>(this.OnMouseOut);
 			this.m_blocksDisplayBrowser.OnDocumentCompleted += new System.EventHandler<Gecko.Events.GeckoDocumentCompletedEventArgs>(this.OnDocumentCompleted);
 			// 
 			// m_title

--- a/Glyssen/Controls/ScriptBlocksViewer.cs
+++ b/Glyssen/Controls/ScriptBlocksViewer.cs
@@ -163,45 +163,54 @@ namespace Glyssen.Controls
 				e.Value = m_getDelivery(block);
 			}
 		}
+
+		private void HideToolTip()
+		{
+			if(m_toolTip != null)
+			{
+				m_toolTip.Hide(this);
+				m_toolTip.Dispose();
+				m_toolTip = null;
+			}
+		}
 		#endregion
 
 		#region Browser events
 		private void OnMouseOver(object sender, DomMouseEventArgs e)
 		{
 			if (e.Target == null || m_getCharacterIdForUi == null || !m_blocksDisplayBrowser.Visible)
+			{
+				HideToolTip();
 				return;
+			}
 
 			var geckoElement = e.Target.CastToGeckoElement();
-			var divElement = geckoElement as GeckoDivElement;
-			if (divElement == null)
-				return;
+			var checkElement = geckoElement as GeckoHtmlElement;
 
-			if (divElement.Parent.ClassName == BlockNavigatorViewModel.kCssClassContext)
+			for (int i = 0; i < 10; i++)
 			{
-				m_toolTip = new ToolTip {IsBalloon = true};
+				if(checkElement == null)
+				{
+					HideToolTip();
+					return;
+				}
+				else if(checkElement.ClassName != BlockNavigatorViewModel.kCssClassContext)
+					checkElement = checkElement.Parent;
+				else
+					break;
+			}
+
+			if (m_toolTip == null)
+			{
+				m_toolTip = new ToolTip { IsBalloon = true };
+				string toolTipText = m_getCharacterIdForUi(checkElement.GetAttribute(BlockNavigatorViewModel.kDataCharacter));
+
 				// 42 and 43 are the magic numbers which happens to make these display in the correct place
 				// REVIEW: it would be nice to figure out a better way to place these which is more robust. These numbers have changed several times already
 				int x = m_blocksDisplayBrowser.Location.X + m_blocksDisplayBrowser.Size.Width - 42;
 				int y = m_blocksDisplayBrowser.Location.Y + e.ClientY - m_blocksDisplayBrowser.Margin.Top - 43;
-				m_toolTip.Show(m_getCharacterIdForUi(divElement.Parent.GetAttribute(BlockNavigatorViewModel.kDataCharacter)), this,
-					x, y);
-			}
-		}
 
-		private void OnMouseOut(object sender, DomMouseEventArgs e)
-		{
-			if (e.Target == null || m_toolTip == null)
-				return;
-			var geckoElement = e.Target.CastToGeckoElement();
-			var divElement = geckoElement as GeckoDivElement;
-			if (divElement == null)
-				return;
-
-			if (divElement.Parent.ClassName == BlockNavigatorViewModel.kCssClassContext)
-			{
-				m_toolTip.Hide(this);
-				m_toolTip.Dispose();
-				m_toolTip = null;
+				m_toolTip.Show(toolTipText, this, x, y);
 			}
 		}
 

--- a/Glyssen/Controls/ScriptBlocksViewer.cs
+++ b/Glyssen/Controls/ScriptBlocksViewer.cs
@@ -166,7 +166,7 @@ namespace Glyssen.Controls
 
 		private void HideToolTip()
 		{
-			if(m_toolTip != null)
+			if (m_toolTip != null)
 			{
 				m_toolTip.Hide(this);
 				m_toolTip.Dispose();
@@ -189,12 +189,12 @@ namespace Glyssen.Controls
 
 			for (int i = 0; i < 10; i++)
 			{
-				if(checkElement == null)
+				if (checkElement == null)
 				{
 					HideToolTip();
 					return;
 				}
-				else if(checkElement.ClassName != BlockNavigatorViewModel.kCssClassContext)
+				else if (checkElement.ClassName != BlockNavigatorViewModel.kCssClassContext)
 					checkElement = checkElement.Parent;
 				else
 					break;


### PR DESCRIPTION
When the mouseover event is triggered, up to ten parents are checked above the target to see if the element is a context.

Tooltip is only shown when no tooltip is present.

Tooltip is only hidden when an area that isn't a context is entered.