### PR TITLE
PG-303 Improve VA Info editing with Edit button

### DIFF
--- a/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
@@ -57,7 +57,7 @@
 			this.l10NSharpExtender1.SetLocalizingId(this.m_contextMenu, "DialogBoxes.VoiceActorInformation.DataGridContextMenu");
 			this.m_contextMenu.Name = "contextMenuStrip1";
 			this.m_contextMenu.ShowImageMargin = false;
-			this.m_contextMenu.Size = new System.Drawing.Size(128, 48);
+			this.m_contextMenu.Size = new System.Drawing.Size(120, 26);
 			this.m_contextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.m_contextMenu_Opening);
 			this.m_contextMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.contextMenu_ItemClicked);
 			// 
@@ -68,7 +68,7 @@
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_contextMenu_itemDeleteActors, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_contextMenu_itemDeleteActors, "DialogBoxes.VoiceActorInformation.ContextMenu.DeleteActors");
 			this.m_contextMenu_itemDeleteActors.Name = "m_contextMenu_itemDeleteActors";
-			this.m_contextMenu_itemDeleteActors.Size = new System.Drawing.Size(127, 22);
+			this.m_contextMenu_itemDeleteActors.Size = new System.Drawing.Size(119, 22);
 			this.m_contextMenu_itemDeleteActors.Text = "Delete Actors";
 			// 
 			// m_deleteRowsToolStripMenuItem
@@ -114,6 +114,7 @@
 			this.m_dataGrid.ContextMenuStrip = this.m_contextMenu;
 			this.m_dataGrid.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.m_dataGrid.DrawTextBoxEditControlBorder = false;
+			this.m_dataGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
 			this.m_dataGrid.Font = new System.Drawing.Font("Segoe UI", 9F);
 			this.m_dataGrid.FullRowFocusRectangleColor = System.Drawing.Color.Empty;
 			this.m_dataGrid.GridColor = System.Drawing.Color.Black;
@@ -156,6 +157,7 @@
 			// 
 			// ActorName
 			// 
+			this.ActorName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
 			this.ActorName.DataPropertyName = "Name";
 			dataGridViewCellStyle3.NullValue = "[new actor]";
 			this.ActorName.DefaultCellStyle = dataGridViewCellStyle3;
@@ -165,6 +167,7 @@
 			// 
 			// ActorGender
 			// 
+			this.ActorGender.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
 			this.ActorGender.DataPropertyName = "Gender";
 			this.ActorGender.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
 			this.ActorGender.HeaderText = "_L10N_:DialogBoxes.VoiceActorInformation.Gender!Gender";
@@ -174,9 +177,11 @@
 			this.ActorGender.MinimumWidth = 90;
 			this.ActorGender.Name = "ActorGender";
 			this.ActorGender.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+			this.ActorGender.Width = 342;
 			// 
 			// ActorAge
 			// 
+			this.ActorAge.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
 			this.ActorAge.DataPropertyName = "Age";
 			dataGridViewCellStyle4.BackColor = System.Drawing.Color.White;
 			this.ActorAge.DefaultCellStyle = dataGridViewCellStyle4;
@@ -189,6 +194,7 @@
 			this.ActorAge.MinimumWidth = 90;
 			this.ActorAge.Name = "ActorAge";
 			this.ActorAge.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+			this.ActorAge.Width = 308;
 			// 
 			// VoiceActorInformationGrid
 			// 

--- a/Glyssen/Controls/VoiceActorInformationGrid.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.cs
@@ -46,6 +46,12 @@ namespace Glyssen.Controls
 			get { return m_dataGrid.SelectedRows; }
 		}
 
+		public bool ReadOnly
+		{
+			get { return m_dataGrid.ReadOnly; }
+			set { m_dataGrid.ReadOnly = value; }
+		}
+
 		public void Initialize(Project project)
 		{
 			m_project = project;
@@ -65,6 +71,17 @@ namespace Glyssen.Controls
 		public DataGridView.HitTestInfo HitTest(int x, int y)
 		{
 			return m_dataGrid.HitTest(x, y);
+		}
+
+		public DataGridViewEditMode EditMode
+		{
+			get { return m_dataGrid.EditMode; }
+			set { m_dataGrid.EditMode = value; }
+		}
+
+		public bool EndEdit()
+		{
+			return m_dataGrid.EndEdit();
 		}
 
 		private void LoadVoiceActorInformation()

--- a/Glyssen/Dialogs/VoiceActorAssignmentDlg.Designer.cs
+++ b/Glyssen/Dialogs/VoiceActorAssignmentDlg.Designer.cs
@@ -49,19 +49,22 @@ namespace Glyssen.Dialogs
 			this.label2 = new System.Windows.Forms.Label();
 			this.label3 = new System.Windows.Forms.Label();
 			this.m_linkClose = new System.Windows.Forms.LinkLabel();
-			this.m_saveStatus = new Glyssen.Controls.SaveStatus();
-			this.m_voiceActorGrid = new Glyssen.Controls.VoiceActorInformationGrid();
-			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+			this.m_linkEdit = new System.Windows.Forms.LinkLabel();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+			this.panel1 = new System.Windows.Forms.Panel();
+			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+			this.m_saveStatus = new Glyssen.Controls.SaveStatus();
+			this.m_voiceActorGrid = new Glyssen.Controls.VoiceActorInformationGrid();
 			((System.ComponentModel.ISupportInitialize)(this.m_characterGroupGrid)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).BeginInit();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.tableLayoutPanel2.SuspendLayout();
+			this.panel1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
 			this.splitContainer1.Panel1.SuspendLayout();
 			this.splitContainer1.Panel2.SuspendLayout();
 			this.splitContainer1.SuspendLayout();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// m_btnAssignActor
@@ -70,7 +73,7 @@ namespace Glyssen.Dialogs
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_btnAssignActor, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_btnAssignActor, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_btnAssignActor, "DialogBoxes.VoiceActorAssignmentDlg.AssignActor");
-			this.m_btnAssignActor.Location = new System.Drawing.Point(376, 134);
+			this.m_btnAssignActor.Location = new System.Drawing.Point(318, 134);
 			this.m_btnAssignActor.Name = "m_btnAssignActor";
 			this.m_btnAssignActor.Size = new System.Drawing.Size(48, 36);
 			this.m_btnAssignActor.TabIndex = 2;
@@ -154,7 +157,7 @@ namespace Glyssen.Dialogs
 			this.m_characterGroupGrid.SelectedRowForeColor = System.Drawing.Color.Empty;
 			this.m_characterGroupGrid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
 			this.m_characterGroupGrid.ShowWaterMarkWhenDirty = false;
-			this.m_characterGroupGrid.Size = new System.Drawing.Size(357, 421);
+			this.m_characterGroupGrid.Size = new System.Drawing.Size(300, 356);
 			this.m_characterGroupGrid.TabIndex = 0;
 			this.m_characterGroupGrid.TextBoxEditControlBorderColor = System.Drawing.Color.Silver;
 			this.m_characterGroupGrid.WaterMark = "!";
@@ -219,7 +222,7 @@ namespace Glyssen.Dialogs
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_btnUpdateGroup, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_btnUpdateGroup, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_btnUpdateGroup, "DialogBoxes.VoiceActorAssignmentDlg.UpdateGroup");
-			this.m_btnUpdateGroup.Location = new System.Drawing.Point(15, 472);
+			this.m_btnUpdateGroup.Location = new System.Drawing.Point(15, 407);
 			this.m_btnUpdateGroup.Name = "m_btnUpdateGroup";
 			this.m_btnUpdateGroup.Size = new System.Drawing.Size(185, 23);
 			this.m_btnUpdateGroup.TabIndex = 4;
@@ -234,7 +237,7 @@ namespace Glyssen.Dialogs
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.label2, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.label2, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.label2, "DialogBoxes.VoiceActorAssignmentDlg.label2");
-			this.label2.Location = new System.Drawing.Point(133, 3);
+			this.label2.Location = new System.Drawing.Point(105, 3);
 			this.label2.Name = "label2";
 			this.label2.Size = new System.Drawing.Size(90, 13);
 			this.label2.TabIndex = 1;
@@ -242,13 +245,13 @@ namespace Glyssen.Dialogs
 			// 
 			// label3
 			// 
-			this.label3.Anchor = System.Windows.Forms.AnchorStyles.None;
+			this.label3.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
 			this.label3.AutoSize = true;
 			this.label3.ForeColor = System.Drawing.Color.White;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.label3, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.label3, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.label3, "DialogBoxes.VoiceActorAssignmentDlg.label3");
-			this.label3.Location = new System.Drawing.Point(122, 3);
+			this.label3.Location = new System.Drawing.Point(87, 0);
 			this.label3.Name = "label3";
 			this.label3.Size = new System.Drawing.Size(67, 13);
 			this.label3.TabIndex = 2;
@@ -258,10 +261,11 @@ namespace Glyssen.Dialogs
 			// 
 			this.m_linkClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.m_linkClose.AutoSize = true;
+			this.m_linkClose.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(153)))), ((int)(((byte)(255)))));
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_linkClose, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_linkClose, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_linkClose, "DialogBoxes.VoiceActorAssignmentDlg.Close");
-			this.m_linkClose.Location = new System.Drawing.Point(705, 477);
+			this.m_linkClose.Location = new System.Drawing.Point(579, 412);
 			this.m_linkClose.Name = "m_linkClose";
 			this.m_linkClose.Size = new System.Drawing.Size(33, 13);
 			this.m_linkClose.TabIndex = 5;
@@ -269,35 +273,61 @@ namespace Glyssen.Dialogs
 			this.m_linkClose.Text = "Close";
 			this.m_linkClose.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.m_linkClose_LinkClicked);
 			// 
-			// m_saveStatus
+			// m_linkEdit
 			// 
-			this.m_saveStatus.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-			this.m_saveStatus.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.m_saveStatus.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
-			this.m_saveStatus.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
-			this.m_saveStatus.ForeColor = System.Drawing.Color.White;
-			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_saveStatus, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this.m_saveStatus, null);
-			this.l10NSharpExtender1.SetLocalizingId(this.m_saveStatus, "DialogBoxes.VoiceActorAssignmentDlg.SaveStatus");
-			this.m_saveStatus.Location = new System.Drawing.Point(427, 477);
-			this.m_saveStatus.Name = "m_saveStatus";
-			this.m_saveStatus.Size = new System.Drawing.Size(122, 49);
-			this.m_saveStatus.TabIndex = 6;
+			this.m_linkEdit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.m_linkEdit.AutoSize = true;
+			this.m_linkEdit.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(153)))), ((int)(((byte)(255)))));
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_linkEdit, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_linkEdit, null);
+			this.l10NSharpExtender1.SetLocalizingId(this.m_linkEdit, "DialogBoxes.VoiceActorAssignmentDlg.Edit");
+			this.m_linkEdit.Location = new System.Drawing.Point(214, 0);
+			this.m_linkEdit.Name = "m_linkEdit";
+			this.m_linkEdit.Size = new System.Drawing.Size(25, 13);
+			this.m_linkEdit.TabIndex = 6;
+			this.m_linkEdit.TabStop = true;
+			this.m_linkEdit.Text = "Edit";
+			this.m_linkEdit.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.m_linkEdit_LinkClicked);
 			// 
-			// m_voiceActorGrid
+			// tableLayoutPanel1
 			// 
-			this.m_voiceActorGrid.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
-			this.m_voiceActorGrid.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
-			this.m_voiceActorGrid.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_voiceActorGrid, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this.m_voiceActorGrid, null);
-			this.l10NSharpExtender1.SetLocalizationPriority(this.m_voiceActorGrid, L10NSharp.LocalizationPriority.NotLocalizable);
-			this.l10NSharpExtender1.SetLocalizingId(this.m_voiceActorGrid, "DialogBoxes.VoiceActorAssignmentDlg.VoiceActorInformationGrid");
-			this.m_voiceActorGrid.Location = new System.Drawing.Point(0, 20);
-			this.m_voiceActorGrid.Margin = new System.Windows.Forms.Padding(0);
-			this.m_voiceActorGrid.Name = "m_voiceActorGrid";
-			this.m_voiceActorGrid.Size = new System.Drawing.Size(311, 421);
-			this.m_voiceActorGrid.TabIndex = 1;
+			this.tableLayoutPanel1.ColumnCount = 1;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Controls.Add(this.m_characterGroupGrid, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
+			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 2;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(300, 376);
+			this.tableLayoutPanel1.TabIndex = 0;
+			// 
+			// tableLayoutPanel2
+			// 
+			this.tableLayoutPanel2.ColumnCount = 1;
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.Controls.Add(this.m_voiceActorGrid, 0, 1);
+			this.tableLayoutPanel2.Controls.Add(this.panel1, 0, 0);
+			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+			this.tableLayoutPanel2.RowCount = 2;
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.Size = new System.Drawing.Size(242, 376);
+			this.tableLayoutPanel2.TabIndex = 2;
+			// 
+			// panel1
+			// 
+			this.panel1.Controls.Add(this.m_linkEdit);
+			this.panel1.Controls.Add(this.label3);
+			this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.panel1.Location = new System.Drawing.Point(3, 3);
+			this.panel1.Name = "panel1";
+			this.panel1.Size = new System.Drawing.Size(236, 14);
+			this.panel1.TabIndex = 2;
 			// 
 			// splitContainer1
 			// 
@@ -317,49 +347,52 @@ namespace Glyssen.Dialogs
 			// 
 			this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel2);
 			this.splitContainer1.Panel2.Margin = new System.Windows.Forms.Padding(3);
-			this.splitContainer1.Panel2MinSize = 300;
-			this.splitContainer1.Size = new System.Drawing.Size(723, 441);
-			this.splitContainer1.SplitterDistance = 357;
+			this.splitContainer1.Panel2MinSize = 200;
+			this.splitContainer1.Size = new System.Drawing.Size(597, 376);
+			this.splitContainer1.SplitterDistance = 300;
 			this.splitContainer1.SplitterWidth = 55;
 			this.splitContainer1.TabIndex = 0;
 			this.splitContainer1.TabStop = false;
 			this.splitContainer1.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.splitContainer1_SplitterMoved);
 			this.splitContainer1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.splitContainer1_MouseUp);
 			// 
-			// tableLayoutPanel1
+			// m_saveStatus
 			// 
-			this.tableLayoutPanel1.ColumnCount = 1;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Controls.Add(this.m_characterGroupGrid, 0, 1);
-			this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
-			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 2;
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(357, 441);
-			this.tableLayoutPanel1.TabIndex = 0;
+			this.m_saveStatus.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+			this.m_saveStatus.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.m_saveStatus.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_saveStatus.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_saveStatus.ForeColor = System.Drawing.Color.White;
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_saveStatus, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_saveStatus, null);
+			this.l10NSharpExtender1.SetLocalizingId(this.m_saveStatus, "DialogBoxes.VoiceActorAssignmentDlg.SaveStatus");
+			this.m_saveStatus.Location = new System.Drawing.Point(373, 412);
+			this.m_saveStatus.Name = "m_saveStatus";
+			this.m_saveStatus.Size = new System.Drawing.Size(182, 18);
+			this.m_saveStatus.TabIndex = 6;
 			// 
-			// tableLayoutPanel2
+			// m_voiceActorGrid
 			// 
-			this.tableLayoutPanel2.ColumnCount = 1;
-			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Controls.Add(this.m_voiceActorGrid, 0, 1);
-			this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
-			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			this.tableLayoutPanel2.RowCount = 2;
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Size = new System.Drawing.Size(311, 441);
-			this.tableLayoutPanel2.TabIndex = 2;
+			this.m_voiceActorGrid.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_voiceActorGrid.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_voiceActorGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.m_voiceActorGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
+			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_voiceActorGrid, null);
+			this.l10NSharpExtender1.SetLocalizationComment(this.m_voiceActorGrid, null);
+			this.l10NSharpExtender1.SetLocalizationPriority(this.m_voiceActorGrid, L10NSharp.LocalizationPriority.NotLocalizable);
+			this.l10NSharpExtender1.SetLocalizingId(this.m_voiceActorGrid, "DialogBoxes.VoiceActorAssignmentDlg.VoiceActorInformationGrid");
+			this.m_voiceActorGrid.Location = new System.Drawing.Point(0, 20);
+			this.m_voiceActorGrid.Margin = new System.Windows.Forms.Padding(0);
+			this.m_voiceActorGrid.Name = "m_voiceActorGrid";
+			this.m_voiceActorGrid.ReadOnly = false;
+			this.m_voiceActorGrid.Size = new System.Drawing.Size(242, 356);
+			this.m_voiceActorGrid.TabIndex = 1;
+			this.m_voiceActorGrid.Leave += new System.EventHandler(this.m_voiceActorGrid_Leave);
 			// 
 			// VoiceActorAssignmentDlg
 			// 
 			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
-			this.ClientSize = new System.Drawing.Size(750, 507);
+			this.ClientSize = new System.Drawing.Size(624, 442);
 			this.Controls.Add(this.m_saveStatus);
 			this.Controls.Add(this.m_linkClose);
 			this.Controls.Add(this.m_btnAssignActor);
@@ -380,14 +413,15 @@ namespace Glyssen.Dialogs
 			this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.VoiceActorAssignmentDlg_KeyUp);
 			((System.ComponentModel.ISupportInitialize)(this.m_characterGroupGrid)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.l10NSharpExtender1)).EndInit();
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			this.tableLayoutPanel2.ResumeLayout(false);
+			this.panel1.ResumeLayout(false);
+			this.panel1.PerformLayout();
 			this.splitContainer1.Panel1.ResumeLayout(false);
 			this.splitContainer1.Panel2.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
 			this.splitContainer1.ResumeLayout(false);
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel1.PerformLayout();
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
@@ -413,6 +447,8 @@ namespace Glyssen.Dialogs
 		private System.Windows.Forms.Label label3;
 		private System.Windows.Forms.LinkLabel m_linkClose;
 		private Controls.SaveStatus m_saveStatus;
+		private System.Windows.Forms.Panel panel1;
+		private System.Windows.Forms.LinkLabel m_linkEdit;
 
 	}
 }

--- a/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
@@ -33,10 +33,13 @@ namespace Glyssen.Dialogs
 
 			WindowState = FormWindowState.Maximized;
 
+			AlignBtnAssignActorToSplitter();
+
 			m_project = project;
 			m_canAssign = true;
 
 			m_voiceActorGrid.Initialize(m_project);
+			m_voiceActorGrid.ReadOnly = true;
 
 			m_voiceActorGrid.Saved += m_voiceActorGrid_Saved;
 			m_voiceActorGrid.CellUpdated += m_voiceActorGrid_CellUpdated;
@@ -155,6 +158,9 @@ namespace Glyssen.Dialogs
 		{
 			var grid = sender as DataGridView;
 
+			if (grid.IsCurrentCellInEditMode)
+				return;
+
 			if (grid.Columns[e.ColumnIndex].DataPropertyName == "Name" && e.RowIndex >= 0 && e.Button == MouseButtons.Left)
 				AssignSelectedActorToSelectedGroup();
 		}
@@ -210,7 +216,7 @@ namespace Glyssen.Dialogs
 
 		private void m_voiceActorGrid_MouseMove(object sender, MouseEventArgs e)
 		{
-			if (e.Button == MouseButtons.Left)
+			if (m_voiceActorGrid.ReadOnly && e.Button == MouseButtons.Left)
 			{
 				var hitInfo = m_voiceActorGrid.HitTest(e.X, e.Y);
 				if (hitInfo.Type == DataGridViewHitTestType.Cell)
@@ -321,6 +327,22 @@ namespace Glyssen.Dialogs
 		{
 			SaveAssignments();
 			Close();
+		}
+
+		private void m_linkEdit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		{
+			m_voiceActorGrid.ReadOnly = false;
+			//Restore EditMode overwritten in m_voiceActorGrid_Leave
+			m_voiceActorGrid.EditMode = DataGridViewEditMode.EditOnEnter;
+			m_voiceActorGrid.Focus();
+		}
+
+		private void m_voiceActorGrid_Leave(object sender, EventArgs e)
+		{
+			m_voiceActorGrid.ReadOnly = true;
+			//EndEdit is insufficient in and of itself
+			m_voiceActorGrid.EditMode = DataGridViewEditMode.EditOnKeystrokeOrF2;
+			m_voiceActorGrid.EndEdit();
 		}
 	}
 }

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
@@ -93,12 +93,14 @@
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.m_dataGrid.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
 			this.m_dataGrid.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_dataGrid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_dataGrid, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_dataGrid, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_dataGrid, "DialogBoxes.VoiceActorInformation.voiceActorInformationGrid21");
 			this.m_dataGrid.Location = new System.Drawing.Point(12, 29);
 			this.m_dataGrid.Margin = new System.Windows.Forms.Padding(0);
 			this.m_dataGrid.Name = "m_dataGrid";
+			this.m_dataGrid.ReadOnly = false;
 			this.m_dataGrid.Size = new System.Drawing.Size(476, 264);
 			this.m_dataGrid.TabIndex = 3;
 			// 
@@ -108,12 +110,13 @@
 			this.m_saveStatus.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
 			this.m_saveStatus.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
 			this.m_saveStatus.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(73)))), ((int)(((byte)(108)))));
+			this.m_saveStatus.ForeColor = System.Drawing.Color.White;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.m_saveStatus, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.m_saveStatus, null);
 			this.l10NSharpExtender1.SetLocalizingId(this.m_saveStatus, "DialogBoxes.VoiceActorInformation.SaveStatus");
 			this.m_saveStatus.Location = new System.Drawing.Point(15, 307);
 			this.m_saveStatus.Name = "m_saveStatus";
-			this.m_saveStatus.Size = new System.Drawing.Size(99, 15);
+			this.m_saveStatus.Size = new System.Drawing.Size(224, 15);
 			this.m_saveStatus.TabIndex = 4;
 			// 
 			// VoiceActorInformationDlg


### PR DESCRIPTION
VA Info's EditMode is now EditOnEnter, which makes it easier to edit. However, the grid is readonly in VA Assign unless the "Edit" button has been clicked, whereupon the grid is editable until left.

Other un-related minor adjustments:
- Widths of split panel 2, VA Info columns, and SaveStatuses (Todo: autosize seems broken here) adjusted
- Initial color of VA Info SaveStatus white
- Initial call to AlignBtnAssignActorToSplitter in VA Assign