### PR TITLE
Tom's updates to character id localizations and automated processor

### DIFF
--- a/DevTools/TermTranslator/Processor.cs
+++ b/DevTools/TermTranslator/Processor.cs
@@ -125,7 +125,17 @@ namespace DevTools.TermTranslator
 		{
 			string[] parts = name.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
-			Localization term = s_englishTermsList.Terms.Locals.Find(t => t.Gloss == parts[0]);
+			string englishGloss = parts[0];
+			string endingPunct;
+			if (Char.IsPunctuation(englishGloss.Last()))
+			{
+				endingPunct = englishGloss.Last().ToString();
+				englishGloss = englishGloss.Remove(englishGloss.Length - 1);
+			}
+			else
+				endingPunct = null;
+
+			Localization term = s_englishTermsList.Terms.Locals.Find(t => t.Gloss == englishGloss);
 			if (term != null)
 			{
 				Localization localTerm = localTermsList.Terms.Locals.Find(t => t.Id == term.Id);
@@ -136,26 +146,29 @@ namespace DevTools.TermTranslator
 
 					if (localGloss != "")
 					{
+						if (endingPunct != null)
+							localGloss += endingPunct;
 						parts[0] = localGloss;
 
 						if (Char.IsUpper(name[0]) && parts.Length > 1)
 						{
 							for (int i = 1; i < parts.Length; i++)
 							{
-								var englishTerm = parts[i];
+								englishGloss = parts[i];
 								bool openingParenthesis = false;
-								bool closingParenthesis = false;
-								if (englishTerm.StartsWith("("))
+								if (englishGloss.StartsWith("("))
 								{
-									englishTerm = englishTerm.Substring(1);
+									englishGloss = englishGloss.Substring(1);
 									openingParenthesis = true;
 								}
-								if (englishTerm.EndsWith(")"))
+								if (Char.IsPunctuation(englishGloss.Last()))
 								{
-									englishTerm = englishTerm.Remove(englishTerm.Length - 1);
-									closingParenthesis = true;
+									endingPunct = englishGloss.Last().ToString();
+									englishGloss = englishGloss.Remove(englishGloss.Length - 1);
 								}
-								term = s_englishTermsList.Terms.Locals.Find(t => t.Gloss == parts[i]);
+								else
+									endingPunct = null;
+								term = s_englishTermsList.Terms.Locals.Find(t => t.Gloss == englishGloss);
 								if (term != null)
 								{
 									localTerm = localTermsList.Terms.Locals.Find(t => t.Id == term.Id);
@@ -167,8 +180,8 @@ namespace DevTools.TermTranslator
 										{
 											if (openingParenthesis)
 												localGloss = "(" + localGloss;
-											if (closingParenthesis)
-												localGloss += ")";
+											if (endingPunct != null)
+												localGloss += endingPunct;
 											parts[i] = localGloss;
 											continue;
 										}

--- a/DevTools/TermTranslator/Processor.cs
+++ b/DevTools/TermTranslator/Processor.cs
@@ -17,7 +17,7 @@ namespace DevTools.TermTranslator
 		// A) New/modified localizations of the Biblical Terms files (from Paratext) become available.
 		// B) New HUMAN localizations of TMX files are done for Glyssen.
 		private static readonly List<string> LanguagesToProcess = new List<string> { "Es", "Fr", "Pt", "zh-Hans", "zh-Hant" };
-		private static readonly List<string> LanguagesWithCustomizedTranslations = new List<string> {"es"};
+		private static readonly List<string> LanguagesWithCustomizedTranslations = new List<string> {"es", "fr", "pt"};
 		private static readonly bool ProcessingUpdatedBiblicalTermsFiles = false;
 
 		private static readonly Regex s_partOfChineseOrFrenchGlossThatIsNotTheGloss = new Regex("((（|。).+)|(\\[1\\] )", RegexOptions.Compiled);
@@ -123,7 +123,11 @@ namespace DevTools.TermTranslator
 		private static void AddLocalizedTerm(TmxFormat newTmx, string modifiedLangAbbr, BiblicalTermsLocalizations localTermsList,
 			Tu tmxTermEntry, string name, Action<TmxFormat, Tu, Tuv> ProcessLocalizedGloss)
 		{
-			string[] parts = name.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+			// We only want to break a character ID into separate words for individual localization if it begins with a
+			// proper name.
+			int maxParts = Char.IsUpper(name[0]) ? Int32.MaxValue : 1;
+
+			string[] parts = name.Split(new[] { ' ' }, maxParts, StringSplitOptions.RemoveEmptyEntries);
 
 			string englishGloss = parts[0];
 			string endingPunct;
@@ -150,7 +154,7 @@ namespace DevTools.TermTranslator
 							localGloss += endingPunct;
 						parts[0] = localGloss;
 
-						if (Char.IsUpper(name[0]) && parts.Length > 1)
+						if (parts.Length > 1)
 						{
 							for (int i = 1; i < parts.Length; i++)
 							{

--- a/DistFiles/localization/Glyssen.en.tmx
+++ b/DistFiles/localization/Glyssen.en.tmx
@@ -15,6 +15,12 @@
         <seg>OK</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName. guard">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg> guard</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.2 other disciples">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -201,10 +207,10 @@
         <seg>Agabus the prophet</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Agag, king of Amalekites">
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Agag, king of Amalekites</seg>
+        <seg>Agag, king of the Amalekites</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahab, king of Israel">
@@ -315,10 +321,10 @@
         <seg>Amasa)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+    <tu tuid="CharacterName.Amasai, chief of thirty">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+        <seg>Amasai, chief of thirty</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">
@@ -2961,10 +2967,10 @@
         <seg>Hadad the Edomite</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, the Egyptian">
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, the Egyptian</seg>
+        <seg>Hagar, Sarai’s maid</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haggai (word of the LORD)">
@@ -3255,12 +3261,6 @@
         <seg>Huldah, prophetess</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Huldah, prophetess (the LORD says)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Huldah, prophetess (the LORD says)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.husband of Shunammite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3379,30 +3379,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Isaiah, the prophet</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Isaiah, the prophet (sign)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Isaiah, the prophet (sign)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Isaiah, the prophet (the LORD says)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Isaiah, the prophet (the LORD says)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Isaiah, the prophet (word of the LORD came)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Isaiah, the prophet (word of the LORD came)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Isaiah, the prophet (word of the LORD)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Isaiah, the prophet (word of the LORD)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
@@ -5487,18 +5463,6 @@
         <seg>Nebuzaradan</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Nebuzaradan, Babylonian commander of imperial guard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Nebuzaradan, Babylonian commander of imperial guard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Nebuzaradan, commander for king of Babylon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Nebuzaradan, commander for king of Babylon</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Neco, king of Egypt">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -5635,6 +5599,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>officer of king of Israel, on whose arm the king leaned (post mortem)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.officers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>officers</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.officers of King of Aram">
@@ -7203,12 +7173,6 @@
         <seg>Shemaiah</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Shemaiah, prophet (the LORD says)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Shemaiah, prophet (the LORD says)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -7663,12 +7627,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>temple guards</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.temple police">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple police</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">

--- a/DistFiles/localization/Glyssen.en.tmx
+++ b/DistFiles/localization/Glyssen.en.tmx
@@ -15,12 +15,6 @@
         <seg>OK</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName. guard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg> guard</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.2 other disciples">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2967,10 +2961,10 @@
         <seg>Hadad the Edomite</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haggai (word of the LORD)">

--- a/DistFiles/localization/Glyssen.en.tmx
+++ b/DistFiles/localization/Glyssen.en.tmx
@@ -3507,12 +3507,6 @@
         <seg>Israelite foreman</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3553,6 +3547,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Israelites (excluding Benjamites)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israelites (soldiers)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelites (soldiers)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelites, all">
@@ -4789,6 +4789,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>men (angels) in clothes that gleamed like lightning, two</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.men (soldiers) standing near David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>men (soldiers) standing near David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.men (spies)">

--- a/DistFiles/localization/Glyssen.en.tmx
+++ b/DistFiles/localization/Glyssen.en.tmx
@@ -111,10 +111,10 @@
         <seg>Abishai, Joab's brother</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Abner</seg>
+        <seg>Abner, commander of Saul's army</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
@@ -129,10 +129,10 @@
         <seg>Abraham's chief servant</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
+    <tu tuid="CharacterName.Absalom, son of David">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Absalom</seg>
+        <seg>Absalom, son of David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Absalom's men">
@@ -153,10 +153,10 @@
         <seg>Achan</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Achish">
+    <tu tuid="CharacterName.Achish, king of Gath">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Achish</seg>
+        <seg>Achish, king of Gath</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Acsah, Caleb's daughter">
@@ -189,10 +189,10 @@
         <seg>Adoni-Zedek, king of Jerusalem</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Advisers to king">
+    <tu tuid="CharacterName.advisers to king">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Advisers to king</seg>
+        <seg>advisers to king</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Agabus the prophet">
@@ -225,10 +225,16 @@
         <seg>Ahaziah, king of Israel</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Ahijah, the prophet">
+    <tu tuid="CharacterName.Ahijah the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Ahijah, the prophet</seg>
+        <seg>Ahijah the priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahimaaz (messenger)">
@@ -315,12 +321,6 @@
         <seg>Amasai, chief of thirty (Spirit came upon)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -339,10 +339,10 @@
         <seg>Ammonite nobles</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amnon">
+    <tu tuid="CharacterName.Amnon, son of David">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Amnon</seg>
+        <seg>Amnon, son of David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -951,10 +951,10 @@
         <seg>Bethlehem, elders of</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
+        <seg>Bethuel, Rebekah's father</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
@@ -1017,6 +1017,12 @@
         <seg>brothers at Puteoli, some</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.brothers of beloved">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>brothers of beloved</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.bystanders at Calvary, some">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1051,12 +1057,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Caleb</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -1497,12 +1497,6 @@
         <seg>Danites</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Darius">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Darius</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Darius, king">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1543,6 +1537,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.David, king">
@@ -1969,6 +1969,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Elisha (had said)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elisha (the LORD says)">
@@ -2541,6 +2547,12 @@
         <seg>Gilead, elders of</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gilead, men of">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2895,10 +2907,10 @@
         <seg>God the Father (Majestic Glory)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
+    <tu tuid="CharacterName.Goliath, Philistine champion">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Goliath</seg>
+        <seg>Goliath, Philistine champion</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Good Priest">
@@ -2973,10 +2985,10 @@
         <seg>Haman, highest noble to Xerxes, king</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hamor">
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hamor</seg>
+        <seg>Hamor, Hivite ruler</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -2995,6 +3007,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Hanani the seer</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hananiah, false prophet">
@@ -3133,12 +3151,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Hiram, king of Tyre</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.his sons">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>his sons</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hittites">
@@ -3495,6 +3507,12 @@
         <seg>Israelite foreman</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3507,16 +3525,10 @@
         <seg>Israelite people, the</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
+        <seg>Israelite soldier in Saul's army</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite spies from house of Joseph">
@@ -3657,16 +3669,16 @@
         <seg>Jehoash, king of Israel</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Jehoiada the priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoiada's sons">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoiada's sons</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehonadab, son of Recab">
@@ -4233,12 +4245,6 @@
         <seg>King of Nineveh</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.King Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>King Rehoboam</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.kings of the earth">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4279,12 +4285,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Laban</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Laban's mother">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Laban's mother</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Laban's sons">
@@ -4413,10 +4413,16 @@
         <seg>living creature, third</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Lookout">
+    <tu tuid="CharacterName.lookout">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Lookout</seg>
+        <seg>lookout</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.lookout in Jezreel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>lookout in Jezreel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lord">
@@ -4899,6 +4905,12 @@
         <seg>men of Jabesh</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.men of Jericho">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>men of Jericho</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.men of Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4909,18 +4921,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>men of Sodom (wicked)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.men of the city (Bethel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>men of the city (Bethel)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.men of the city (Jericho)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>men of the city (Jericho)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.men of the town (Philistines)">
@@ -5127,6 +5127,18 @@
         <seg>messengers sent from Pharisees (the Jews)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.messengers to Jezebel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>messengers to Jezebel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.messengers to Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>messengers to Saul</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Micah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -5145,10 +5157,10 @@
         <seg>Micaiah, prophet of the LORD</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
+    <tu tuid="CharacterName.Michael, archangel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
+        <seg>Michael, archangel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Michal, David's wife">
@@ -5493,10 +5505,10 @@
         <seg>Nehemiah</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.neighbors and relatives of Elizabeth (and Zechariah)">
+    <tu tuid="CharacterName.neighbors and relatives of Elizabeth and Zacharias (Zechariah)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>neighbors and relatives of Elizabeth (and Zechariah)</seg>
+        <seg>neighbors and relatives of Elizabeth and Zacharias (Zechariah)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.neighbors of man blind from birth">
@@ -5575,12 +5587,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>nobles and officials (Jewish)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.nobles of city">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>nobles of city</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.non-reader">
@@ -5715,10 +5721,10 @@
         <seg>officials, royal, to Xerxes, king</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.old man of Gibeah">
+    <tu tuid="CharacterName.old man in Gibeah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>old man of Gibeah</seg>
+        <seg>old man in Gibeah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.older daughter of Lot">
@@ -5997,10 +6003,10 @@
         <seg>people standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
+    <tu tuid="CharacterName.people who had known Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
@@ -6231,6 +6237,12 @@
         <seg>Pharaoh (3rd)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Pharaoh (6th)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharaoh (6th)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Pharaoh's daughter">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -6309,16 +6321,16 @@
         <seg>Philip</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
+    <tu tuid="CharacterName.Philip the apostle">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
+        <seg>Philip the apostle</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
+    <tu tuid="CharacterName.Philip the evangelist">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
+        <seg>Philip the evangelist</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -6333,16 +6345,16 @@
         <seg>Philistine priests and fortune tellers</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Philistine rulers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philistine rulers</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Philistines">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Philistines</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Philistines, rulers of">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Philistines, rulers of</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Phineas the priest">
@@ -6385,12 +6397,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Potiphar's wife</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>priest</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.priests">
@@ -6549,6 +6555,12 @@
         <seg>Rebekah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Rebekah's mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rebekah's mother</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.rebels">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -6571,12 +6583,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Regem-Melech</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rehoboam, king">
@@ -6735,10 +6741,10 @@
         <seg>Samson</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samson's 30 companions">
+    <tu tuid="CharacterName.Samson's 30 Philistine companions">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Samson's 30 companions</seg>
+        <seg>Samson's 30 Philistine companions</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samson's father-in-law">
@@ -6765,10 +6771,10 @@
         <seg>Samuel (boy)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samuel (old)">
+    <tu tuid="CharacterName.Samuel (dead)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Samuel (old)</seg>
+        <seg>Samuel (dead)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sanballat">
@@ -6789,10 +6795,10 @@
         <seg>Sanhedrin</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Sapphira (wife of Ananias of Jerusalem)">
+    <tu tuid="CharacterName.Sapphira, wife of Ananias of Jerusalem">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Sapphira (wife of Ananias of Jerusalem)</seg>
+        <seg>Sapphira, wife of Ananias of Jerusalem</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
@@ -6825,12 +6831,6 @@
         <seg>Saul</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Saul (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Saul (old)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Saul (Paul)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -6849,10 +6849,10 @@
         <seg>Saul's attendants</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Saul's messengers">
+    <tu tuid="CharacterName.Saul's messengers to Jesse">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Saul's messengers</seg>
+        <seg>Saul's messengers to Jesse</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul's servant">
@@ -6979,6 +6979,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>scripture (God)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.scripture (law of Moses)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>scripture (law of Moses)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.scripture (prophet)">
@@ -7275,6 +7281,12 @@
         <seg>Shua (Judah's wife)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.sign on the cross">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -7293,16 +7305,16 @@
         <seg>Simeon</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
+        <seg>Simeon, devout man in Jerusalem</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Simon (sorcerer)">
+    <tu tuid="CharacterName.Simon, sorcerer">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Simon (sorcerer)</seg>
+        <seg>Simon, sorcerer</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.singers">
@@ -7447,12 +7459,6 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>someone in Jerusalem</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.someone in Saul's army">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>someone in Saul's army</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.someone like a son of man">
@@ -7971,12 +7977,6 @@
         <seg>voice from heaven (God)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.voice from heaven (God), loud">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>voice from heaven (God), loud</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.voice from heaven (God?)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -7987,6 +7987,12 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>voice from heaven, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.voice from heaven, loud">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>voice from heaven, loud</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.voice from temple">
@@ -8247,12 +8253,6 @@
         <seg>woman, Samaritan</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.woman, Shunammite">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>woman, Shunammite</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.woman, wise">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -8379,6 +8379,12 @@
         <seg>Zaccheaus</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zacharias (Zechariah)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zacharias (Zechariah)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zalmunna">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -8427,12 +8433,6 @@
         <seg>Zechariah, son of Jehoiada the priest</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest (Spirit of God upon)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Zechariah, son of Jehoiada the priest (Spirit of God upon)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Zedekiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -8475,10 +8475,10 @@
         <seg>Zerubbabel</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Ziba">
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Ziba</seg>
+        <seg>Ziba, servant of Saul's household</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -56,15 +56,6 @@
         <seg>Abimélec</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Abner</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Abner</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -74,15 +65,6 @@
         <seg>Abraham (Abram)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Absalom</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Absalón</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Achan">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -90,15 +72,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Acán</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Achish">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Achish</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Aquís</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -126,24 +99,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Ahitófel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Amasías</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amnon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amnon</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Amnón</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -306,15 +261,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Caleb</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Caleb (anciano)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanites">
@@ -497,15 +443,6 @@
         <seg>Guehazí</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Goliath</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Goliat</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Habakkuk">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -513,15 +450,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Habacuc</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Hamor">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Hamor</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Hamor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanani">
@@ -621,15 +549,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Santiago</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Joiadá</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jephthah">
@@ -1001,15 +920,6 @@
         <seg>Rebeca</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Roboam</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1170,15 +1080,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Zacarías</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Ziba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Ziba</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Sibá</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">
@@ -1548,15 +1449,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>pueblo</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>priest</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>sacerdote</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proclamation">
@@ -2838,15 +2730,6 @@
         <seg>Balaam (sobre el cual vino el Espíritu de Dios)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Betuel (padre de Labán)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3243,24 +3126,6 @@
         <seg>israelitas</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>soldado israelita (del ejército de Saúl)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>soldados israelitas</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite spies from Joshua, two men">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3549,15 +3414,6 @@
         <seg>María madre de Santiago</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Miguel (arcángel)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3792,15 +3648,6 @@
         <seg>pueblo standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo who knew Saul</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3862,24 +3709,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Fariseo (Simón)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Felipe (apóstolo)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Felipe (el evangelista)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -3972,15 +3801,6 @@
         <seg>Samuel (niño)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samuel (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Samuel (old)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Samuel (anciano)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Sanballat the Horonite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3988,15 +3808,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Sambalat horonita</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Sapphira (wife of Ananias of Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Sapphira (wife of Ananias of Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Safira (esposa de Ananías de Jerusalén)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
@@ -4024,15 +3835,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Satanás (el diáblo)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Saul (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Saul (old)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Saulo (anciano)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -4287,24 +4089,6 @@
         <seg>señal on the cross</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Simeón (hombre justo y piadoso en Jerusalén)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simon (sorcerer)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simon (sorcerer)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Simón el mago</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.steward of Joseph's house">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4438,6 +4222,114 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Sofar naamatita</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ahías ***the*** sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ahías ***the*** profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>David ***(old)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Eliseo ***(old)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Israelita ***men***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite soldier in Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Israelita ***soldier*** ***in*** ***Saul's*** ***army***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people who had known Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people who had known Saul</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo who had known Saul</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Philistine rulers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philistine rulers</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Filisteos ***rulers***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Samuel (dead)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samuel (dead)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Samuel ***(dead)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sunamita ***woman***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Philip the apostle">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philip the apostle</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Felipe ***the*** ***apostle***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Philip the evangelist">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philip the evangelist</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Felipe ***the*** ***evangelist***</seg>
       </tuv>
     </tu>
   </body>

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -1484,7 +1484,7 @@
         <seg>seventy-two</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>setenta y dos</seg>
+        <seg>los setenta y dos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.synagogue ruler">
@@ -2559,49 +2559,13 @@
         <seg>Ananías de Damasco</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.angel flying directly overhead">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel flying directly overhead</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, second">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel flying directly overhead, second</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, third">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel flying directly overhead, third</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel from the rising sun with seal of living God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel from the rising sun with seal of living God</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.angel Gabriel, sent by God">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>angel Gabriel, sent by God</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel Gabriel, sent by God</seg>
+        <seg>ángel Gabriel, enviado por Dios</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel of God, an">
@@ -2610,7 +2574,7 @@
         <seg>angel of God, an</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel of God, an</seg>
+        <seg>ángel de Dios</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel of God, the">
@@ -2619,7 +2583,7 @@
         <seg>angel of God, the</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel of God, the</seg>
+        <seg>ángel de Dios</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel of the LORD, an">
@@ -2628,7 +2592,7 @@
         <seg>angel of the LORD, an</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel of the LORD, an</seg>
+        <seg>ángel del Señor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel of the LORD, the">
@@ -2637,43 +2601,7 @@
         <seg>angel of the LORD, the</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel of the LORD, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel or messenger (Greek variant: someone speaking to John)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel over waters">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel over waters</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel over waters</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing in sun">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing in sun</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel standing in sun</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing on sea and land">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ángel standing on sea and land</seg>
+        <seg>ángel del Señor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel who talked with Zechariah">
@@ -2682,7 +2610,7 @@
         <seg>angel who talked with Zechariah</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel who talked with Zechariah</seg>
+        <seg>ángel que habló con Zacarías</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel who talked with Zechariah (vision)">
@@ -2691,7 +2619,7 @@
         <seg>angel who talked with Zechariah (vision)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel who talked with Zechariah (vision)</seg>
+        <seg>ángel que habló con Zacarías (en una visión)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel who wrestled with Jacob">
@@ -2700,7 +2628,7 @@
         <seg>angel who wrestled with Jacob</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ángel who wrestled with Jacob</seg>
+        <seg>ángel que luchó con Jacob</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Azariah the chief priest">
@@ -2745,7 +2673,7 @@
         <seg>brother who discovered his silver in his sack</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>hermano who discovered his silver in his sack</seg>
+        <seg>hermano que descubrió su plata en su saco</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -2799,7 +2727,7 @@
         <seg>disciple who wanted to bury his father</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>discípulo who wanted to bury his father</seg>
+        <seg>discípulo que quería enterrar a su padre</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.disciple whom Jesus loved">
@@ -2808,7 +2736,7 @@
         <seg>disciple whom Jesus loved</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>discípulo whom Jesus loved</seg>
+        <seg>discípulo a quien Jesús amaba</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
@@ -2826,7 +2754,7 @@
         <seg>donkey (female)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>asno, burro (female)</seg>
+        <seg>asna</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Egyptian (slave of Amalekite)">
@@ -2844,7 +2772,7 @@
         <seg>eighty other priests</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>ochenta other priests</seg>
+        <seg>otros ochenta sacerdotes</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eleazar the priest, son of Aaron">
@@ -2980,24 +2908,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Herodes el grande</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest's servant (relative of the man whose ear Peter cut off)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>alto priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.holy one (in vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>holy one (in vision)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>santo one (in vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hosea saying what Israel should say">
@@ -3357,7 +3267,7 @@
         <seg>king of Bela</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>rey of Bela</seg>
+        <seg>rey de Bela (Zoar)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Cain)">
@@ -3376,15 +3286,6 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Lámec (descendiente de Set)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.law of Moses where LORD commanded">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>law of Moses where LORD commanded</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>ley of Moses where LORD commanded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Malta islanders">
@@ -3477,103 +3378,13 @@
         <seg>Pablo y Silas</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people at cistern">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at cistern</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo at cistern</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at coronation of King Joash">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo at coronation of King Joash</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at Jairus' house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo at Jairus' house</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.people in Capernaum">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>people in Capernaum</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo in Capernaum</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in crowd by Sea of Galilee">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in crowd by Sea of Galilee</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Jericho, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in Jericho, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Pisidian Antioch synagogue">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in Pisidian Antioch synagogue</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in temple courts, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in temple courts, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in the temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in the temple</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo in the temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people near Jordan River">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people near Jordan River</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo near Jordan River</seg>
+        <seg>pueblo de Capernaum</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of Decapolis">
@@ -3582,7 +3393,7 @@
         <seg>people of Decapolis</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of Decapolis</seg>
+        <seg>pueblo de Decapolis</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of Jerusalem">
@@ -3591,7 +3402,7 @@
         <seg>people of Jerusalem</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of Jerusalem</seg>
+        <seg>pueblo de Jerusalem</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of Jerusalem, some">
@@ -3600,7 +3411,7 @@
         <seg>people of Jerusalem, some</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of Jerusalem, some</seg>
+        <seg>pueblo de Jerusalem, algunos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of Samaria, all the">
@@ -3609,7 +3420,7 @@
         <seg>people of Samaria, all the</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of Samaria, all the</seg>
+        <seg>todo el pueblo de Samaria</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of the region of the Gerasenes">
@@ -3618,7 +3429,7 @@
         <seg>people of the region of the Gerasenes</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of the region of the Gerasenes</seg>
+        <seg>pueblo de la región de los Gerasenes</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people of Tyre and Sidon">
@@ -3627,34 +3438,7 @@
         <seg>people of Tyre and Sidon</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo of Tyre and Sidon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people praying at John Mark's mother's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo praying at John Mark's mother's house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people standing there">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people standing there</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo standing there</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>pueblo who saw healing of demon-possessed man who was blind and mute</seg>
+        <seg>pueblo de Tiro y Sidón</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon)">
@@ -3735,7 +3519,7 @@
         <seg>prophet in Bethel</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>profeta in Bethel</seg>
+        <seg>profeta en Betel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.prophet of the LORD">
@@ -3744,7 +3528,7 @@
         <seg>prophet of the LORD</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>profeta of the LORD</seg>
+        <seg>profeta del Señor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.prophet who confronts Ahab">
@@ -3753,7 +3537,7 @@
         <seg>prophet who confronts Ahab</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>profeta who confronts Ahab</seg>
+        <seg>profeta que confronta al rey Acab</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proverb about a dog">
@@ -3762,7 +3546,7 @@
         <seg>proverb about a dog</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>proverbio, comparación about a dog</seg>
+        <seg>proverbio acerca de un perro</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Puah (midwife)">
@@ -3780,7 +3564,7 @@
         <seg>queen of Babylon</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>reina of Babylon</seg>
+        <seg>reina de Babilonia</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.queen of Sheba">
@@ -3789,7 +3573,7 @@
         <seg>queen of Sheba</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>reina of Sheba</seg>
+        <seg>reina de Sabá</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samuel (boy)">
@@ -4149,7 +3933,7 @@
         <seg>young man</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>joven, nuevo man</seg>
+        <seg>joven</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.young man in white robe (angel)">
@@ -4158,7 +3942,7 @@
         <seg>young man in white robe (angel)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>joven, nuevo man in white robe (angel)</seg>
+        <seg>joven con vestiduras blancas (ángel)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.young men (advisors of Rehoboam)">
@@ -4167,7 +3951,7 @@
         <seg>young men (advisors of Rehoboam)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>joven, nuevo men (advisors of Rehoboam)</seg>
+        <seg>jovenes (consejeros de Roboám)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (the LORD says)">
@@ -4257,7 +4041,7 @@
         <seg>people who had known Saul</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>pueblo who had known Saul</seg>
+        <seg>los que habían conocido a Saúl</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine rulers">

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -980,7 +980,7 @@
         <seg>Saul</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Saulo</seg>
+        <seg>Saúl</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shemaiah">
@@ -3852,7 +3852,7 @@
         <seg>saying (proverb)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo (proverb)</seg>
+        <seg>dicho (oráculo o proverbio)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about Anakites">
@@ -3861,7 +3861,7 @@
         <seg>saying about Anakites</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about Anakites</seg>
+        <seg>dicho acerca de los anaceos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about blind and lame">
@@ -3870,7 +3870,7 @@
         <seg>saying about blind and lame</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about blind and lame</seg>
+        <seg>dicho acerca de los ciegos y cojos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about captivity and death by the sword">
@@ -3879,7 +3879,7 @@
         <seg>saying about captivity and death by the sword</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about captivity and death by the sword</seg>
+        <seg>dicho acerca de la cautividad y la espada</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about Gentile nations">
@@ -3888,7 +3888,7 @@
         <seg>saying about Gentile nations</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about Gentile nations</seg>
+        <seg>dicho acerca de las naciones</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about going beyond what is written">
@@ -3897,7 +3897,7 @@
         <seg>saying about going beyond what is written</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about going beyond what is written</seg>
+        <seg>dicho acerca de no sobrepasar lo que está escrito</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about Nimrod">
@@ -3906,7 +3906,7 @@
         <seg>saying about Nimrod</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about Nimrod</seg>
+        <seg>dicho acerca de Nimrod</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about Saul">
@@ -3915,7 +3915,7 @@
         <seg>saying about Saul</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about Saul</seg>
+        <seg>dicho acerca de Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about seer">
@@ -3924,7 +3924,7 @@
         <seg>saying about seer</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about seer</seg>
+        <seg>dicho acerca de ir al vidente</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about sow">
@@ -3933,7 +3933,7 @@
         <seg>saying about sow</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about sow</seg>
+        <seg>proverbio acerca de la puerca</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about what controls you">
@@ -3942,7 +3942,7 @@
         <seg>saying about what controls you</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about what controls you</seg>
+        <seg>dicho acerca de la esclavitud a lo que le vence a uno</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about yeast">
@@ -3951,7 +3951,7 @@
         <seg>saying about yeast</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about yeast</seg>
+        <seg>dicho acerca de la levadura</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about Zion">
@@ -3960,16 +3960,7 @@
         <seg>saying about Zion</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>dicho, oráculo about Zion</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.second person to accuse Peter (man)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>second person to accuse Peter (man)</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>segundo person to accuse Peter (man)</seg>
+        <seg>dicho acerca de Sión</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant girl">
@@ -3978,7 +3969,7 @@
         <seg>servant girl</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor girl</seg>
+        <seg>criada</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant girl at high priest's courtyard">
@@ -3987,7 +3978,7 @@
         <seg>servant girl at high priest's courtyard</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor girl at high priest's courtyard</seg>
+        <seg>sirvienta en el patio del sumo sacerdote</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant girl who watched the door">
@@ -3996,7 +3987,7 @@
         <seg>servant girl who watched the door</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor girl who watched the door</seg>
+        <seg>portera</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant girl, another">
@@ -4005,7 +3996,7 @@
         <seg>servant girl, another</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor girl, another</seg>
+        <seg>otra servienta</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of concubine's husband">
@@ -4014,7 +4005,7 @@
         <seg>servant of concubine's husband</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of concubine's husband</seg>
+        <seg>criado del levita</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of Elijah">
@@ -4023,7 +4014,7 @@
         <seg>servant of Elijah</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of Elijah</seg>
+        <seg>criado de Elijah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of Naaman's wife (young girl)">
@@ -4032,7 +4023,7 @@
         <seg>servant of Naaman's wife (young girl)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of Naaman's wife (young girl)</seg>
+        <seg>muchachita de la esposa de Naamán</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of Nabal">
@@ -4041,7 +4032,7 @@
         <seg>servant of Nabal</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of Nabal</seg>
+        <seg>criado de Nabal</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of priest">
@@ -4050,7 +4041,7 @@
         <seg>servant of priest</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of priest</seg>
+        <seg>criado del sacerdote</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant of Saul">
@@ -4059,7 +4050,7 @@
         <seg>servant of Saul</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>servidor of Saul</seg>
+        <seg>criado de Saúl</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shiphrah (midwife)">
@@ -4080,22 +4071,13 @@
         <seg>Súa (esposa de Judá)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.sign on the cross">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>sign on the cross</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>señal on the cross</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.steward of Joseph's house">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>steward of Joseph's house</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>mayordomo of Joseph's house</seg>
+        <seg>mayordomo de la casa de José</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.tax collectors">
@@ -4104,7 +4086,7 @@
         <seg>tax collectors</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>impuesto collectors</seg>
+        <seg>recaudadores de impuestos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.temple guards">
@@ -4113,16 +4095,16 @@
         <seg>temple guards</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>templo guards</seg>
+        <seg>guardia del templo</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.temple police">
+    <tu tuid="CharacterName.officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>temple police</seg>
+        <seg>officers</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>templo police</seg>
+        <seg>guardias</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tobiah the Ammonite">
@@ -4131,7 +4113,7 @@
         <seg>Tobiah the Ammonite</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Tobías amonita</seg>
+        <seg>Tobías, el amonita</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tobiah the Ammonite official">
@@ -4230,7 +4212,7 @@
         <seg>Ahijah the priest</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Ahías ***the*** sacerdote</seg>
+        <seg>Ahías el sacerdote</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahijah the prophet">
@@ -4239,7 +4221,7 @@
         <seg>Ahijah the prophet</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Ahías ***the*** profeta</seg>
+        <seg>Ahías el profeta</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.David (old)">
@@ -4260,22 +4242,13 @@
         <seg>Eliseo ***(old)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-      <tuv xml:lang="es">
-        <seg>Israelita ***men***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Israelite soldier in Saul's army</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Israelita ***soldier*** ***in*** ***Saul's*** ***army***</seg>
+        <seg>soldado israelita en el ejército de Saúl</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who had known Saul">
@@ -4293,7 +4266,7 @@
         <seg>Philistine rulers</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Filisteos ***rulers***</seg>
+        <seg>jefes filisteos</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samuel (dead)">
@@ -4302,7 +4275,7 @@
         <seg>Samuel (dead)</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Samuel ***(dead)***</seg>
+        <seg>Samuel (muerto)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shunammite woman">
@@ -4311,7 +4284,7 @@
         <seg>Shunammite woman</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Sunamita ***woman***</seg>
+        <seg>señora sunamita</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philip the apostle">
@@ -4320,7 +4293,7 @@
         <seg>Philip the apostle</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Felipe ***the*** ***apostle***</seg>
+        <seg>Felipe el apóstol</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philip the evangelist">
@@ -4329,7 +4302,1627 @@
         <seg>Philip the evangelist</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Felipe ***the*** ***evangelist***</seg>
+        <seg>Felipe el evangelista</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abijah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abijah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abías, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of Gerar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of Gerar</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abimélec, rey de Guerar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abimélec, rey de los filisteos</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines (in Gerar)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines (in Gerar)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abimélec, rey de los filisteos (en Guerar)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abimélec, hijo de Gedeón (Jerubaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abishai, Joab's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abishai, Joab's brother</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abisai, hermano de Joab</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abner, commander of Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abner, general del ejército de Saúl</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Absalom, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Absalom, son of David</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Absalón, hijo de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Achish, king of Gath">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Achish, king of Gath</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Aquís, rey de Gat</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adonijah, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adonijah, son of David</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Adonías, hijo de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adoni-Zedek, king of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adoni-Zedek, king of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Adonisédec, rey de Jerusalén</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Agag, rey de los amalecitas</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahab, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahab, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ahab, rey de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaz, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaz, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ahaz, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaziah, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaziah, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ocozías, rey de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasa)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasa)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amasá)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amasai, jefe de los treinta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amasías, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, priest of Bethel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, priest of Bethel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amasías, sacerdote de Betel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amnon, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amnon, son of David</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amnón, hijo de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ananias, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ananias, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ananías, el sumo sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Andrew, Simon Peter's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Andrew, Simon Peter's brother</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Andrés, hermano de Simón Pedro</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ángel, another (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another, coming down from heaven">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ángel, another, coming down from heaven</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ángel, coming out of temple</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ángel, coming out of temple, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, powerful">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, powerful</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ángel, powerful</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Anna, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Anna, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ana, profetisa</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Annas, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Annas, high priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Anás, alto sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Araunah, the Jebusite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Araunah, the Jebusite</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Arauna, el jebuseo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Artaxerxes, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Artaxerxes, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Artajerjes, rey de Persia</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asa, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asa, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Asá, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asahel, brother of Joab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asahel, brother of Joab</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Asael, hermano de Joab</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.assembly, whole">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>assembly, whole</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>asamblea, whole</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, mother of Ahaziah (Queen)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, mother of Ahaziah (Queen)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Atalía, madre de Ocozías (reina)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Atalía, reina</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, Johanan and all the arrogant men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, Johanan and all the arrogant men</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Azarías, Johanán  y todos los hombres arrogantes</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Hoshaiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Hoshaiah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Azarías, hijo de Hosaías</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Jehohanan">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Jehohanan</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Azarías, hijo de Johanán</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Oded">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Oded</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Azarías, hijo de Oded</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.beast, the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>beast, the</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>bestia, fiera, the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Benaiah, son of Jehoiada">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Benaiah, son of Jehoiada</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Benaías, hijo de Joiadá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ben-Hadad, king of Aram">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ben-Hadad, king of Aram</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ben-hadad, rey de Aram</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bera, king of Sodom">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bera, king of Sodom</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Beerá, rey de Sodoma</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethlehem, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethlehem, elders of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>los ancianos de Belén</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethuel, Rebekah's father</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Betuel, padre de Rebeca</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Birsha, king of Gomorrah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Birsha, king of Gomorrah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Birsá, rey de Gomorra</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Caiaphas, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Caiaphas, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Caifás, el sumo sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cleopas' companion (on road to Emmaus)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cleopas' companion (on road to Emmaus)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>compañero de Cleofás (en el camino a Emaús)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cyrus, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cyrus, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ciro, rey de Persia</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David, king</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>David, rey</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Deborah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Deborah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Débora, profetisa</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.disciple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>disciple, another</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>discípulo, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eglon, king of Moab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eglon, king of Moab</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Eglón, rey de Moab</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ehud, Israelite deliverer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ehud, Israelite deliverer</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ehud, libertador israelita</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ekron, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ekron, people of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ecronitas</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliab, David's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliab, David's brother</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Eliab, hermano de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliezer, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliezer, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Eliézer, profeta del Señor</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elihu, son of Barakel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elihu, son of Barakel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Elihú, hijo de Baraquel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>hombres de Efraín</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, survivor of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, survivor of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>fugitivo de Efraín</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Esther, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Esther, queen</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ester, reina</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Felix, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Felix, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Félix, gobernador de Judea</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Festus, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Festus, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Festo, gobernador de Judea</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaal, son of Ebed">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaal, son of Ebed</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Gáal, hijo de Ébed</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gad, the prophet, David's seer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gad, the prophet, David's seer</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Gad, profeta, vidente de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gallio, proconsul of Achaia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gallio, proconsul of Achaia</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Galión, procónsul de Acaya</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gamaliel, a Pharisee on Sanhedrin">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gamaliel, a Pharisee on Sanhedrin</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Gamaliel, fariseo en el Sanedrín</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaza, people of (wicked)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaza, people of (wicked)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>los de Gaza</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, governor of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, governor of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Guedalías, gobernador de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, son of Pashur">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, son of Pashur</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Guedalías, hijo de Pasur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gehazi, servant of Elisha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gehazi, servant of Elisha</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Guehazí, criado de Eliseo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, elders of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>ancianos de Galaad</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>jefes de Galaad</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>hombres de Galaad</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Goliath, Philistine champion">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Goliath, Philistine champion</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Goliat, paladín de los filisteos</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hagar, Sarai’s maid</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Agar, sierva de Saray</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Haman, highest noble to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Amam, agagueo, oficial sobre todos los príncipes del rey Asuero</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hamor, Hivite ruler</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hamor, Heveos principado</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hananí, hermano de Nehemías</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hananiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hananiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hananías, falso profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Herodias' daughter">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Herodias' daughter</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>hija de Herodías</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hezekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hezekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ezequías, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hilkiah, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hilkiah, high priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hilquías, alto sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hirah, the Adullamite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hirah, the Adullamite</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hirá, el adulamita</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hobab, Moses brother-in-law">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hobab, Moses brother-in-law</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Hobab, el cuñado de Moisés</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Huldah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Huldah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Huldá, profetisa</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hushai, David's friend">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hushai, David's friend</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Husai, amigo de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Irijah, captain of the guard of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Irijah, captain of the guard of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Irías, capitán de la guardia de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Isaiah, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Isaiah, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Isaías, profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ish-Bosheth, son of Saul</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Is-bóset, hijo de Saúl</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ishmael, son of Nethaniah (murderer)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ishmael, son of Nethaniah (murderer)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ismael, hijo de Netanías ***(murderer)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>todo Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>todos los hombres de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the tribes">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the tribes</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>odas las tribus de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>príncipes de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>israelitas (hombres)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, the people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, the people of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>el pueblo de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, elders of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>los ancianos de Jabés</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>los hombres de Jabés</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoash, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoash, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Joás, rey de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehonadab, son of Recab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehonadab, son of Recab</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jonadab, hijo de Recab</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoshaphat, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoshaphat, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Josafat, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Hanani">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Hanani</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jehú, hijo de Hananí</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Nimshi">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Nimshi</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jehú, hijo de Nimsí</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jeroboam, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jeroboam, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jeroboam, rey de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' brothers</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>hermanos de Jesús</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' disciples">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' disciples</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>discípulos de Jesús</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' family</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>familia de Jesús</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' mother and brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' mother and brothers</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>la madre (María) y los hermanos de Jesús</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, father of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, father of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Joás, padre de Gedeón (Jerubaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Joás, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Juan)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John, Alexander, and other men of the high priest's family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John, Alexander, and other men of the high priest's family</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Juan, Alejandro y todos los que pertenecían a la familia de los sumos sacerdotes</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jonathan, son of Abiathar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jonathan, son of Abiathar</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jonatán, hijo de Abiatar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joram, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joram, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Joram, rey de Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joseph, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joseph, people of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>descendientes de José</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Josiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Josiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Josías, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jotham, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jotham, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Jotam, hijo de Gedeón (Jerubaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, all</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>todo Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, men of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>hombres de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, people in">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, people in</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>la gente de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judas, apostle (not Judas Iscariot)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judas, apostle (not Judas Iscariot)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Judas, el apóstol (no el Iscariote)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Kish, father of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Kish, father of Saul</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Quis, padre de Saúl</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Manoah, father of Samson">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Manoah, father of Samson</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Manoa, padre de Sansón</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, Jesus' mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, Jesus' mother</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>María, madre de Jesús</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, sister of Martha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, sister of Martha</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>María, hermana de Marta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Melchizedek, king of Salem (priest of God Most High)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Melchizedek, king of Salem (priest of God Most High)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Melquisedec, rey de Salem (sacerdote del Dios Altísimo)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Memucan, noble advisor to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Memucan, noble advisor to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Memucán, príncipe y consejero al rey Asuero</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Micaiah, prophet of the LORD">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Micaiah, prophet of the LORD</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Micaías, profeta del Señor</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michael, archangel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michael, archangel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Miguel, el arcángel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michal, David's wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michal, David's wife</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Mical, esposa de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mordecai, cousin of Esther">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mordecai, cousin of Esther</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Mardoqueo, primo de Ester</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Nathan, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Nathan, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Natán, el profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Neco, king of Egypt">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Neco, king of Egypt</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Necao, rey de Egipto</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Obadiah, manager of Ahab's palace">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Obadiah, manager of Ahab's palace</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Abdías, mayordomo de Ahab</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Oded, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Oded, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Oded, profeta del Señor</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, all the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, all the</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, all the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, arrogant wicked">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, arrogant wicked</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, God's">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, God's</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, God's</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, hurried">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, hurried</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, hurried</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, Israel, tribes of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, Israel, tribes of</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, many (at Gennesaret)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, many (at Gennesaret)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, other">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, other</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, other</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, righteous">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, righteous</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, righteous</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, sick">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, sick</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, sick</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, some">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, some</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, some</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, still others">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, still others</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>pueblo, still others</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Pharisee, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharisee, a</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>fariseo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.prophet, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>prophet, a</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>profeta, a</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Rehoboam, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Roboam, rey</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Samaria, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samaria, people of</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>los que viven en Samaria</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sapphira, wife of Ananias of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sapphira, wife of Ananias of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Safira, esposa de Ananías de Jerusalén</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.saying, true">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>saying, true</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>dicho, oráculo, true</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Senaquerib, rey de Asiria</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.seraph, one of the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>seraph, one of the</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>serafín, one of the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shaphan, secretary">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shaphan, secretary</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Safán, el cronista del rey Josías</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sheba, son of Bicri">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sheba, son of Bicri</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sebá, hijo de Bicrí</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shecaniah, son of Jehiel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shecaniah, son of Jehiel</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Secanías, hijo de Jehiel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shechem, son of Hamor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shechem, son of Hamor</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Siquem, hijo de Hamor</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemaiah, son of Delaiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Semaías, hijo de Delaías, falso profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemeber, king of Zeboiim">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemeber, king of Zeboiim</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Seméber, rey de Seboím</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shinab, king of Admah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shinab, king of Admah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sinab, rey de Admá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simeon, devout man in Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Simeón, hombre justo y piadoso en Jerusalén</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Simon, sorcerer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simon, sorcerer</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Simón el mago</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Solomon, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Solomon, king</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Salomón, rey</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter of David</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Tamar, hija de David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter-in-law of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Tamar, nuera de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tattenai, governor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tattenai, governor</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Tatenai, gobernador</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tertullus, lawyer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tertullus, lawyer</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Tértulo, abogado</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tirzah, daughters of Zelophehad">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tirzah, daughters of Zelophehad</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Tirsá, hijas de Selofhad</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zebul, governor of Shechem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zebul, governor of Shechem</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Zebul, gobernador de Siquem</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah, son of Jehoiada the priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Zacarías, hijo de Joiadá el sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sedequías, rey de Judá</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Hananiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Hananiah</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sedequías, hijo de Hananías</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Kenaanah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Kenaanah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sedequías, hijo de Quenaaná, falso profeta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zephaniah, priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sofonías, sacerdote</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zeresh, wife of Haman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zeresh, wife of Haman</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Zeres, mujer de Amam</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ziba, servant of Saul's household</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Sibá, siervo de Saúl</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zipporah, Moses' wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zipporah, Moses' wife</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Séfora, esposa de Moisés</seg>
       </tuv>
     </tu>
   </body>

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -4773,13 +4773,13 @@
         <seg>Goliat, paladín de los filisteos</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>Agar, sierva de Saray</seg>
+        <seg>Agar, ***Sarai's*** ***maid***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">

--- a/DistFiles/localization/Glyssen.fr.tmx
+++ b/DistFiles/localization/Glyssen.fr.tmx
@@ -194,15 +194,6 @@
         <seg>Agabus ***the*** prophète</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Agag, king of Amalekites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Agag, king of Amalekites</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Agag, roi // [2] Mélek ***of*** ***Amalekites***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ahab, king of Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -302,15 +293,6 @@
         <seg>Amassa)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Amassaï, ***chief*** ***of*** trente ***(Spirit*** ***came*** ***upon)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -408,204 +390,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>angel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel (one of the seven)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel (one of the seven)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel (one of the seven)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, second">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, third">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel from the rising sun with seal of living God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel Gabriel, sent by God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel Gabriel, sent by God</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel Gabriel, sent by God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, an</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel of God, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel of God, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, an</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel of the LORD, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel of the LORD, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel or messenger (Greek variant: someone speaking to John)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel over waters">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel over waters</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel over waters</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing in sun">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing in sun</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel standing in sun</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing on sea and land">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel who talked with Zechariah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel who talked with Zechariah (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who wrestled with Jacob">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who wrestled with Jacob</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel who wrestled with Jacob</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another (vision)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel, another (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another, coming down from heaven">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another, coming down from heaven</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel, another, coming down from heaven</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel, coming out of temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple, another</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel, coming out of temple, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, powerful">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, powerful</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>angel, powerful</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Anna, prophetess">
@@ -1004,15 +788,6 @@
         <seg>Cananéen (Phénicie de Syrie) ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.chariot commanders of Aram">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>chariot commanders of Aram</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>chariot, char commanders of Aram</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Cleopas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1055,7 +830,7 @@
         <seg>Cretan prophet</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>de Crète, Crétois prophète</seg>
+        <seg>prophète crétois</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cyrus, king of Persia">
@@ -1166,33 +941,6 @@
         <seg>Démétrius ***the*** ***silversmith***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.disciple who wanted to bury his father">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple who wanted to bury his father</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>disciple, élève, partisan who wanted to bury his father</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple whom Jesus loved">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple whom Jesus loved</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>disciple, élève, partisan whom Jesus loved</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple, another</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>disciple, élève, partisan, another</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1208,7 +956,7 @@
         <seg>donkey (female)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>âne, ânesse, bête (female)</seg>
+        <seg>ânesse</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Edom">
@@ -1245,15 +993,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Éhoud, Israélite ***deliverer***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.eighty other priests">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>eighty other priests</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>quatre-vingts other priests</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ekron, people of">
@@ -1877,24 +1616,6 @@
         <seg>Ézékias, roi // [2] Mélek ***of*** Juda</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.high priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>high priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest's servant (relative of the man whose ear Peter cut off)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Hilkiah, high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1929,15 +1650,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Hogla</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.holy one (in vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>holy one (in vision)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>saint one (in vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hosea">
@@ -2873,7 +2585,7 @@
         <seg>king of Bela</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>roi // [2] Mélek of Bela</seg>
+        <seg>roi de Béla</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Kish, father of Saul">
@@ -2900,7 +2612,7 @@
         <seg>Laban</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>blanc // [2] Laban</seg>
+        <seg>Laban</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Cain)">
@@ -2919,15 +2631,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Lémek ***(descendent*** ***of*** postérieur // [2] base // [3] Seth)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.law of Moses where LORD commanded">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>law of Moses where LORD commanded</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>law of Moses where LORD commanded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Leah">
@@ -3350,295 +3053,7 @@
         <seg>people</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>people</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at cistern">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at cistern</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people at cistern</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at coronation of King Joash">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at Jairus' house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Capernaum">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Capernaum</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in Capernaum</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in crowd by Sea of Galilee">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Jericho, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Pisidian Antioch synagogue">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in temple courts, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in the temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in the temple</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people in the temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people near Jordan River">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people near Jordan River</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people near Jordan River</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Decapolis">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Decapolis</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of Decapolis</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of Jerusalem</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem, some</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of Jerusalem, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Samaria, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Samaria, all the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of Samaria, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of the region of the Gerasenes">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of the region of the Gerasenes</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of the region of the Gerasenes</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Tyre and Sidon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Tyre and Sidon</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people of Tyre and Sidon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people praying at John Mark's mother's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people standing there">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people standing there</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people standing there</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who had known Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who had known Saul</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people who had known Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, all the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, arrogant wicked">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, arrogant wicked</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, arrogant wicked</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, God's">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, God's</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, God's</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, hurried">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, hurried</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, hurried</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, Israel, tribes of">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, Israel, tribes of</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, Israel, tribes of</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, many (at Gennesaret)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, many (at Gennesaret)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, many (at Gennesaret)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, other">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, other</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, other</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, righteous">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, righteous</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, righteous</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, sick">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, sick</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, sick</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, some</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, still others">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, still others</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>people, still others</seg>
+        <seg>personnes</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon)">
@@ -3800,34 +3215,7 @@
         <seg>prophet in Bethel</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>prophète in Bethel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet of the LORD">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet of the LORD</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>prophète of the LORD</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet who confronts Ahab">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet who confronts Ahab</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>prophète who confronts Ahab</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet, a">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet, a</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>prophète, a</seg>
+        <seg>prophète en Bethel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Puah (midwife)">
@@ -3839,31 +3227,13 @@
         <seg>Pouva ***(midwife)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.queen of Babylon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Babylon</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>queen of Babylon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.queen of Sheba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Sheba</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>queen of Sheba</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Rachel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Rachel</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>brebis (mouton femelle</seg>
+        <seg>Rachel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rahab">
@@ -3872,7 +3242,7 @@
         <seg>Rahab</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>large, étendu // [2] Rahab</seg>
+        <seg>Rahab</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rebekah">
@@ -4071,15 +3441,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Sennakérib, roi // [2] Mélek ***of*** ***Assyria***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.seraph, one of the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>seraph, one of the</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>type de serpent (FF 72.73) // [2] séraphin // [3] Saraph, one of the</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.seventy-two">
@@ -4295,7 +3656,7 @@
         <seg>Tamar, daughter of David</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>palmier dattier (FF 160-162) // [2] Tamar, ***daughter*** ***of*** David</seg>
+        <seg>Tamar, ***daughter*** ***of*** David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
@@ -4304,16 +3665,7 @@
         <seg>Tamar, daughter-in-law of Judah</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>palmier dattier (FF 160-162) // [2] Tamar, ***daughter-in-law*** ***of*** Juda</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.tax collectors">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>tax collectors</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>tax collectors</seg>
+        <seg>Tamar, ***daughter-in-law*** ***of*** Juda</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">
@@ -4397,15 +3749,6 @@
         <seg>Urie</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.vineyard owner (God?)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>vineyard owner (God?)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>vigne (FF 188.190) owner (God?)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Zalmunna">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4484,7 +3827,7 @@
         <seg>Zedekiah, king of Judah</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Sidequia, roi // [2] Mélek ***of*** Juda</seg>
+        <seg>Sidequia, roi ***of*** Juda</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zedekiah, son of Hananiah">
@@ -4566,6 +3909,51 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Sofar ***the*** de Naama</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of the Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Agag, roi ***of*** ***the*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amassaï, ***chief*** ***of*** trente</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.council of elders">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>council of elders</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>collège des anciens (du plus haut conseil juif ou d'un conseil d'église)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.synagogue ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>synagogue ruler</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>chef de la synagogue</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zechariah (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah (vision)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Zacharie (vision)</seg>
       </tuv>
     </tu>
   </body>

--- a/DistFiles/localization/Glyssen.fr.tmx
+++ b/DistFiles/localization/Glyssen.fr.tmx
@@ -4064,141 +4064,6 @@
         <seg>Saul (Paul)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.saying (proverb)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying (proverb)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal (proverb)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Anakites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Anakites</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Anakites</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about blind and lame">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about blind and lame</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about blind and lame</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about captivity and death by the sword">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about captivity and death by the sword</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about captivity and death by the sword</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Gentile nations">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Gentile nations</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Gentile nations</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about going beyond what is written">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about going beyond what is written</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about going beyond what is written</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Nimrod">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Nimrod</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Nimrod</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Saul</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Saül</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about seer">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about seer</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about seer</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about sow">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about sow</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about sow</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about what controls you">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about what controls you</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about what controls you</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about yeast">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about yeast</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about yeast</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Zion">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Zion</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Zion</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying, true">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying, true</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal, true</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.second person to accuse Peter (man)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>second person to accuse Peter (man)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>deuxième person to accuse Peter (man)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Sennacherib, king of Assyria">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4215,96 +4080,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>type de serpent (FF 72.73) // [2] séraphin // [3] Saraph, one of the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur girl</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl at high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl at high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur girl at high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl who watched the door">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl who watched the door</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur girl who watched the door</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl, another</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur girl, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of concubine's husband">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of concubine's husband</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of concubine's husband</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Elijah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Elijah</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of Elijah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Naaman's wife (young girl)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Naaman's wife (young girl)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of Naaman's wife (young girl)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Nabal">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Nabal</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of Nabal</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of priest</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Saul</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>serviteur of Saül</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.seventy-two">
@@ -4451,15 +4226,6 @@
         <seg>Chounem ***woman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.sign on the cross">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>sign on the cross</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>sign on the cross</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Silas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4550,15 +4316,6 @@
         <seg>tax collectors</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.temple guards">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple guards</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>temple guards</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Tempter">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4574,7 +4331,7 @@
         <seg>Tertius</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Tertius (ROM.16:22)</seg>
+        <seg>Tertius</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tertullus, lawyer">
@@ -4583,7 +4340,7 @@
         <seg>Tertullus, lawyer</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Tertulle (ACT.24:1,2), ***lawyer***</seg>
+        <seg>Tertulle, ***lawyer***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Thomas">
@@ -4629,15 +4386,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Tobia ***the*** Ammonite ***official***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.twenty-four elders">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>twenty-four elders</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>vingt-quatre elders</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Uriah">
@@ -4701,15 +4449,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Zacharie ***(the*** ***LORD*** ***says)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Zacharie (vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">

--- a/DistFiles/localization/Glyssen.fr.tmx
+++ b/DistFiles/localization/Glyssen.fr.tmx
@@ -50,15 +50,6 @@
         <seg>Abirâm</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Abner</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Abner</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -68,15 +59,6 @@
         <seg>Abraham ***(Abram)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Absalom</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Abichalom</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Achan">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -84,15 +66,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Akan</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Achish">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Achish</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Akich</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -120,6 +93,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Agabus ***the*** prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ahia ***the*** prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ahia ***the*** prophète</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahimaaz (messenger)">
@@ -167,15 +158,6 @@
         <seg>Amassa</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Amassia</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -183,15 +165,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Ammonite ***nobles***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amnon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amnon</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Amnôn</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -572,15 +545,6 @@
         <seg>Bérénice</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Betouel ***(Laban's*** ***father)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -615,15 +579,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Caleb</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Caleb ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -714,6 +669,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>David ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Deborah">
@@ -885,6 +849,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Élisée ***(had*** ***said)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Élisée ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elisha (the LORD says)">
@@ -1085,15 +1058,6 @@
         <seg>Gédéon ***(Jerubbaal)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Goliath</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Goliath</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Habakkuk">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1110,15 +1074,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Hadad ***the*** Édomite</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Hamor">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Hamor</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>âne (FF 5.6) // [2] Hamor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1373,6 +1328,15 @@
         <seg>Israélite ***foreman***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israélite ***men***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1391,22 +1355,13 @@
         <seg>Israélite ***people,*** ***the***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
+        <seg>Israelite soldier in Saul's army</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Israélite ***soldier*** ***(in*** ***Saul's*** ***army)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Israélite ***soldiers***</seg>
+        <seg>Israélite ***soldier*** ***in*** ***Saul's*** ***army***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite spies from house of Joseph">
@@ -1497,15 +1452,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Ézékias</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Yoyada</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
@@ -2003,15 +1949,6 @@
         <seg>Mika</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Mikaël ***(archangel)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2390,13 +2327,13 @@
         <seg>people standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
+    <tu tuid="CharacterName.people who had known Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
@@ -2480,22 +2417,22 @@
         <seg>Philippe</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
+    <tu tuid="CharacterName.Philip the apostle">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
+        <seg>Philip the apostle</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Philippe ***(apostle)***</seg>
+        <seg>Philippe ***the*** ***apostle***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
+    <tu tuid="CharacterName.Philip the evangelist">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
+        <seg>Philip the evangelist</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Philippe ***(the*** ***evangelist)***</seg>
+        <seg>Philippe ***the*** ***evangelist***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -2516,6 +2453,15 @@
         <seg>Philistin ***priests*** ***and*** ***fortune*** ***tellers***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Philistine rulers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philistine rulers</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Philistin ***rulers***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Pilate">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2523,15 +2469,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Pilate</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>priest</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>prêtre, sacrificateur</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proclamation">
@@ -2642,15 +2579,6 @@
         <seg>Béthel</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Roboam</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2723,13 +2651,13 @@
         <seg>Samuel ***(boy)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samuel (old)">
+    <tu tuid="CharacterName.Samuel (dead)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Samuel (old)</seg>
+        <seg>Samuel (dead)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Samuel ***(old)***</seg>
+        <seg>Samuel ***(dead)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sanballat">
@@ -2748,15 +2676,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Saneballath ***the*** Horonite</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Sapphira (wife of Ananias of Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Sapphira (wife of Ananias of Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Saphira ***(wife*** ***of*** Ananias: (1) mari de Sapphira ***of*** ***Jerusalem)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
@@ -2793,15 +2712,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Saul: (1) Nom hébreu de l'apôtre Paul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Saul (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Saul (old)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Saul: (1) Nom hébreu de l'apôtre Paul ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -3101,6 +3011,15 @@
         <seg>Choua ***(Judah's*** ***wife)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chounem ***woman***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.sign on the cross">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3126,24 +3045,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Siméon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Siméon ***(devout*** ***man*** ***in*** ***Jerusalem)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simon (sorcerer)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simon (sorcerer)</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg> // Simon: (1) Simon Pierre ***(sorcerer)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sisera">
@@ -3333,15 +3234,6 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Sidequia</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Ziba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Ziba</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Siba</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">

--- a/DistFiles/localization/Glyssen.fr.tmx
+++ b/DistFiles/localization/Glyssen.fr.tmx
@@ -1472,13 +1472,13 @@
         <seg>Hadad ***the*** Édomite</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Agar, ***Sarai’s*** ***maid***</seg>
+        <seg>Agar, ***Sarai's*** ***maid***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">

--- a/DistFiles/localization/Glyssen.fr.tmx
+++ b/DistFiles/localization/Glyssen.fr.tmx
@@ -23,6 +23,15 @@
         <seg>Abigaïl</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abijah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abijah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abia, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abimelech">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -41,6 +50,42 @@
         <seg>Abimélek ***and*** Pikol</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abimelech, King of Gerar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of Gerar</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abimélek, ***King*** ***of*** Guérar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abimélek, ***King*** ***of*** ***the*** ***Philistines***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines (in Gerar)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines (in Gerar)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abimélek, ***King*** ***of*** ***the*** ***Philistines*** ***(in*** Guérar)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abimélek, ***son*** ***of*** Gédéon (Yeroubaal)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abiram">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -50,13 +95,40 @@
         <seg>Abirâm</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abishai, Joab's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abishai, Joab's brother</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abichaï, ***Joab's*** ***brother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abner, commander of Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abner, ***commander*** ***of*** ***Saul's*** ***army***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Abraham (Abram)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Abraham ***(Abram)***</seg>
+        <seg>Abraham (Abram)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Absalom, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Absalom, son of David</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Abichalom, ***son*** ***of*** David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Achan">
@@ -66,6 +138,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Akan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Achish, king of Gath">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Achish, king of Gath</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Akich, roi // [2] Mélek ***of*** Gath</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -86,6 +167,24 @@
         <seg>Adoni-Bézec</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Adonijah, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adonijah, son of David</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Adonia, ***son*** ***of*** David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adoni-Zedek, king of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adoni-Zedek, king of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Adoni-Sédec, roi // [2] Mélek ***of*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Agabus the prophet">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -93,6 +192,42 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Agabus ***the*** prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Agag, roi // [2] Mélek ***of*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahab, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahab, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Achab, roi // [2] Mélek ***of*** Israël</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaz, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaz, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ahaz, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaziah, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaziah, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ahazia, roi // [2] Mélek ***of*** Israël</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahijah the priest">
@@ -128,7 +263,7 @@
         <seg>Ahimelech the priest (son of Ahitub)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Ahimélek ***the*** prêtre, sacrificateur ***(son*** ***of*** ***Ahitub)***</seg>
+        <seg>Ahimélek ***the*** prêtre, sacrificateur ***(son*** ***of*** Ahitoub)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahithophel">
@@ -158,6 +293,42 @@
         <seg>Amassa</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Amasa)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasa)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amassa)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amassaï, ***chief*** ***of*** trente ***(Spirit*** ***came*** ***upon)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amassia, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, priest of Bethel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, priest of Bethel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amassia, prêtre, sacrificateur ***of*** Béthel</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -165,6 +336,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Ammonite ***nobles***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amnon, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amnon, son of David</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Amnôn, ***son*** ***of*** David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -182,7 +362,7 @@
         <seg>Ananias (Annas), the high priest (father-in-law of Caiaphas)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Ananias: (1) mari de Sapphira ***(Annas),*** ***the*** high prêtre, sacrificateur ***(father-in-law*** ***of*** ***Caiaphas)***</seg>
+        <seg>Ananias: (1) mari de Sapphira ***(Annas),*** ***the*** high prêtre, sacrificateur ***(father-in-law*** ***of*** Caïphe)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ananias of Damascus">
@@ -194,6 +374,15 @@
         <seg>Ananias: (1) mari de Sapphira ***of*** Damas</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ananias, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ananias, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ananias: (1) mari de Sapphira, ***the*** high prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Andrew">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -201,6 +390,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>André</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Andrew, Simon Peter's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Andrew, Simon Peter's brother</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>André,  // Simon: (1) Simon Pierre ***Peter's*** ***brother***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel">
@@ -365,6 +563,69 @@
         <seg>angel who wrestled with Jacob</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.angel, another (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another, coming down from heaven">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, powerful">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, powerful</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>angel, powerful</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Anna, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Anna, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Anne, prophétesse</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Annas, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Annas, high priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hanne, high prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Apollos">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -372,6 +633,42 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Apollos</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Araunah, the Jebusite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Araunah, the Jebusite</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Aravna, ***the*** Jébusite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Artaxerxes, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Artaxerxes, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Artaxerxès, roi // [2] Mélek ***of*** ***Persia***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asa, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asa, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Asa, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asahel, brother of Joab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asahel, brother of Joab</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Assaël, ***brother*** ***of*** Joab</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Asaph">
@@ -401,6 +698,24 @@
         <seg>Athalie</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Athaliah, mother of Ahaziah (Queen)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, mother of Ahaziah (Queen)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Athalie, ***mother*** ***of*** Ahazia ***(Queen)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Athalie, queen</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Azariah the chief priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -417,6 +732,42 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Yezania ***the*** prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, Johanan and all the arrogant men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, Johanan and all the arrogant men</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yezania, Yohanan ***and*** ***all*** ***the*** ***arrogant*** ***men***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Hoshaiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Hoshaiah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yezania, ***son*** ***of*** Hochaya</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Jehohanan">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Jehohanan</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yezania, ***son*** ***of*** Yohanan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Oded">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Oded</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yezania, ***son*** ***of*** Oded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Baanah">
@@ -518,6 +869,24 @@
         <seg>Batchéba</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Benaiah, son of Jehoiada">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Benaiah, son of Jehoiada</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Benaya, ***son*** ***of*** Yoyada</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ben-Hadad, king of Aram">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ben-Hadad, king of Aram</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ben-Hadad, roi // [2] Mélek ***of*** Aram, Syrie</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Benjamin">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -525,6 +894,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Benjamin</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bera, king of Sodom">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bera, king of Sodom</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Beéra, roi // [2] Mélek ***of*** Sodome</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Berekiah">
@@ -545,6 +923,24 @@
         <seg>Bérénice</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Bethlehem, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethlehem, elders of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Bethléem, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethuel, Rebekah's father</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Betouel, ***Rebekah's*** ***father***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -554,6 +950,15 @@
         <seg>Bildad ***the*** Chouha</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Birsha, king of Gomorrah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Birsha, king of Gomorrah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Bircha, roi // [2] Mélek ***of*** Gomorrhe</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Boaz">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -561,6 +966,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Booz</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Caiaphas, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Caiaphas, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Caïphe, ***the*** high prêtre, sacrificateur</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cain">
@@ -587,7 +1001,7 @@
         <seg>Canaanite (Syrophoenician) mother of possessed girl</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Cananéen ***(Syrophoenician)*** ***mother*** ***of*** ***possessed*** ***girl***</seg>
+        <seg>Cananéen (Phénicie de Syrie) ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.chariot commanders of Aram">
@@ -614,7 +1028,16 @@
         <seg>Cleopas and his companion (on road to Emmaus)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Cléopas ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** ***Emmaus)***</seg>
+        <seg>Cléopas ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** Emmaüs)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cleopas' companion (on road to Emmaus)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cleopas' companion (on road to Emmaus)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Cléopas' ***companion*** ***(on*** ***road*** ***to*** Emmaüs)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cornelius">
@@ -633,6 +1056,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>de Crète, Crétois prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cyrus, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cyrus, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Cyrus, roi // [2] Mélek ***of*** ***Persia***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Dan">
@@ -680,6 +1112,15 @@
         <seg>David ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.David, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David, king</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>David, roi // [2] Mélek</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Deborah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -687,6 +1128,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Débora</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Deborah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Deborah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Débora, prophétesse</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Delaiah">
@@ -734,6 +1184,15 @@
         <seg>disciple, élève, partisan whom Jesus loved</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.disciple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>disciple, another</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>disciple, élève, partisan, another</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -761,13 +1220,31 @@
         <seg>Édom</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eglon, king of Moab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eglon, king of Moab</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Églon, roi // [2] Mélek ***of*** Moab</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Egyptian (slave of Amalekite)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Egyptian (slave of Amalekite)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Égyptien ***(slave*** ***of*** ***Amalekite)***</seg>
+        <seg>Égyptien ***(slave*** ***of*** Amalécite)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ehud, Israelite deliverer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ehud, Israelite deliverer</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Éhoud, Israélite ***deliverer***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.eighty other priests">
@@ -779,13 +1256,22 @@
         <seg>quatre-vingts other priests</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ekron, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ekron, people of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Écron, people ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Eleazar the priest, son of Aaron">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Eleazar the priest, son of Aaron</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Élazar ***the*** ***priest,*** ***son*** ***of*** Aaron</seg>
+        <seg>Élazar ***the*** prêtre, sacrificateur, ***son*** ***of*** Aaron</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eli">
@@ -806,6 +1292,15 @@
         <seg>Héli ***(very*** ***old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eliab, David's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliab, David's brother</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Éliab, ***David's*** ***brother***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Eliakim">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -813,6 +1308,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Éliaquim</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliezer, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliezer, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Éliézer, prophète ***of*** ***the*** ***Lord***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elihu, son of Barakel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elihu, son of Barakel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Élihou, ***son*** ***of*** ***Barakel***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elijah">
@@ -932,6 +1445,24 @@
         <seg>Éfraïm</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ephraim, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Éfraïm, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, survivor of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, survivor of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Éfraïm, ***survivor*** ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ephron the Hittite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -948,6 +1479,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Ésaü</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Esther, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Esther, queen</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Esther, queen</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ethiopian officer of Queen Candace">
@@ -986,6 +1526,15 @@
         <seg>Ézékiel ***(in*** vision ***of*** ***God)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Felix, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Felix, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Félix, ***governor*** ***of*** Judée</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Festus">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -995,6 +1544,15 @@
         <seg>Festus (successeur de Felix comme procurateurr de Palestine)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Festus, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Festus, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Festus (successeur de Felix comme procurateurr de Palestine), ***governor*** ***of*** Judée</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.fool">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1002,6 +1560,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>stupide, délaissé</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaal, son of Ebed">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaal, son of Ebed</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Gaal, ***son*** ***of*** Ébed</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gabriel">
@@ -1022,6 +1589,15 @@
         <seg>Gadarénien ***(or*** ***Gerasenes)*** people</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gallio, proconsul of Achaia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gallio, proconsul of Achaia</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Gallion, ***proconsul*** ***of*** Achaïe</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gamaliel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1031,6 +1607,42 @@
         <seg>Gamliel</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gamaliel, a Pharisee on Sanhedrin">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gamaliel, a Pharisee on Sanhedrin</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Gamliel, ***a*** Pharisien ***on*** ***Sanhedrin***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaza, people of (wicked)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaza, people of (wicked)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Gaza, people ***of*** ***(wicked)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, governor of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, governor of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Guedalia, ***governor*** ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, son of Pashur">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, son of Pashur</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Guedalia, ***son*** ***of*** ***Pashur***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gehazi">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1038,6 +1650,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Guéhazi</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gehazi, servant of Elisha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gehazi, servant of Elisha</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Guéhazi, serviteur ***of*** Élisée</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gemariah">
@@ -1055,7 +1676,43 @@
         <seg>Gideon (Jerubbaal)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Gédéon ***(Jerubbaal)***</seg>
+        <seg>Gédéon (Yeroubaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, elders of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Galaad, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Galaad, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Galaad, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Goliath, Philistine champion">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Goliath, Philistine champion</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Goliath, Philistin ***champion***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Habakkuk">
@@ -1074,6 +1731,33 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Hadad ***the*** Édomite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hagar, Sarai’s maid</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Agar, ***Sarai’s*** ***maid***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Haman, highest noble to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Haman, ***highest*** ***noble*** ***to*** ***Xerxes,*** roi // [2] Mélek</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hamor, Hivite ruler</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>âne (FF 5.6) // [2] Hamor, Hévien ruler</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1101,6 +1785,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Hanani ***the*** ***seer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hanani, ***brother*** ***of*** Nehémia</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hananiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hananiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hanania, ***false*** prophète</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hannah">
@@ -1157,6 +1859,24 @@
         <seg>Hérodiade</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Herodias' daughter">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Herodias' daughter</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hérodiade' ***daughter***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hezekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hezekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ézékias, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1173,6 +1893,33 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hilkiah, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hilkiah, high priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hilquia, high prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hirah, the Adullamite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hirah, the Adullamite</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hira, ***the*** d'Adoullam</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hobab, Moses brother-in-law">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hobab, Moses brother-in-law</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Hobab, ***Moses*** ***brother-in-law***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hoglah">
@@ -1229,6 +1976,33 @@
         <seg>Osée proverbe, parole // [2] Machal ***what*** ***wicked*** ***will*** ***say***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Huldah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Huldah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Houlda, prophétesse</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hushai, David's friend">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hushai, David's friend</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Houchaï, ***David's*** friend</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Irijah, captain of the guard of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Irijah, captain of the guard of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Iria, ***captain*** ***of*** ***the*** ***guard*** ***of*** Juda</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Isaac">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1256,6 +2030,33 @@
         <seg>Ésaïe</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Isaiah, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Isaiah, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ésaïe, ***the*** prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ish-Bosheth, son of Saul</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ichebaal, ***son*** ***of*** Saül</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ishmael, son of Nethaniah (murderer)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ishmael, son of Nethaniah (murderer)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ismaël, ***son*** ***of*** Netania ***(murderer)***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1263,6 +2064,60 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Israël</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***all*** ***the*** ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the tribes">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the tribes</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***all*** ***the*** ***tribes***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, the people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, the people of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Israël, ***the*** people ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite army commanding officers">
@@ -1328,15 +2183,6 @@
         <seg>Israélite ***foreman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>Israélite ***men***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1352,7 +2198,7 @@
         <seg>Israelite people, the</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Israélite ***people,*** ***the***</seg>
+        <seg>Israélite people, ***the***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite soldier in Saul's army">
@@ -1379,7 +2225,7 @@
         <seg>Israelite spies from Joshua, two men</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Israélite ***spies*** ***from*** ***Joshua,*** ***two*** ***men***</seg>
+        <seg>Israélite ***spies*** ***from*** Josué, ***two*** ***men***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ittai">
@@ -1389,6 +2235,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Ittaï</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, elders of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yabech, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yabech, ***men*** ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jabez">
@@ -1406,7 +2270,7 @@
         <seg>Jacob (Israel)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Jacob ***(Israel)***</seg>
+        <seg>Jacob (Israël)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jael">
@@ -1454,6 +2318,15 @@
         <seg>Ézékias</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jehoash, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoash, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Joas, roi // [2] Mélek ***of*** Israël</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1461,6 +2334,42 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Yoyada ***the*** prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehonadab, son of Recab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehonadab, son of Recab</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yonadab, ***son*** ***of*** ***Recab***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoshaphat, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoshaphat, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Josaphat, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Hanani">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Hanani</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yéhou, ***son*** ***of*** Hanani</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Nimshi">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Nimshi</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yéhou, ***son*** ***of*** Nimchi</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehucal">
@@ -1544,6 +2453,15 @@
         <seg>Jéroboam</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jeroboam, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jeroboam, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jéroboam, roi // [2] Mélek ***of*** Israël</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jeshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1580,6 +2498,33 @@
         <seg>Jésus ***(child)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jesus' brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' brothers</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jésus' ***brothers***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' disciples">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' disciples</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jésus' ***disciples***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' family</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jésus' ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jesus in 2 John">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1596,6 +2541,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Jésus ***in*** ***Hebrews***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' mother and brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' mother and brothers</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jésus' ***mother*** ***and*** ***brothers***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jethro (Reuel), Moses' father-in-law">
@@ -1652,6 +2606,24 @@
         <seg>Yoa</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joash, father of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, father of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yoach, ***father*** ***of*** Gédéon (Yeroubaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yoach, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Job">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1694,7 +2666,7 @@
         <seg>John (disciple whom Jesus loved)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Jean, Jean-Baptiste ***(disciple*** ***whom*** Jésus ***loved)***</seg>
+        <seg>Jean, Jean-Baptiste (disciple, élève, partisan ***whom*** Jésus ***loved)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (sons of Zebedee)">
@@ -1703,7 +2675,7 @@
         <seg>John (sons of Zebedee)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Jean, Jean-Baptiste ***(sons*** ***of*** ***Zebedee)***</seg>
+        <seg>Jean, Jean-Baptiste ***(sons*** ***of*** Zébédée)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (who had asked the Lord who was going to betray Him)">
@@ -1724,6 +2696,24 @@
         <seg>Jean, Jean-Baptiste ***the*** Baptiste (Jean)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.John)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jean, Jean-Baptiste)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John, Alexander, and other men of the high priest's family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John, Alexander, and other men of the high priest's family</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jean, Jean-Baptiste, Alexandre, ***and*** ***other*** ***men*** ***of*** ***the*** high ***priest's*** ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jonah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1740,6 +2730,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Jonatan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jonathan, son of Abiathar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jonathan, son of Abiathar</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Jonatan, ***son*** ***of*** Abiatar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joram, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joram, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yoram, roi // [2] Mélek ***of*** Israël</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Joseph">
@@ -1760,6 +2768,15 @@
         <seg>Joseph ***of*** Arimathée</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joseph, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joseph, people of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Joseph, people ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Joshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1778,6 +2795,24 @@
         <seg>Josué ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Josiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Josiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yosia, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jotham, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jotham, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Yotam, ***son*** ***of*** Gédéon (Yeroubaal)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1785,6 +2820,33 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, all</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Juda, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, men of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Juda, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, people in">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, people in</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Juda, people ***in***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Judas Iscariot">
@@ -1796,6 +2858,15 @@
         <seg>(1) Judas: (a) fils de Jacob, sa tribu, son territoire (1 C-6) Iscariote</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Judas, apostle (not Judas Iscariot)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judas, apostle (not Judas Iscariot)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>(1) Judas: (a) fils de Jacob, sa tribu, son territoire (1 C-6), ***apostle*** ***(not*** (1) Judas: (a) fils de Jacob, sa tribu, son territoire (1 C-6) Iscariote)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.king of Bela">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1803,6 +2874,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>roi // [2] Mélek of Bela</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Kish, father of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Kish, father of Saul</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Quich, ***father*** ***of*** Saül</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Korah">
@@ -1829,7 +2909,7 @@
         <seg>Lamech (descendent of Cain)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Lémek ***(descendent*** ***of*** ***Cain)***</seg>
+        <seg>Lémek ***(descendent*** ***of*** Caïn)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Seth)">
@@ -1838,7 +2918,7 @@
         <seg>Lamech (descendent of Seth)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Lémek ***(descendent*** ***of*** ***Seth)***</seg>
+        <seg>Lémek ***(descendent*** ***of*** postérieur // [2] base // [3] Seth)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.law of Moses where LORD commanded">
@@ -1904,6 +2984,15 @@
         <seg>Malte ***islanders***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Manoah, father of Samson">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Manoah, father of Samson</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Manoa, ***father*** ***of*** Samson</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Martha">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1931,6 +3020,42 @@
         <seg>Marie ***mother*** ***of*** Jacques</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mary, Jesus' mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, Jesus' mother</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Marie, Jésus' ***mother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, sister of Martha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, sister of Martha</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Marie, ***sister*** ***of*** Marthe</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Melchizedek, king of Salem (priest of God Most High)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Melchizedek, king of Salem (priest of God Most High)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Melkisédec, roi // [2] Mélek ***of*** intact, complet, de la paix // [2] Salem (prêtre, sacrificateur ***of*** ***God*** ***Most*** ***High)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Memucan, noble advisor to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Memucan, noble advisor to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Memoukan, ***noble*** ***advisor*** ***to*** ***Xerxes,*** roi // [2] Mélek</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Mephibosheth">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1947,6 +3072,33 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Mika</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Micaiah, prophet of the LORD">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Micaiah, prophet of the LORD</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Mikaya, prophète ***of*** ***the*** ***LORD***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michael, archangel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michael, archangel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Mikaël, ***archangel***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michal, David's wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michal, David's wife</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Mikal, ***David's*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
@@ -2012,6 +3164,15 @@
         <seg>Moabite ***officials,*** ***more*** ***distinguished***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mordecai, cousin of Esther">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mordecai, cousin of Esther</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Mordokaï, ***cousin*** ***of*** Esther</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Naaman">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2066,6 +3227,15 @@
         <seg>Natan</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Nathan, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Nathan, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Natan, ***the*** prophète</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Nathanael">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2082,6 +3252,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Nebouzaradan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Neco, king of Egypt">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Neco, king of Egypt</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Néco, roi // [2] Mélek ***of*** Égypte</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Nehemiah">
@@ -2109,6 +3288,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Noé</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Obadiah, manager of Ahab's palace">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Obadiah, manager of Ahab's palace</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Obadia, ***manager*** ***of*** ***Ahab's*** palace</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Oded, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Oded, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Oded, prophète ***of*** ***the*** ***Lord***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.On">
@@ -2345,13 +3542,112 @@
         <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.people, all the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, all the</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, all the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, arrogant wicked">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, God's">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, God's</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, God's</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, hurried">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, hurried</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, hurried</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, Israel, tribes of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, many (at Gennesaret)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, other">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, other</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, other</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, righteous">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, righteous</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, righteous</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, sick">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, sick</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, sick</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, some">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, some</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, some</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, still others">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, still others</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>people, still others</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Peter (Simon)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Peter (Simon)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Pierre ***(Simon)***</seg>
+        <seg>Pierre ( // Simon: (1) Simon Pierre)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon) and companions">
@@ -2360,7 +3656,7 @@
         <seg>Peter (Simon) and companions</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Pierre ***(Simon)*** ***and*** ***companions***</seg>
+        <seg>Pierre ( // Simon: (1) Simon Pierre) ***and*** ***companions***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon), with Eleven">
@@ -2387,7 +3683,7 @@
         <seg>Pharisee (expert in religious law)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Pharisien ***(expert*** ***in*** ***religious*** ***law)***</seg>
+        <seg>Pharisien ***(expert*** ***in*** ***religious*** law)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Pharisee (Simon)">
@@ -2396,7 +3692,16 @@
         <seg>Pharisee (Simon)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Pharisien ***(Simon)***</seg>
+        <seg>Pharisien ( // Simon: (1) Simon Pierre)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Pharisee, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharisee, a</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Pharisien, ***a***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Phicol">
@@ -2516,6 +3821,15 @@
         <seg>prophète who confronts Ahab</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.prophet, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>prophet, a</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>prophète, a</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Puah (midwife)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2579,6 +3893,15 @@
         <seg>Béthel</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Rehoboam, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Roboam, roi // [2] Mélek</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2622,6 +3945,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Salomé</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Samaria, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samaria, people of</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Samarie, people ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samson">
@@ -2678,13 +4010,22 @@
         <seg>Saneballath ***the*** Horonite</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sapphira, wife of Ananias of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sapphira, wife of Ananias of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Saphira, ***wife*** ***of*** Ananias: (1) mari de Sapphira ***of*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Sarah (Sarai)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Sara ***(Sarai)***</seg>
+        <seg>Sara (Saraï)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai) (old)">
@@ -2693,7 +4034,7 @@
         <seg>Sarah (Sarai) (old)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Sara ***(Sarai)*** ***(old)***</seg>
+        <seg>Sara (Saraï) ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Satan (Devil)">
@@ -2711,7 +4052,7 @@
         <seg>Saul</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Saul: (1) Nom hébreu de l'apôtre Paul</seg>
+        <seg>Saül</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -2720,7 +4061,7 @@
         <seg>Saul (Paul)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Saul: (1) Nom hébreu de l'apôtre Paul ***(Paul)***</seg>
+        <seg>Saul (Paul)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying (proverb)">
@@ -2792,7 +4133,7 @@
         <seg>saying about Saul</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>proverbe, parole // [2] Machal about Saul</seg>
+        <seg>proverbe, parole // [2] Machal about Saül</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying about seer">
@@ -2840,6 +4181,15 @@
         <seg>proverbe, parole // [2] Machal about Zion</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.saying, true">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>saying, true</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>proverbe, parole // [2] Machal, true</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.second person to accuse Peter (man)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2847,6 +4197,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>deuxième person to accuse Peter (man)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Sennakérib, roi // [2] Mélek ***of*** ***Assyria***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.seraph, one of the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>seraph, one of the</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>type de serpent (FF 72.73) // [2] séraphin // [3] Saraph, one of the</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.servant girl">
@@ -2936,7 +4304,7 @@
         <seg>servant of Saul</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>serviteur of Saul</seg>
+        <seg>serviteur of Saül</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.seventy-two">
@@ -2948,6 +4316,15 @@
         <seg>soixante-douze</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shaphan, secretary">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shaphan, secretary</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chafan, ***secretary***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sharezer">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2957,6 +4334,33 @@
         <seg>Saresser</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sheba, son of Bicri">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sheba, son of Bicri</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chéba, ***son*** ***of*** ***Bicri***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shecaniah, son of Jehiel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shecaniah, son of Jehiel</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chekania, ***son*** ***of*** Yéhiel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shechem, son of Hamor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shechem, son of Hamor</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chékem, ***son*** ***of*** âne (FF 5.6) // [2] Hamor</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Shemaiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2964,6 +4368,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Chemaya</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemaiah, son of Delaiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chemaya, ***son*** ***of*** Delaya, ***false*** prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemeber, king of Zeboiim">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemeber, king of Zeboiim</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chéméber, roi // [2] Mélek ***of*** Seboïm</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shephatiah">
@@ -2982,6 +4404,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Chiméi</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shinab, king of Admah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shinab, king of Admah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Chinab, roi // [2] Mélek ***of*** Adma</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shiphrah (midwife)">
@@ -3047,6 +4478,24 @@
         <seg>Siméon</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simeon, devout man in Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Siméon, ***devout*** ***man*** ***in*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Simon, sorcerer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simon, sorcerer</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg> // Simon: (1) Simon Pierre, ***sorcerer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sisera">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3056,6 +4505,15 @@
         <seg>Sisra</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Solomon, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Solomon, king</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Salomon, roi // [2] Mélek</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Stephen">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3063,6 +4521,24 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Étienne</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter of David</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>palmier dattier (FF 160-162) // [2] Tamar, ***daughter*** ***of*** David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter-in-law of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>palmier dattier (FF 160-162) // [2] Tamar, ***daughter-in-law*** ***of*** Juda</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.tax collectors">
@@ -3083,15 +4559,6 @@
         <seg>temple guards</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.temple police">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple police</seg>
-      </tuv>
-      <tuv xml:lang="fr">
-        <seg>temple police</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Tempter">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3110,6 +4577,15 @@
         <seg>Tertius (ROM.16:22)</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Tertullus, lawyer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tertullus, lawyer</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Tertulle (ACT.24:1,2), ***lawyer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Thomas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3117,6 +4593,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Thomas</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tirzah, daughters of Zelophehad">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tirzah, daughters of Zelophehad</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Tirsa, ***daughters*** ***of*** Selofad</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Titus">
@@ -3191,6 +4676,15 @@
         <seg>Zéba</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zebul, governor of Shechem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zebul, governor of Shechem</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Zéboul, ***governor*** ***of*** Chékem</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zechariah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3215,7 +4709,7 @@
         <seg>Zechariah (vision)</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Zacharie ***(vision)***</seg>
+        <seg>Zacharie (vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">
@@ -3227,6 +4721,15 @@
         <seg>Zacharie ***(word*** ***of*** ***the*** ***LORD)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah, son of Jehoiada the priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Zacharie, ***son*** ***of*** Yoyada ***the*** prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zedekiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3234,6 +4737,60 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>Sidequia</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Sidequia, roi // [2] Mélek ***of*** Juda</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Hananiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Hananiah</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Sidequia, ***son*** ***of*** Hanania</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Kenaanah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Kenaanah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Sidequia, ***son*** ***of*** ***Kenaanah,*** ***false*** prophète</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zephaniah, priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Sefania, prêtre, sacrificateur</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zeresh, wife of Haman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zeresh, wife of Haman</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Zérech, ***wife*** ***of*** Haman</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ziba, servant of Saul's household</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Siba, serviteur ***of*** ***Saul's*** ***household***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">
@@ -3252,6 +4809,15 @@
       </tuv>
       <tuv xml:lang="fr">
         <seg>de Zif</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zipporah, Moses' wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zipporah, Moses' wife</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Séfora, ***Moses'*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zophar the Naamathite">

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -3956,13 +3956,13 @@
         <seg>conselho de anciãos</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Hagar, ***Sarai’s*** ***maid***</seg>
+        <seg>Hagar, ***Sarai's*** ***maid***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sennacherib, king of Assyria">

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -194,15 +194,6 @@
         <seg>Ágabo ***the*** prophet</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Agag, king of Amalekites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Agag, king of Amalekites</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Agag, king ***of*** ***Amalekites***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ahab, king of Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -302,15 +293,6 @@
         <seg>Amasa)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Amasai, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -408,204 +390,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>anjo</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel (one of the seven)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel (one of the seven)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo (one of the seven)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo flying directly overhead</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, second">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo flying directly overhead, second</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, third">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo flying directly overhead, third</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel from the rising sun with seal of living God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo from the rising sun with seal of living God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel Gabriel, sent by God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel Gabriel, sent by God</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo Gabriel, sent by God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, an</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo of God, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo of God, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, an</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo of the LORD, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo of the LORD, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel or messenger (Greek variant: someone speaking to John)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel over waters">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel over waters</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo over waters</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing in sun">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing in sun</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo standing in sun</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing on sea and land">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo standing on sea and land</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo who talked with Zechariah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo who talked with Zechariah (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who wrestled with Jacob">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who wrestled with Jacob</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo who wrestled with Jacob</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another (vision)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo, another (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another, coming down from heaven">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another, coming down from heaven</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo, another, coming down from heaven</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo, coming out of temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple, another</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo, coming out of temple, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, powerful">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, powerful</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>anjo, powerful</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Anna, prophetess">
@@ -878,15 +662,6 @@
         <seg>Bathsheba</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.beast, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>beast, the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>animal selvagem(2Mac 4.25), the</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Benaiah, son of Jehoiada">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -986,15 +761,6 @@
         <seg>Boaz</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.brother who discovered his silver in his sack">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>brother who discovered his silver in his sack</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>irmão who discovered his silver in his sack</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Caiaphas, the high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1029,15 +795,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Canaanite (Siro-fenícia) ***mother*** ***of*** ***possessed*** ***girl***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.chariot commanders of Aram">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>chariot commanders of Aram</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>carruagem, carro commanders of Aram</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cleopas">
@@ -1202,33 +959,6 @@
         <seg>Demétrio ***the*** ***silversmith***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.disciple who wanted to bury his father">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple who wanted to bury his father</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>discípulo who wanted to bury his father</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple whom Jesus loved">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple whom Jesus loved</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>discípulo whom Jesus loved</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple, another</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>discípulo, another</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1236,15 +966,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Doeg ***the*** Edomite</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.donkey (female)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>donkey (female)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>donkey (female)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Edom">
@@ -1910,7 +1631,7 @@
         <seg>Herodias' daughter</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Herodias' ***daughter***</seg>
+        <seg>filha de Herodias</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hezekiah, king of Judah">
@@ -1919,25 +1640,7 @@
         <seg>Hezekiah, king of Judah</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Hezekiah, king ***of*** Judah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>alto priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest's servant (relative of the man whose ear Peter cut off)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>alto priest's servant (relative of the man whose ear Peter cut off)</seg>
+        <seg>Ezequias, rei de Judá</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hilkiah, high priest">
@@ -1946,7 +1649,7 @@
         <seg>Hilkiah, high priest</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Hilkiah, alto priest</seg>
+        <seg>Hilquias, o sumo sacerdote</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hirah, the Adullamite">
@@ -1974,15 +1677,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Hoglah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.holy one (in vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>holy one (in vision)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>holy one (in vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hosea">
@@ -2912,15 +2606,6 @@
         <seg>Judas, ***apostle*** ***(not*** Judas Iscariotes)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.king of Bela">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>king of Bela</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>king of Bela</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Kish, father of Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2964,15 +2649,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Lamech ***(descendent*** ***of*** Seth)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.law of Moses where LORD commanded">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>law of Moses where LORD commanded</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>lei of Moses where LORD commanded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Leah">
@@ -3398,294 +3074,6 @@
         <seg>Povo</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people at cistern">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at cistern</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo at cistern</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at coronation of King Joash">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo at coronation of King Joash</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at Jairus' house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo at Jairus' house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Capernaum">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Capernaum</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in Capernaum</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in crowd by Sea of Galilee">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in crowd by Sea of Galilee</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Jericho, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in Jericho, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Pisidian Antioch synagogue">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in Pisidian Antioch synagogue</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in temple courts, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in temple courts, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in the temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in the temple</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo in the temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people near Jordan River">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people near Jordan River</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo near Jordan River</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Decapolis">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Decapolis</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of Decapolis</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of Jerusalem</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem, some</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of Jerusalem, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Samaria, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Samaria, all the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of Samaria, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of the region of the Gerasenes">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of the region of the Gerasenes</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of the region of the Gerasenes</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Tyre and Sidon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Tyre and Sidon</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo of Tyre and Sidon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people praying at John Mark's mother's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo praying at John Mark's mother's house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people standing there">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people standing there</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo standing there</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who had known Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who had known Saul</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo who had known Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, all the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, arrogant wicked">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, arrogant wicked</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, arrogant wicked</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, God's">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, God's</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, God's</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, hurried">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, hurried</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, hurried</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, Israel, tribes of">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, Israel, tribes of</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, Israel, tribes of</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, many (at Gennesaret)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, many (at Gennesaret)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, many (at Gennesaret)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, other">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, other</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, other</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, righteous">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, righteous</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, righteous</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, sick">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, sick</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, sick</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, some</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, still others">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, still others</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Povo, still others</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Peter (Simon)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3848,49 +3236,13 @@
         <seg>prophet</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.prophet in Bethel">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet in Bethel</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>prophet in Bethel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet of the LORD">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet of the LORD</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>prophet of the LORD</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet who confronts Ahab">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet who confronts Ahab</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>prophet who confronts Ahab</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.prophet, a">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>prophet, a</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>prophet, a</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.proverb about a dog">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>proverb about a dog</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>provérbio; linguagem figurada about a dog</seg>
+        <seg>profeta</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Puah (midwife)">
@@ -3908,7 +3260,7 @@
         <seg>queen of Babylon</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>queen of Babylon</seg>
+        <seg>rainha da Babilônia</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.queen of Sheba">
@@ -3917,7 +3269,7 @@
         <seg>queen of Sheba</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>queen of Sheba</seg>
+        <seg>rainha de Sabá</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rachel">
@@ -4424,15 +3776,6 @@
         <seg>Uriah</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.young man in white robe (angel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>young man in white robe (angel)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>novo man in white robe (angel)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Zalmunna">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4584,6 +3927,78 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Zophar ***the*** Naamathite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of the Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Agag, king ***of*** ***the*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amasai, ***chief*** ***of*** ***thirty***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.council of elders">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>council of elders</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>conselho de anciãos</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hagar, Sarai’s maid</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hagar, ***Sarai’s*** ***maid***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Sennacherib, king ***of*** ***Assyria***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.synagogue ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>synagogue ruler</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>chefe da sinagoga</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zechariah (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah (vision)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zechariah (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zedekiah, king ***of*** Judah</seg>
       </tuv>
     </tu>
   </body>

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -23,6 +23,15 @@
         <seg>Abigail</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abijah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abijah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abijah, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abimelech">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -41,6 +50,42 @@
         <seg>Abimelech ***and*** Phicol</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abimelech, King of Gerar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of Gerar</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abimelech, ***King*** ***of*** Gerar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abimelech, ***King*** ***of*** ***the*** Filisteu</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines (in Gerar)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines (in Gerar)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abimelech, ***King*** ***of*** ***the*** Filisteu ***(in*** Gerar)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abimelech, ***son*** ***of*** Gideon (Jerubbaal)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abiram">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -50,13 +95,40 @@
         <seg>Abiram</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abishai, Joab's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abishai, Joab's brother</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abishai, ***Joab's*** irmão</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abner, commander of Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Abner, ***commander*** ***of*** ***Saul's*** ***army***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Abraham (Abram)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Abraham ***(Abram)***</seg>
+        <seg>Abraham (Abram)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Absalom, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Absalom, son of David</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Absalom, ***son*** ***of*** David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Achan">
@@ -66,6 +138,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Achan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Achish, king of Gath">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Achish, king of Gath</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Achish, king ***of*** Gath</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -86,6 +167,24 @@
         <seg>Adoni-Bezek</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Adonijah, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adonijah, son of David</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Adonijah, ***son*** ***of*** David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adoni-Zedek, king of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adoni-Zedek, king of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Adoni-Zedek, king ***of*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Agabus the prophet">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -93,6 +192,42 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ágabo ***the*** prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Agag, king ***of*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahab, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahab, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ahab, king ***of*** Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaz, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaz, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ahaz, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaziah, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaziah, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ahaziah, king ***of*** Israel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahijah the priest">
@@ -128,7 +263,7 @@
         <seg>Ahimelech the priest (son of Ahitub)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Ahimelech ***the*** priest ***(son*** ***of*** ***Ahitub)***</seg>
+        <seg>Ahimelech ***the*** priest ***(son*** ***of*** Ahitub)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahithophel">
@@ -158,6 +293,42 @@
         <seg>Amasa</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Amasa)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasa)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amasa)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amasai, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amaziah, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, priest of Bethel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, priest of Bethel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amaziah, priest ***of*** Bethel</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -165,6 +336,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ammonite ***nobles***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amnon, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amnon, son of David</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Amnon, ***son*** ***of*** David</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -182,7 +362,7 @@
         <seg>Ananias (Annas), the high priest (father-in-law of Caiaphas)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Ananias ***(Annas),*** ***the*** alto priest ***(father-in-law*** ***of*** ***Caiaphas)***</seg>
+        <seg>Ananias ***(Annas),*** ***the*** alto priest ***(father-in-law*** ***of*** Caifás)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ananias of Damascus">
@@ -194,6 +374,15 @@
         <seg>Ananias ***of*** Damascus</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ananias, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ananias, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ananias, ***the*** alto priest</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Andrew">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -201,6 +390,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>André</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Andrew, Simon Peter's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Andrew, Simon Peter's brother</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>André, Simão ***Peter's*** irmão</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel">
@@ -365,6 +563,69 @@
         <seg>anjo who wrestled with Jacob</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.angel, another (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>anjo, another (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another, coming down from heaven">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>anjo, another, coming down from heaven</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>anjo, coming out of temple</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>anjo, coming out of temple, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, powerful">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, powerful</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>anjo, powerful</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Anna, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Anna, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ana, profetisa</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Annas, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Annas, high priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Anás, alto priest</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Apollos">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -374,6 +635,42 @@
         <seg>Apolo</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Araunah, the Jebusite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Araunah, the Jebusite</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Araunah, ***the*** Jebusite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Artaxerxes, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Artaxerxes, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Artaxerxes, king ***of*** Pérsia</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asa, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asa, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Asa, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asahel, brother of Joab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asahel, brother of Joab</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Asahel, irmão ***of*** Joab</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Asaph">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -381,6 +678,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Asaph</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.assembly, whole">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>assembly, whole</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>assembleia, reunião (1Mac 5.16), whole</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.astrologers">
@@ -401,6 +707,24 @@
         <seg>Athaliah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Athaliah, mother of Ahaziah (Queen)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, mother of Ahaziah (Queen)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Athaliah, ***mother*** ***of*** Ahaziah ***(Queen)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Azariah the chief priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -417,6 +741,42 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Azariah ***the*** priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, Johanan and all the arrogant men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, Johanan and all the arrogant men</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Azariah, Johanan ***and*** ***all*** ***the*** ***arrogant*** ***men***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Hoshaiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Hoshaiah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Azariah, ***son*** ***of*** Hoshaiah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Jehohanan">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Jehohanan</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Azariah, ***son*** ***of*** Jehohanan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Oded">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Oded</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Azariah, ***son*** ***of*** Oded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Baanah">
@@ -518,6 +878,33 @@
         <seg>Bathsheba</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.beast, the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>beast, the</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>animal selvagem(2Mac 4.25), the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Benaiah, son of Jehoiada">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Benaiah, son of Jehoiada</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Benaiah, ***son*** ***of*** Jehoiada</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ben-Hadad, king of Aram">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ben-Hadad, king of Aram</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ben-Hadad, king ***of*** Aram</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Benjamin">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -525,6 +912,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Benjamin</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bera, king of Sodom">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bera, king of Sodom</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Bera, king ***of*** Sodom</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Berekiah">
@@ -545,6 +941,24 @@
         <seg>Berenice</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Bethlehem, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethlehem, elders of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Bethlehem, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethuel, Rebekah's father</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Bethuel, ***Rebekah's*** ***father***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -552,6 +966,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Bildad ***the*** Shuhite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Birsha, king of Gomorrah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Birsha, king of Gomorrah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Birsha, king ***of*** Gomorrah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Boaz">
@@ -570,6 +993,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>irmão who discovered his silver in his sack</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Caiaphas, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Caiaphas, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Caifás, ***the*** alto priest</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cain">
@@ -596,7 +1028,7 @@
         <seg>Canaanite (Syrophoenician) mother of possessed girl</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Canaanite ***(Syrophoenician)*** ***mother*** ***of*** ***possessed*** ***girl***</seg>
+        <seg>Canaanite (Siro-fenícia) ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.chariot commanders of Aram">
@@ -623,7 +1055,16 @@
         <seg>Cleopas and his companion (on road to Emmaus)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Cleopas ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** ***Emmaus)***</seg>
+        <seg>Cleopas ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** Emaús)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cleopas' companion (on road to Emmaus)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cleopas' companion (on road to Emmaus)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Cleopas' ***companion*** ***(on*** ***road*** ***to*** Emaús)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cornelius">
@@ -651,6 +1092,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Cretense prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cyrus, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cyrus, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Cyrus, king ***of*** Pérsia</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Dan">
@@ -698,6 +1148,15 @@
         <seg>David ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.David, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David, king</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>David, king</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Deborah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -705,6 +1164,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Deborah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Deborah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Deborah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Deborah, profetisa</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Delaiah">
@@ -752,6 +1220,15 @@
         <seg>discípulo whom Jesus loved</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.disciple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>disciple, another</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>discípulo, another</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -779,13 +1256,40 @@
         <seg>Edom</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eglon, king of Moab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eglon, king of Moab</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Eglon, king ***of*** Moab</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Egyptian (slave of Amalekite)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Egyptian (slave of Amalekite)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Egyptian ***(slave*** ***of*** ***Amalekite)***</seg>
+        <seg>Egyptian ***(slave*** ***of*** Amalekite)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ehud, Israelite deliverer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ehud, Israelite deliverer</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ehud, Israelite ***deliverer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ekron, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ekron, people of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ekron, Povo ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eleazar the priest, son of Aaron">
@@ -794,7 +1298,7 @@
         <seg>Eleazar the priest, son of Aaron</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Eleazar ***the*** ***priest,*** ***son*** ***of*** Aaron</seg>
+        <seg>Eleazar ***the*** priest, ***son*** ***of*** Aaron</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eli">
@@ -815,6 +1319,15 @@
         <seg>Eli ***(very*** ***old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eliab, David's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliab, David's brother</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Eliab, ***David's*** irmão</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Eliakim">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -822,6 +1335,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Eliakim</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliezer, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliezer, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Eliezer, prophet ***of*** ***the*** ***Lord***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elihu, son of Barakel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elihu, son of Barakel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Elihu, ***son*** ***of*** ***Barakel***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elijah">
@@ -941,6 +1472,24 @@
         <seg>Ephraim</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ephraim, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ephraim, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, survivor of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, survivor of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ephraim, ***survivor*** ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ephron the Hittite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -957,6 +1506,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Esau</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Esther, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Esther, queen</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Esther, queen</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ethiopian officer of Queen Candace">
@@ -995,6 +1553,15 @@
         <seg>Ezekiel ***(in*** vision ***of*** ***God)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Felix, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Felix, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Félix, ***governor*** ***of*** Judeia</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Festus">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1002,6 +1569,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Festo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Festus, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Festus, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Festo, ***governor*** ***of*** Judeia</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.fool">
@@ -1013,6 +1589,15 @@
         <seg>foolish, helpless</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gaal, son of Ebed">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaal, son of Ebed</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gaal, ***son*** ***of*** Ebed</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gabriel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1020,6 +1605,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Gabriel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gad, the prophet, David's seer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gad, the prophet, David's seer</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gad, ***the*** prophet, ***David's*** ***seer***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gadarene (or Gerasenes) people">
@@ -1031,6 +1625,15 @@
         <seg>Gadareno ***(or*** ***Gerasenes)*** Povo</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gallio, proconsul of Achaia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gallio, proconsul of Achaia</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gálio, ***proconsul*** ***of*** Acaia</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gamaliel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1040,6 +1643,42 @@
         <seg>Gamaliel</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gamaliel, a Pharisee on Sanhedrin">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gamaliel, a Pharisee on Sanhedrin</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gamaliel, ***a*** Fariseu ***on*** ***Sanhedrin***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaza, people of (wicked)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaza, people of (wicked)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gaza, Povo ***of*** ***(wicked)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, governor of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, governor of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gedaliah, ***governor*** ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, son of Pashur">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, son of Pashur</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gedaliah, ***son*** ***of*** ***Pashur***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gehazi">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1047,6 +1686,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Gehazi</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gehazi, servant of Elisha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gehazi, servant of Elisha</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gehazi, servo ***of*** Elisha</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gemariah">
@@ -1064,7 +1712,43 @@
         <seg>Gideon (Jerubbaal)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Gideon ***(Jerubbaal)***</seg>
+        <seg>Gideon (Jerubbaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, elders of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gilead, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gilead, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Gilead, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Goliath, Philistine champion">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Goliath, Philistine champion</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Goliath, Philistine ***champion***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Habakkuk">
@@ -1083,6 +1767,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Hadad ***the*** Edomite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Haman, highest noble to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Haman, altíssimo, mais alto ***noble*** ***to*** ***Xerxes,*** king</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hamor, Hivite ruler</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hamor, Hivite principado</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1110,6 +1812,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Hanani ***the*** ***seer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hanani, irmão ***of*** Nehemiah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hananiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hananiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hananiah, ***false*** prophet</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hannah">
@@ -1184,6 +1904,24 @@
         <seg>Herodias</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Herodias' daughter">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Herodias' daughter</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Herodias' ***daughter***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hezekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hezekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hezekiah, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1200,6 +1938,33 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>alto priest's servant (relative of the man whose ear Peter cut off)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hilkiah, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hilkiah, high priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hilkiah, alto priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hirah, the Adullamite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hirah, the Adullamite</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hirah, ***the*** Adullamite</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hobab, Moses brother-in-law">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hobab, Moses brother-in-law</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hobab, ***Moses*** ***brother-in-law***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hoglah">
@@ -1256,6 +2021,33 @@
         <seg>Oseias saying ***what*** ***wicked*** ***will*** ***say***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Huldah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Huldah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Huldah, profetisa</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hushai, David's friend">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hushai, David's friend</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Hushai, ***David's*** amigo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Irijah, captain of the guard of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Irijah, captain of the guard of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Irijah, ***captain*** ***of*** ***the*** ***guard*** ***of*** Judah</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Isaac">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1283,6 +2075,33 @@
         <seg>Isaiah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Isaiah, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Isaiah, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Isaiah, ***the*** prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ish-Bosheth, son of Saul</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ish-Bosheth, ***son*** ***of*** Saulo</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ishmael, son of Nethaniah (murderer)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ishmael, son of Nethaniah (murderer)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ishmael, ***son*** ***of*** Nethaniah ***(murderer)***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1290,6 +2109,60 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Israel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***all*** ***the*** ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the tribes">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the tribes</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***all*** ***the*** ***tribes***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, the people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, the people of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israel, ***the*** Povo ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite army commanding officers">
@@ -1316,7 +2189,7 @@
         <seg>Israelite assembly, elders of</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Israelite ***assembly,*** ***elders*** ***of***</seg>
+        <seg>Israelite assembleia, reunião (1Mac 5.16), ***elders*** ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite community">
@@ -1355,15 +2228,6 @@
         <seg>Israelite ***foreman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Israelite ***men***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1379,7 +2243,7 @@
         <seg>Israelite people, the</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Israelite ***people,*** ***the***</seg>
+        <seg>Israelite Povo, ***the***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite soldier in Saul's army">
@@ -1406,7 +2270,7 @@
         <seg>Israelite spies from Joshua, two men</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Israelite ***spies*** ***from*** ***Joshua,*** ***two*** ***men***</seg>
+        <seg>Israelite ***spies*** ***from*** Joshua, ***two*** ***men***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ittai">
@@ -1416,6 +2280,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ittai</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, elders of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jabesh, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jabesh, ***men*** ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jabez">
@@ -1433,7 +2315,7 @@
         <seg>Jacob (Israel)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Jacob ***(Israel)***</seg>
+        <seg>Jacob (Israel)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jael">
@@ -1481,6 +2363,15 @@
         <seg>Jehizkiah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jehoash, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoash, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jehoash, king ***of*** Israel</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1488,6 +2379,42 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Jehoiada ***the*** priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehonadab, son of Recab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehonadab, son of Recab</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jehonadab, ***son*** ***of*** ***Recab***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoshaphat, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoshaphat, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jehoshaphat, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Hanani">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Hanani</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jehu, ***son*** ***of*** Hanani</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Nimshi">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Nimshi</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jehu, ***son*** ***of*** Nimshi</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehucal">
@@ -1571,6 +2498,15 @@
         <seg>Jeroboam</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jeroboam, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jeroboam, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jeroboam, king ***of*** Israel</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jeshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1607,6 +2543,33 @@
         <seg>Jesus ***(child)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jesus' brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' brothers</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jesus' ***brothers***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' disciples">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' disciples</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jesus' ***disciples***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' family</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jesus' ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jesus in 2 John">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1623,6 +2586,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Jesus ***in*** ***Hebrews***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' mother and brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' mother and brothers</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jesus' ***mother*** ***and*** ***brothers***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jethro (Reuel), Moses' father-in-law">
@@ -1679,6 +2651,24 @@
         <seg>Joah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joash, father of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, father of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Joash, ***father*** ***of*** Gideon (Jerubbaal)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Joash, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Job">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1721,7 +2711,7 @@
         <seg>John (disciple whom Jesus loved)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>João ***(disciple*** ***whom*** Jesus ***loved)***</seg>
+        <seg>João (discípulo ***whom*** Jesus ***loved)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (sons of Zebedee)">
@@ -1730,7 +2720,7 @@
         <seg>John (sons of Zebedee)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>João ***(sons*** ***of*** ***Zebedee)***</seg>
+        <seg>João ***(sons*** ***of*** Zebedeu)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (who had asked the Lord who was going to betray Him)">
@@ -1751,6 +2741,24 @@
         <seg>João ***the*** Batista</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.John)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>João)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John, Alexander, and other men of the high priest's family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John, Alexander, and other men of the high priest's family</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>João, Alexandre, ***and*** ***other*** ***men*** ***of*** ***the*** alto ***priest's*** ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jonah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1767,6 +2775,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Jonathan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jonathan, son of Abiathar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jonathan, son of Abiathar</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jonathan, ***son*** ***of*** Abiathar</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joram, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joram, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Joram, king ***of*** Israel</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Joseph">
@@ -1787,6 +2813,15 @@
         <seg>Joseph ***of*** Arimateia</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joseph, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joseph, people of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Joseph, Povo ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Joshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1805,6 +2840,24 @@
         <seg>Joshua ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Josiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Josiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Josiah, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jotham, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jotham, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Jotham, ***son*** ***of*** Gideon (Jerubbaal)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1812,6 +2865,33 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, all</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Judah, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, men of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Judah, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, people in">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, people in</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Judah, Povo ***in***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Judas Iscariot">
@@ -1823,6 +2903,15 @@
         <seg>Judas Iscariotes</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Judas, apostle (not Judas Iscariot)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judas, apostle (not Judas Iscariot)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Judas, ***apostle*** ***(not*** Judas Iscariotes)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.king of Bela">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1830,6 +2919,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>king of Bela</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Kish, father of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Kish, father of Saul</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Kish, ***father*** ***of*** Saulo</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Korah">
@@ -1856,7 +2954,7 @@
         <seg>Lamech (descendent of Cain)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Lamech ***(descendent*** ***of*** ***Cain)***</seg>
+        <seg>Lamech ***(descendent*** ***of*** Caim)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Seth)">
@@ -1865,7 +2963,7 @@
         <seg>Lamech (descendent of Seth)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Lamech ***(descendent*** ***of*** ***Seth)***</seg>
+        <seg>Lamech ***(descendent*** ***of*** Seth)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.law of Moses where LORD commanded">
@@ -1931,6 +3029,15 @@
         <seg>Malta ***islanders***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Manoah, father of Samson">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Manoah, father of Samson</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Manoah, ***father*** ***of*** Samson</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Martha">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1958,6 +3065,42 @@
         <seg>Maria ***mother*** ***of*** Tiago</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mary, Jesus' mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, Jesus' mother</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Maria, Jesus' ***mother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, sister of Martha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, sister of Martha</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Maria, irmã ***of*** Marta</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Melchizedek, king of Salem (priest of God Most High)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Melchizedek, king of Salem (priest of God Most High)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Melchizedek, king ***of*** Salem (priest ***of*** ***God*** ***Most*** ***High)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Memucan, noble advisor to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Memucan, noble advisor to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Memucan, ***noble*** ***advisor*** ***to*** ***Xerxes,*** king</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Mephibosheth">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1974,6 +3117,33 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Micah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Micaiah, prophet of the LORD">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Micaiah, prophet of the LORD</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Micaiah, prophet ***of*** ***the*** ***LORD***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michael, archangel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michael, archangel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Michael, ***archangel***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michal, David's wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michal, David's wife</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Michal, ***David's*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
@@ -2018,7 +3188,7 @@
         <seg>Miriam (young)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Miriam ***(young)***</seg>
+        <seg>Miriam (novo)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Moabite officials">
@@ -2037,6 +3207,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Moabite ***officials,*** ***more*** ***distinguished***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mordecai, cousin of Esther">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mordecai, cousin of Esther</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Mordecai, ***cousin*** ***of*** Esther</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Naaman">
@@ -2093,6 +3272,15 @@
         <seg>Nathan</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Nathan, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Nathan, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Nathan, ***the*** prophet</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Nathanael">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2109,6 +3297,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Nebuzaradan</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Neco, king of Egypt">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Neco, king of Egypt</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Neco, rei do Egito</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Nehemiah">
@@ -2136,6 +3333,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Noah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Obadiah, manager of Ahab's palace">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Obadiah, manager of Ahab's palace</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Obadiah, ***manager*** ***of*** ***Ahab's*** palácio dos reis</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Oded, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Oded, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Oded, prophet ***of*** ***the*** ***Lord***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.On">
@@ -2372,13 +3587,112 @@
         <seg>Povo who saw healing of demon-possessed man who was blind and mute</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.people, all the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, all the</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, all the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, arrogant wicked">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, arrogant wicked</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, God's">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, God's</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, God's</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, hurried">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, hurried</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, hurried</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, Israel, tribes of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, Israel, tribes of</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, many (at Gennesaret)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, many (at Gennesaret)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, other">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, other</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, other</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, righteous">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, righteous</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, righteous</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, sick">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, sick</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, sick</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, some">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, some</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, some</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, still others">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, still others</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Povo, still others</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Peter (Simon)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Peter (Simon)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Pedro ***(Simon)***</seg>
+        <seg>Pedro (Simão)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon) and companions">
@@ -2387,7 +3701,7 @@
         <seg>Peter (Simon) and companions</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Pedro ***(Simon)*** ***and*** ***companions***</seg>
+        <seg>Pedro (Simão) ***and*** ***companions***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon), with Eleven">
@@ -2414,7 +3728,7 @@
         <seg>Pharisee (expert in religious law)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Fariseu ***(expert*** ***in*** ***religious*** ***law)***</seg>
+        <seg>Fariseu ***(expert*** ***in*** ***religious*** lei)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Pharisee (Simon)">
@@ -2423,7 +3737,16 @@
         <seg>Pharisee (Simon)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Fariseu ***(Simon)***</seg>
+        <seg>Fariseu (Simão)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Pharisee, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharisee, a</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Fariseu, ***a***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Phicol">
@@ -2552,6 +3875,15 @@
         <seg>prophet who confronts Ahab</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.prophet, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>prophet, a</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>prophet, a</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.proverb about a dog">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2624,6 +3956,15 @@
         <seg>Regem-Melech</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Rehoboam, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2667,6 +4008,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Salomé</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Samaria, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samaria, people of</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>os moradores de Samaria</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samson">
@@ -2723,13 +4073,22 @@
         <seg>Sanballat ***the*** Horonite</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sapphira, wife of Ananias of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sapphira, wife of Ananias of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Safira, ***wife*** ***of*** Ananias ***of*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Sarah (Sarai)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Sarah ***(Sarai)***</seg>
+        <seg>Sarah (Sarai)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai) (old)">
@@ -2738,7 +4097,7 @@
         <seg>Sarah (Sarai) (old)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Sarah ***(Sarai)*** ***(old)***</seg>
+        <seg>Sarah (Sarai) ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Satan (Devil)">
@@ -2756,7 +4115,7 @@
         <seg>Saul</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Saulo</seg>
+        <seg>Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -2765,7 +4124,7 @@
         <seg>Saul (Paul)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Saulo ***(Paul)***</seg>
+        <seg>Saulo (Paulo)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying (proverb)">
@@ -2885,6 +4244,33 @@
         <seg>saying about Zion</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.saying, true">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>saying, true</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>saying, true</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Sennacherib, king ***of*** ***Assyria***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.seraph, one of the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>seraph, one of the</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>seraph, one of the</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.servant girl">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2975,6 +4361,15 @@
         <seg>servo of Saul</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shaphan, secretary">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shaphan, secretary</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shaphan, ***secretary***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sharezer">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2984,6 +4379,33 @@
         <seg>Sharezer</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sheba, son of Bicri">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sheba, son of Bicri</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Sheba, ***son*** ***of*** ***Bicri***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shecaniah, son of Jehiel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shecaniah, son of Jehiel</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shecaniah, ***son*** ***of*** Jehiel</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shechem, son of Hamor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shechem, son of Hamor</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shechem, ***son*** ***of*** Hamor</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Shemaiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2991,6 +4413,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Shemaiah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemaiah, son of Delaiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shemaiah, ***son*** ***of*** Delaiah, ***false*** prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemeber, king of Zeboiim">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemeber, king of Zeboiim</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shemeber, king ***of*** Zeboiim</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shephatiah">
@@ -3009,6 +4449,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Shimei</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shinab, king of Admah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shinab, king of Admah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shinab, king ***of*** Admah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shiphrah (midwife)">
@@ -3074,6 +4523,24 @@
         <seg>Simeon</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simeon, devout man in Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Simeon, ***devout*** ***man*** ***in*** ***Jerusalem***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Simon, sorcerer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simon, sorcerer</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Simão, ***sorcerer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sisera">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3081,6 +4548,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Sisera</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Solomon, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Solomon, king</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Solomon, king</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Stephen">
@@ -3101,6 +4577,24 @@
         <seg>administrador, tesoureiro of Joseph's house</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Tamar, daughter of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter of David</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Tamar, ***daughter*** ***of*** David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter-in-law of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Tamar, ***daughter-in-law*** ***of*** Judah</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.tax collectors">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3117,15 +4611,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>templo guards</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.temple police">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple police</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>templo police</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">
@@ -3146,6 +4631,15 @@
         <seg>Tércio</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Tertullus, lawyer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tertullus, lawyer</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Tértulo, ***lawyer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Thomas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3153,6 +4647,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Tomé</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tirzah, daughters of Zelophehad">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tirzah, daughters of Zelophehad</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Tirzah, ***daughters*** ***of*** Zelophehad</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Titus">
@@ -3245,6 +4748,15 @@
         <seg>Zebah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zebul, governor of Shechem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zebul, governor of Shechem</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zebul, ***governor*** ***of*** Shechem</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zechariah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3269,7 +4781,7 @@
         <seg>Zechariah (vision)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Zechariah ***(vision)***</seg>
+        <seg>Zechariah (vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">
@@ -3281,6 +4793,15 @@
         <seg>Zechariah ***(word*** ***of*** ***the*** ***LORD)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah, son of Jehoiada the priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zechariah, ***son*** ***of*** Jehoiada ***the*** priest</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zedekiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3288,6 +4809,60 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Zedekiah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zedekiah, king ***of*** Judah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Hananiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Hananiah</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zedekiah, ***son*** ***of*** Hananiah</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Kenaanah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Kenaanah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zedekiah, ***son*** ***of*** ***Kenaanah,*** ***false*** prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zephaniah, priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zeresh, wife of Haman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zeresh, wife of Haman</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zeresh, ***wife*** ***of*** Haman</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ziba, servant of Saul's household</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ziba, servo ***of*** ***Saul's*** ***household***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">
@@ -3306,6 +4881,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ziphites</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zipporah, Moses' wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zipporah, Moses' wife</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Zipporah, ***Moses'*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zophar the Naamathite">

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -4127,240 +4127,6 @@
         <seg>Saulo (Paulo)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.saying (proverb)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying (proverb)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying (proverb)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Anakites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Anakites</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about Anakites</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about blind and lame">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about blind and lame</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about blind and lame</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about captivity and death by the sword">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about captivity and death by the sword</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about captivity and death by the sword</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Gentile nations">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Gentile nations</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about Gentile nations</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about going beyond what is written">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about going beyond what is written</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about going beyond what is written</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Nimrod">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Nimrod</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about Nimrod</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Saul</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about seer">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about seer</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about seer</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about sow">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about sow</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about sow</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about what controls you">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about what controls you</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about what controls you</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about yeast">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about yeast</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about yeast</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Zion">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Zion</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying about Zion</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying, true">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying, true</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>saying, true</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Sennacherib, king of Assyria">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Sennacherib, king of Assyria</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Sennacherib, king ***of*** ***Assyria***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.seraph, one of the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>seraph, one of the</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>seraph, one of the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo girl</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl at high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl at high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo girl at high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl who watched the door">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl who watched the door</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo girl who watched the door</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl, another</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo girl, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of concubine's husband">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of concubine's husband</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of concubine's husband</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Elijah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Elijah</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of Elijah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Naaman's wife (young girl)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Naaman's wife (young girl)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of Naaman's wife (young girl)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Nabal">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Nabal</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of Nabal</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of priest</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Saul</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>servo of Saul</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Shaphan, secretary">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4496,15 +4262,6 @@
         <seg>Shunammite ***woman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.sign on the cross">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>sign on the cross</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>sinal on the cross</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Silas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4568,15 +4325,6 @@
         <seg>Estêvão</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.steward of Joseph's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>steward of Joseph's house</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>administrador, tesoureiro of Joseph's house</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Tamar, daughter of David">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4593,24 +4341,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Tamar, ***daughter-in-law*** ***of*** Judah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.tax collectors">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>tax collectors</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>imposto collectors</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.temple guards">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple guards</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>templo guards</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">
@@ -4694,24 +4424,6 @@
         <seg>Uriah</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.vineyard owner (God?)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>vineyard owner (God?)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>vineyard owner (God?)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.young man">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>young man</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>novo man</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.young man in white robe (angel)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4719,15 +4431,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>novo man in white robe (angel)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.young men (advisors of Rehoboam)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>young men (advisors of Rehoboam)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>novo men (advisors of Rehoboam)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zalmunna">
@@ -4775,15 +4478,6 @@
         <seg>Zechariah ***(the*** ***LORD*** ***says)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Zechariah (vision)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4809,15 +4503,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Zedekiah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Zedekiah, king of Judah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Zedekiah, king of Judah</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Zedekiah, king ***of*** Judah</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zedekiah, son of Hananiah">

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -50,15 +50,6 @@
         <seg>Abiram</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Abner</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Abner</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -68,15 +59,6 @@
         <seg>Abraham ***(Abram)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Absalom</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Absalom</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Achan">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -84,15 +66,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Achan</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Achish">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Achish</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Achish</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -120,6 +93,24 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ágabo ***the*** prophet</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ahijah ***the*** priest</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Ahijah ***the*** prophet</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahimaaz (messenger)">
@@ -167,15 +158,6 @@
         <seg>Amasa</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Amaziah</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -183,15 +165,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Ammonite ***nobles***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amnon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amnon</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Amnon</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -572,15 +545,6 @@
         <seg>Berenice</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Bethuel ***(Laban's*** ***father)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -624,15 +588,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Caleb</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Caleb ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -732,6 +687,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>David</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>David ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Deborah">
@@ -894,6 +858,15 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Elisha ***(had*** ***said)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Elisha ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elisha (the LORD says)">
@@ -1094,15 +1067,6 @@
         <seg>Gideon ***(Jerubbaal)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Goliath</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Goliath</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Habakkuk">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1119,15 +1083,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Hadad ***the*** Edomite</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Hamor">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Hamor</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Hamor</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1400,6 +1355,15 @@
         <seg>Israelite ***foreman***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Israelite ***men***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1418,22 +1382,13 @@
         <seg>Israelite ***people,*** ***the***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
+        <seg>Israelite soldier in Saul's army</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Israelite ***soldier*** ***(in*** ***Saul's*** ***army)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Israelite ***soldiers***</seg>
+        <seg>Israelite ***soldier*** ***in*** ***Saul's*** ***army***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite spies from house of Joseph">
@@ -1524,15 +1479,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Jehizkiah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Jehoiada</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
@@ -2030,15 +1976,6 @@
         <seg>Micah</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Michael ***(archangel)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2417,13 +2354,13 @@
         <seg>Povo standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
+    <tu tuid="CharacterName.people who had known Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Povo who knew Saul</seg>
+        <seg>Povo who had known Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
@@ -2507,22 +2444,22 @@
         <seg>Filipe</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
+    <tu tuid="CharacterName.Philip the apostle">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
+        <seg>Philip the apostle</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Filipe ***(apostle)***</seg>
+        <seg>Filipe ***the*** ***apostle***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
+    <tu tuid="CharacterName.Philip the evangelist">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
+        <seg>Philip the evangelist</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Filipe ***(the*** ***evangelist)***</seg>
+        <seg>Filipe ***the*** ***evangelist***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -2543,6 +2480,15 @@
         <seg>Philistine ***priests*** ***and*** ***fortune*** ***tellers***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Philistine rulers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philistine rulers</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Philistine ***rulers***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Philistines">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2559,15 +2505,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Pilatos</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>priest</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>priest</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proclamation">
@@ -2687,15 +2624,6 @@
         <seg>Regem-Melech</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Rehoboam</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2768,13 +2696,13 @@
         <seg>Samuel ***(boy)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samuel (old)">
+    <tu tuid="CharacterName.Samuel (dead)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Samuel (old)</seg>
+        <seg>Samuel (dead)</seg>
       </tuv>
       <tuv xml:lang="pt">
-        <seg>Samuel ***(old)***</seg>
+        <seg>Samuel ***(dead)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sanballat">
@@ -2793,15 +2721,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Sanballat ***the*** Horonite</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Sapphira (wife of Ananias of Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Sapphira (wife of Ananias of Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Safira ***(wife*** ***of*** Ananias ***of*** ***Jerusalem)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
@@ -2838,15 +2757,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Saulo</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Saul (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Saul (old)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Saulo ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -3128,6 +3038,15 @@
         <seg>Shua ***(Judah's*** ***wife)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>Shunammite ***woman***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.sign on the cross">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3153,24 +3072,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Simeon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Simeon ***(devout*** ***man*** ***in*** ***Jerusalem)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simon (sorcerer)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simon (sorcerer)</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Simão ***(sorcerer)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sisera">
@@ -3387,15 +3288,6 @@
       </tuv>
       <tuv xml:lang="pt">
         <seg>Zedekiah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Ziba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Ziba</seg>
-      </tuv>
-      <tuv xml:lang="pt">
-        <seg>Ziba</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">

--- a/DistFiles/localization/Glyssen.pt.tmx
+++ b/DistFiles/localization/Glyssen.pt.tmx
@@ -4001,5 +4001,14 @@
         <seg>Zedekiah, king ***of*** Judah</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>high priest</seg>
+      </tuv>
+      <tuv xml:lang="pt">
+        <seg>sumo sacerdote</seg>
+      </tuv>
+    </tu>
   </body>
 </tmx>

--- a/DistFiles/localization/Glyssen.zh-hans.tmx
+++ b/DistFiles/localization/Glyssen.zh-hans.tmx
@@ -194,13 +194,13 @@
         <seg>亚迦布 ***the*** 先知</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Agag, king of Amalekites">
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Agag, king of Amalekites</seg>
+        <seg>Agag, king of the Amalekites</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>亚甲, 王 ***of*** ***Amalekites***</seg>
+        <seg>亚甲, 王 ***of*** ***the*** ***Amalekites***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahab, king of Israel">
@@ -302,13 +302,13 @@
         <seg>亚玛撒)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+    <tu tuid="CharacterName.Amasai, chief of thirty">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+        <seg>Amasai, chief of thirty</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>亚玛赛, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
+        <seg>亚玛赛, ***chief*** ***of*** ***thirty***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">

--- a/DistFiles/localization/Glyssen.zh-hans.tmx
+++ b/DistFiles/localization/Glyssen.zh-hans.tmx
@@ -23,6 +23,15 @@
         <seg>《现》爱比该</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abijah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abijah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比雅, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abimelech">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -41,6 +50,42 @@
         <seg>亚比米勒 ***and*** 非各</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abimelech, King of Gerar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of Gerar</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比米勒, ***King*** ***of*** 基拉耳</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比米勒, ***King*** ***of*** ***the*** ***Philistines***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines (in Gerar)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines (in Gerar)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比米勒, ***King*** ***of*** ***the*** ***Philistines*** ***(in*** 基拉耳)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比米勒, ***son*** ***of*** 基甸 (《现》耶路．巴力)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abiram">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -50,13 +95,40 @@
         <seg>亚比兰</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abishai, Joab's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abishai, Joab's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚比筛, ***Joab's*** ***brother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abner, commander of Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>押尼珥, ***commander*** ***of*** ***Saul's*** ***army***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Abraham (Abram)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>亚伯拉罕 ***(Abram)***</seg>
+        <seg>亚伯拉罕 (亚伯兰)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Absalom, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Absalom, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>押沙龙, ***son*** ***of*** 大卫</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Achan">
@@ -66,6 +138,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚干</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Achish, king of Gath">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Achish, king of Gath</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚吉, 王 ***of*** 迦特</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -86,6 +167,24 @@
         <seg>亚多尼．比色</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Adonijah, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adonijah, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚多尼雅, ***son*** ***of*** 大卫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adoni-Zedek, king of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adoni-Zedek, king of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚多尼．洗德, 王 ***of*** 耶路撒冷</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Agabus the prophet">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -93,6 +192,42 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚迦布 ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚甲, 王 ***of*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahab, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahab, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚哈, 王 ***of*** 《现》以色列</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaz, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaz, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚哈斯, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaziah, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaziah, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚哈谢, 王 ***of*** 《现》以色列</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahijah the priest">
@@ -128,7 +263,7 @@
         <seg>Ahimelech the priest (son of Ahitub)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>亚希米勒 ***the*** 祭司 ***(son*** ***of*** ***Ahitub)***</seg>
+        <seg>亚希米勒 ***the*** 祭司 ***(son*** ***of*** 亚希突)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahithophel">
@@ -158,6 +293,42 @@
         <seg>亚玛撒</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Amasa)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasa)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚玛撒)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚玛赛, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚玛谢, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, priest of Bethel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, priest of Bethel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚玛谢, 祭司 ***of*** 伯特利</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -165,6 +336,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚扪 ***nobles***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amnon, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amnon, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>暗嫩, ***son*** ***of*** 大卫</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -182,7 +362,7 @@
         <seg>Ananias (Annas), the high priest (father-in-law of Caiaphas)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>亚拿尼亚 ***(Annas),*** ***the*** ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司 ***(father-in-law*** ***of*** ***Caiaphas)***</seg>
+        <seg>亚拿尼亚 ***(Annas),*** ***the*** ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司 ***(father-in-law*** ***of*** 该亚法)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ananias of Damascus">
@@ -194,6 +374,15 @@
         <seg>亚拿尼亚 ***of*** 大马士革</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ananias, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ananias, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚拿尼亚, ***the*** ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Andrew">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -201,6 +390,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>安得烈</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Andrew, Simon Peter's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Andrew, Simon Peter's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>安得烈, ***Simon*** ***Peter's*** ***brother***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel">
@@ -365,6 +563,69 @@
         <seg>＜阳＞天使；使者 who wrestled with Jacob</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.angel, another (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞天使；使者, another (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another, coming down from heaven">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞天使；使者, another, coming down from heaven</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞天使；使者, coming out of temple</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞天使；使者, coming out of temple, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, powerful">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, powerful</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞天使；使者, powerful</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Anna, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Anna, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>安娜, ＜阴＞女先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Annas, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Annas, high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚那, ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Apollos">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -372,6 +633,42 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚波罗</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Araunah, the Jebusite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Araunah, the Jebusite</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚劳拿, ***the*** 耶布斯人</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Artaxerxes, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Artaxerxes, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚达薛西, 王 ***of*** ***Persia***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asa, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asa, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚撒, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asahel, brother of Joab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asahel, brother of Joab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚撒黑, ***brother*** ***of*** 约押</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Asaph">
@@ -401,6 +698,24 @@
         <seg>亚她利雅</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Athaliah, mother of Ahaziah (Queen)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, mother of Ahaziah (Queen)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚她利雅, ***mother*** ***of*** 亚哈谢 ***(Queen)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚她利雅, 王后／主母</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Azariah the chief priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -417,6 +732,42 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>《现》耶撒利雅 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, Johanan and all the arrogant men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, Johanan and all the arrogant men</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》耶撒利雅, 约哈难 ***and*** ***all*** ***the*** ***arrogant*** ***men***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Hoshaiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Hoshaiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》耶撒利雅, ***son*** ***of*** 何沙雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Jehohanan">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Jehohanan</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》耶撒利雅, ***son*** ***of*** 约哈难</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Oded">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Oded</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》耶撒利雅, ***son*** ***of*** 俄德</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Baanah">
@@ -518,6 +869,24 @@
         <seg>《现》拔示芭</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Benaiah, son of Jehoiada">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Benaiah, son of Jehoiada</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>比拿雅, ***son*** ***of*** 耶何耶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ben-Hadad, king of Aram">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ben-Hadad, king of Aram</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>便．哈达, 王 ***of*** 亚兰</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Benjamin">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -525,6 +894,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>便雅悯</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bera, king of Sodom">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bera, king of Sodom</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>比拉, 王 ***of*** 所多玛</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Berekiah">
@@ -545,6 +923,24 @@
         <seg>《现》贝妮丝</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Bethlehem, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethlehem, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>伯利恒, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethuel, Rebekah's father</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>彼土利, ***Rebekah's*** ***father***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -554,6 +950,15 @@
         <seg>比勒达 ***the*** 书亚人</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Birsha, king of Gomorrah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Birsha, king of Gomorrah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>比沙, 王 ***of*** 蛾摩拉</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Boaz">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -561,6 +966,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>波阿斯</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Caiaphas, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Caiaphas, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>该亚法, ***the*** ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cain">
@@ -614,7 +1028,16 @@
         <seg>Cleopas and his companion (on road to Emmaus)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>革流巴 ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** ***Emmaus)***</seg>
+        <seg>革流巴 ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** 以马忤斯)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cleopas' companion (on road to Emmaus)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cleopas' companion (on road to Emmaus)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>革流巴' ***companion*** ***(on*** ***road*** ***to*** 以马忤斯)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cornelius">
@@ -633,6 +1056,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>克里特人 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cyrus, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cyrus, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>塞鲁士, 王 ***of*** ***Persia***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Dan">
@@ -680,6 +1112,15 @@
         <seg>大卫 ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.David, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>大卫, 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Deborah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -687,6 +1128,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>底波拉</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Deborah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Deborah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>底波拉, ＜阴＞女先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Delaiah">
@@ -734,6 +1184,15 @@
         <seg>＜阳＞门徒，学生，追随者 whom Jesus loved</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.disciple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>disciple, another</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞门徒，学生，追随者, another</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -761,13 +1220,40 @@
         <seg>以东</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eglon, king of Moab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eglon, king of Moab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>伊矶伦, 王 ***of*** 摩押</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Egyptian (slave of Amalekite)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Egyptian (slave of Amalekite)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>埃及 ***(slave*** ***of*** ***Amalekite)***</seg>
+        <seg>埃及 ***(slave*** ***of*** 亚玛力人)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ehud, Israelite deliverer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ehud, Israelite deliverer</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以笏, 以色列 ***deliverer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ekron, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ekron, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以革伦, ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eleazar the priest, son of Aaron">
@@ -776,7 +1262,7 @@
         <seg>Eleazar the priest, son of Aaron</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>以利亚撒 ***the*** ***priest,*** ***son*** ***of*** 亚伦</seg>
+        <seg>以利亚撒 ***the*** 祭司, ***son*** ***of*** 亚伦</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eli">
@@ -797,6 +1283,15 @@
         <seg>以利 ***(very*** ***old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eliab, David's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliab, David's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以利押, ***David's*** ***brother***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Eliakim">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -804,6 +1299,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>以利亚敬</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliezer, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliezer, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以利以谢, 先知 ***of*** ***the*** ***Lord***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elihu, son of Barakel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elihu, son of Barakel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以利户, ***son*** ***of*** ***Barakel***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elijah">
@@ -924,6 +1437,26 @@
 色列</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ephraim, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以法莲
+色列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, survivor of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, survivor of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以法莲
+色列, ***survivor*** ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ephron the Hittite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -940,6 +1473,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>以扫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Esther, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Esther, queen</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以斯帖, 王后／主母</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ethiopian officer of Queen Candace">
@@ -978,6 +1520,15 @@
         <seg>以西结 ***(in*** 异象／默示／镜子 ***of*** ***God)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Felix, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Felix, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>腓力斯, ***governor*** ***of*** 犹太</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Festus">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -987,6 +1538,15 @@
         <seg>非斯都</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Festus, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Festus, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>非斯都, ***governor*** ***of*** 犹太</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.fool">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -994,6 +1554,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>愚妄／无知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaal, son of Ebed">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaal, son of Ebed</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>迦勒, ***son*** ***of*** 以别</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gabriel">
@@ -1014,6 +1583,15 @@
         <seg>加大拉人 ***(or*** ***Gerasenes)*** ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gallio, proconsul of Achaia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gallio, proconsul of Achaia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>迦流, ***proconsul*** ***of*** 亚该亚</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gamaliel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1023,6 +1601,42 @@
         <seg>迦玛列</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gamaliel, a Pharisee on Sanhedrin">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gamaliel, a Pharisee on Sanhedrin</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>迦玛列, ***a*** 法利赛人 ***on*** ***Sanhedrin***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaza, people of (wicked)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaza, people of (wicked)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>迦萨, ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***of*** ***(wicked)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, governor of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, governor of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基大利, ***governor*** ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, son of Pashur">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, son of Pashur</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基大利, ***son*** ***of*** ***Pashur***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gehazi">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1030,6 +1644,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>基哈西</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gehazi, servant of Elisha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gehazi, servant of Elisha</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基哈西, ＜阳＞仆人 ***of*** 以利沙</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gemariah">
@@ -1047,7 +1670,43 @@
         <seg>Gideon (Jerubbaal)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>基甸 ***(Jerubbaal)***</seg>
+        <seg>基甸 (《现》耶路．巴力)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基列, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基列, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Goliath, Philistine champion">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Goliath, Philistine champion</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>歌利亚, 非利士 ***champion***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Habakkuk">
@@ -1066,6 +1725,33 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>哈达 ***the*** 以东</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hagar, Sarai’s maid</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>夏甲, ***Sarai’s*** ***maid***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Haman, highest noble to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>哈曼, ***highest*** ***noble*** ***to*** ***Xerxes,*** 王</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hamor, Hivite ruler</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>哈抹, 希未人 ＜阴＞起初，首先，根源，第一因；统制的势力，执政者</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1093,6 +1779,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>哈拿尼 ***the*** ***seer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>哈拿尼, ***brother*** ***of*** 尼希米</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hananiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hananiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>哈拿尼雅, ***false*** 先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hannah">
@@ -1149,6 +1853,24 @@
         <seg>希罗底</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Herodias' daughter">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Herodias' daughter</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>希罗底' ***daughter***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hezekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hezekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>希西家, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1165,6 +1887,33 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest's servant (relative of the man whose ear Peter cut off)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hilkiah, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hilkiah, high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>希勒家, ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hirah, the Adullamite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hirah, the Adullamite</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>希拉, ***the*** 亚杜兰人</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hobab, Moses brother-in-law">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hobab, Moses brother-in-law</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>何巴, ***Moses*** ***brother-in-law***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hoglah">
@@ -1221,6 +1970,33 @@
         <seg>何西阿 说 ***what*** ***wicked*** ***will*** ***say***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Huldah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Huldah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>户勒大, ＜阴＞女先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hushai, David's friend">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hushai, David's friend</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>户筛, ***David's*** ＜阳＞朋友</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Irijah, captain of the guard of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Irijah, captain of the guard of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>伊利雅, ***captain*** ***of*** ***the*** ***guard*** ***of*** 犹大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Isaac">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1248,6 +2024,33 @@
         <seg>以赛亚</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Isaiah, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Isaiah, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以赛亚, ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ish-Bosheth, son of Saul</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>伊施波设, ***son*** ***of*** ***Saul***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ishmael, son of Nethaniah (murderer)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ishmael, son of Nethaniah (murderer)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以实玛利, ***son*** ***of*** 尼探雅 ***(murderer)***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1255,6 +2058,60 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>《现》以色列</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***all*** ***the*** ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the tribes">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the tribes</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***all*** ***the*** ***tribes***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, the people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, the people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列, ***the*** ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite army commanding officers">
@@ -1320,15 +2177,6 @@
         <seg>以色列 ***foreman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>以色列 ***men***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1344,7 +2192,7 @@
         <seg>Israelite people, the</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>以色列 ***people,*** ***the***</seg>
+        <seg>以色列 ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, ***the***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite soldier in Saul's army">
@@ -1371,7 +2219,7 @@
         <seg>Israelite spies from Joshua, two men</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>以色列 ***spies*** ***from*** ***Joshua,*** ***two*** ***men***</seg>
+        <seg>以色列 ***spies*** ***from*** 约书亚, ***two*** ***men***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ittai">
@@ -1381,6 +2229,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>以太</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>雅比, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>雅比, ***men*** ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jabez">
@@ -1398,7 +2264,7 @@
         <seg>Jacob (Israel)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>雅各 ***(Israel)***</seg>
+        <seg>雅各 (《现》以色列)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jael">
@@ -1446,6 +2312,15 @@
         <seg>希西家</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jehoash, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoash, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约阿施, 王 ***of*** 《现》以色列</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1453,6 +2328,42 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>耶何耶大 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehonadab, son of Recab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehonadab, son of Recab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约拿达, ***son*** ***of*** ***Recab***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoshaphat, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoshaphat, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约沙法, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Hanani">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Hanani</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶户, ***son*** ***of*** 哈拿尼</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Nimshi">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Nimshi</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶户, ***son*** ***of*** 宁示</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehucal">
@@ -1536,6 +2447,15 @@
         <seg>耶罗波安</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jeroboam, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jeroboam, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶罗波安, 王 ***of*** 《现》以色列</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jeshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1572,6 +2492,33 @@
         <seg>耶稣 ***(child)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jesus' brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' brothers</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶稣' ***brothers***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' disciples">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' disciples</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶稣' ***disciples***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' family</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶稣' ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jesus in 2 John">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1588,6 +2535,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>耶稣 ***in*** ***Hebrews***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' mother and brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' mother and brothers</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>耶稣' ***mother*** ***and*** ***brothers***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jethro (Reuel), Moses' father-in-law">
@@ -1644,6 +2600,24 @@
         <seg>约亚</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joash, father of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, father of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约阿施, ***father*** ***of*** 基甸 (《现》耶路．巴力)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约阿施, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Job">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1686,7 +2660,7 @@
         <seg>John (disciple whom Jesus loved)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>约翰 ***(disciple*** ***whom*** 耶稣 ***loved)***</seg>
+        <seg>约翰 (＜阳＞门徒，学生，追随者 ***whom*** 耶稣 ***loved)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (sons of Zebedee)">
@@ -1695,7 +2669,7 @@
         <seg>John (sons of Zebedee)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>约翰 ***(sons*** ***of*** ***Zebedee)***</seg>
+        <seg>约翰 ***(sons*** ***of*** 西庇太)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (who had asked the Lord who was going to betray Him)">
@@ -1716,6 +2690,24 @@
         <seg>约翰 ***the*** ＜阳＞施洗者</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.John)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约翰)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John, Alexander, and other men of the high priest's family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John, Alexander, and other men of the high priest's family</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约翰, 亚历山大, ***and*** ***other*** ***men*** ***of*** ***the*** ＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 ***priest's*** ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jonah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1732,6 +2724,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>约拿单</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jonathan, son of Abiathar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jonathan, son of Abiathar</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约拿单, ***son*** ***of*** 亚比亚他</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joram, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joram, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约兰, 王 ***of*** 《现》以色列</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Joseph">
@@ -1752,6 +2762,15 @@
         <seg>《现》以色列人 ***of*** 亚利马太</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joseph, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joseph, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》以色列人, ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Joshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1770,6 +2789,24 @@
         <seg>约书亚 ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Josiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Josiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约西亚, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jotham, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jotham, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>约坦, ***son*** ***of*** 基甸 (《现》耶路．巴力)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1777,6 +2814,33 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, all</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>犹大, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>犹大, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, people in">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, people in</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>犹大, ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***in***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Judas Iscariot">
@@ -1788,6 +2852,15 @@
         <seg>犹大 加略人</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Judas, apostle (not Judas Iscariot)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judas, apostle (not Judas Iscariot)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>犹大, ***apostle*** ***(not*** 犹大 加略人)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.king of Bela">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1795,6 +2868,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>王 of Bela</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Kish, father of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Kish, father of Saul</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>基士, ***father*** ***of*** ***Saul***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Korah">
@@ -1821,7 +2903,7 @@
         <seg>Lamech (descendent of Cain)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>拉麦 ***(descendent*** ***of*** ***Cain)***</seg>
+        <seg>拉麦 ***(descendent*** ***of*** 该隐)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Seth)">
@@ -1830,7 +2912,7 @@
         <seg>Lamech (descendent of Seth)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>拉麦 ***(descendent*** ***of*** ***Seth)***</seg>
+        <seg>拉麦 ***(descendent*** ***of*** 塞特)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.law of Moses where LORD commanded">
@@ -1887,6 +2969,15 @@
         <seg>马耳他 ***islanders***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Manoah, father of Samson">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Manoah, father of Samson</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>玛挪亚, ***father*** ***of*** 参孙</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Martha">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1914,6 +3005,42 @@
         <seg>马利亚 ***mother*** ***of*** 雅各</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mary, Jesus' mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, Jesus' mother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>马利亚, 耶稣' ***mother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, sister of Martha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, sister of Martha</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>马利亚, ***sister*** ***of*** 马大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Melchizedek, king of Salem (priest of God Most High)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Melchizedek, king of Salem (priest of God Most High)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>麦基洗德, 王 ***of*** 《现》耶路撒冷 (祭司 ***of*** ***God*** ***Most*** ***High)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Memucan, noble advisor to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Memucan, noble advisor to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》米慕干, ***noble*** ***advisor*** ***to*** ***Xerxes,*** 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Mephibosheth">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1930,6 +3057,33 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>米迦</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Micaiah, prophet of the LORD">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Micaiah, prophet of the LORD</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>米该亚, 先知 ***of*** ***the*** ***LORD***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michael, archangel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michael, archangel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>米迦勒, ***archangel***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michal, David's wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michal, David's wife</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》米甲, ***David's*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
@@ -1995,6 +3149,15 @@
         <seg>摩押人 ***officials,*** ***more*** ***distinguished***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mordecai, cousin of Esther">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mordecai, cousin of Esther</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>末底改, ***cousin*** ***of*** 以斯帖</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Naaman">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2049,6 +3212,15 @@
         <seg>拿单</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Nathan, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Nathan, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>拿单, ***the*** 先知</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Nathanael">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2065,6 +3237,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>尼布撒拉旦</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Neco, king of Egypt">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Neco, king of Egypt</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>尼哥, 王 ***of*** 埃及</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Nehemiah">
@@ -2092,6 +3273,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>挪亚</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Obadiah, manager of Ahab's palace">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Obadiah, manager of Ahab's palace</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>俄巴底亚, ***manager*** ***of*** ***Ahab's*** 皇宫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Oded, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Oded, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>俄德, 先知 ***of*** ***the*** ***Lord***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.On">
@@ -2310,13 +3509,112 @@
         <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 who saw healing of demon-possessed man who was blind and mute</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.people, all the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, all the</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, all the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, arrogant wicked">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, arrogant wicked</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, God's">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, God's</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, God's</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, hurried">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, hurried</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, hurried</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, Israel, tribes of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, Israel, tribes of</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, many (at Gennesaret)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, many (at Gennesaret)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, other">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, other</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, other</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, righteous">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, righteous</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, righteous</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, sick">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, sick</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, sick</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, some">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, some</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, some</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, still others">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, still others</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, still others</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Pharisee (expert in religious law)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Pharisee (expert in religious law)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>法利赛人 ***(expert*** ***in*** ***religious*** ***law)***</seg>
+        <seg>法利赛人 ***(expert*** ***in*** ***religious*** ＜阳＞法律；条例，法则)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Pharisee (Simon)">
@@ -2326,6 +3624,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>法利赛人 ***(Simon)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Pharisee, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharisee, a</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>法利赛人, ***a***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Phicol">
@@ -2436,6 +3743,15 @@
         <seg>先知 who confronts Ahab</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.prophet, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>prophet, a</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>先知, a</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Puah (midwife)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2499,6 +3815,15 @@
         <seg>利坚．米勒</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Rehoboam, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>罗波安, 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2535,6 +3860,15 @@
         <seg>路得</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Samaria, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samaria, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>撒马利亚, ＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Samson">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2568,7 +3902,7 @@
         <seg>Sarah (Sarai)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>《现》莎拉 ***(Sarai)***</seg>
+        <seg>《现》莎拉 (《现》莎莱)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai) (old)">
@@ -2577,7 +3911,7 @@
         <seg>Sarah (Sarai) (old)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>《现》莎拉 ***(Sarai)*** ***(old)***</seg>
+        <seg>《现》莎拉 (《现》莎莱) ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying (proverb)">
@@ -2697,6 +4031,33 @@
         <seg>说 about Zion</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.saying, true">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>saying, true</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>说, true</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西拿基立, 王 ***of*** ***Assyria***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.seraph, one of the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>seraph, one of the</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>撒拉弗, one of the</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.servant girl">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2787,6 +4148,15 @@
         <seg>＜阳＞仆人 of Saul</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shaphan, secretary">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shaphan, secretary</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>沙番, ***secretary***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sharezer">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2796,6 +4166,33 @@
         <seg>沙利色</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sheba, son of Bicri">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sheba, son of Bicri</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>示巴, ***son*** ***of*** ***Bicri***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shecaniah, son of Jehiel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shecaniah, son of Jehiel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>示迦尼, ***son*** ***of*** 耶歇</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shechem, son of Hamor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shechem, son of Hamor</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>示剑, ***son*** ***of*** 哈抹</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Shemaiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2803,6 +4200,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>示玛雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemaiah, son of Delaiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>示玛雅, ***son*** ***of*** 第莱雅, ***false*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemeber, king of Zeboiim">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemeber, king of Zeboiim</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>善以别, 王 ***of*** 《现》洗遍</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shephatiah">
@@ -2830,6 +4245,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>示每</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shinab, king of Admah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shinab, king of Admah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>示纳, 王 ***of*** 押玛</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shiphrah (midwife)">
@@ -2886,6 +4310,15 @@
         <seg>《现》西缅</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simeon, devout man in Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》西缅, ***devout*** ***man*** ***in*** 耶路撒冷</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sisera">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2893,6 +4326,42 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>西西拉</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Solomon, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Solomon, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>所罗门, 王</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》塔玛, ***daughter*** ***of*** 大卫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter-in-law of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>《现》塔玛, ***daughter-in-law*** ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tattenai, governor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tattenai, governor</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>达乃, ***governor***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.tax collectors">
@@ -2913,15 +4382,6 @@
         <seg>＜中＞圣殿；圣殿区 guards</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.temple police">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple police</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜中＞圣殿；圣殿区 police</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Tempter">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2940,6 +4400,15 @@
         <seg>德提</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Tertullus, lawyer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tertullus, lawyer</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>帖土罗, ***lawyer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Thomas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2947,6 +4416,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>多马</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tirzah, daughters of Zelophehad">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tirzah, daughters of Zelophehad</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>得撒, ***daughters*** ***of*** 西罗非哈</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Titus">
@@ -3012,6 +4490,15 @@
         <seg>西巴</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zebul, governor of Shechem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zebul, governor of Shechem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西布勒, ***governor*** ***of*** 示剑</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zechariah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3036,7 +4523,7 @@
         <seg>Zechariah (vision)</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>撒迦利雅 ***(vision)***</seg>
+        <seg>撒迦利雅 (异象／默示／镜子)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">
@@ -3048,6 +4535,15 @@
         <seg>撒迦利雅 ***(word*** ***of*** ***the*** ***LORD)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah, son of Jehoiada the priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>撒迦利雅, ***son*** ***of*** 耶何耶大 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zedekiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3055,6 +4551,60 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>西底家</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西底家, 王 ***of*** 犹大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Hananiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Hananiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西底家, ***son*** ***of*** 哈拿尼雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Kenaanah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Kenaanah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西底家, ***son*** ***of*** ***Kenaanah,*** ***false*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zephaniah, priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西番雅, 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zeresh, wife of Haman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zeresh, wife of Haman</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>细利斯, ***wife*** ***of*** 哈曼</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ziba, servant of Saul's household</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>洗巴, ＜阳＞仆人 ***of*** ***Saul's*** ***household***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">
@@ -3073,6 +4623,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>西弗</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zipporah, Moses' wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zipporah, Moses' wife</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>西坡拉, ***Moses'*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zophar the Naamathite">

--- a/DistFiles/localization/Glyssen.zh-hans.tmx
+++ b/DistFiles/localization/Glyssen.zh-hans.tmx
@@ -50,15 +50,6 @@
         <seg>亚比兰</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Abner</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>押尼珥</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -68,15 +59,6 @@
         <seg>亚伯拉罕 ***(Abram)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Absalom</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>押沙龙</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Achan">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -84,15 +66,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚干</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Achish">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Achish</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>亚吉</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -120,6 +93,24 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚迦布 ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚希亚 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>亚希亚 ***the*** 先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahimaaz (messenger)">
@@ -167,15 +158,6 @@
         <seg>亚玛撒</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>亚玛谢</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -183,15 +165,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>亚扪 ***nobles***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amnon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amnon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>暗嫩</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -572,15 +545,6 @@
         <seg>《现》贝妮丝</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>彼土利 ***(Laban's*** ***father)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -615,15 +579,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>迦勒</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>迦勒 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -714,6 +669,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>大卫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>大卫 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Deborah">
@@ -876,6 +840,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>以利沙 ***(had*** ***said)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以利沙 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elisha (the LORD says)">
@@ -1077,15 +1050,6 @@
         <seg>基甸 ***(Jerubbaal)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Goliath</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>歌利亚</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Habakkuk">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1102,15 +1066,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>哈达 ***the*** 以东</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Hamor">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Hamor</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>哈抹</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1365,6 +1320,15 @@
         <seg>以色列 ***foreman***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>以色列 ***men***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1383,22 +1347,13 @@
         <seg>以色列 ***people,*** ***the***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
+        <seg>Israelite soldier in Saul's army</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>以色列 ***soldier*** ***(in*** ***Saul's*** ***army)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>以色列 ***soldiers***</seg>
+        <seg>以色列 ***soldier*** ***in*** ***Saul's*** ***army***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite spies from house of Joseph">
@@ -1489,15 +1444,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>希西家</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>耶何耶大</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
@@ -1986,15 +1932,6 @@
         <seg>米迦</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>米迦勒 ***(archangel)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2355,13 +2292,13 @@
         <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
+    <tu tuid="CharacterName.people who had known Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 who knew Saul</seg>
+        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 who had known Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
@@ -2409,22 +2346,22 @@
         <seg>腓力</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
+    <tu tuid="CharacterName.Philip the apostle">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
+        <seg>Philip the apostle</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>腓力 ***(apostle)***</seg>
+        <seg>腓力 ***the*** ***apostle***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
+    <tu tuid="CharacterName.Philip the evangelist">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
+        <seg>Philip the evangelist</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>腓力 ***(the*** ***evangelist)***</seg>
+        <seg>腓力 ***the*** ***evangelist***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -2445,13 +2382,13 @@
         <seg>非利士 ***priests*** ***and*** ***fortune*** ***tellers***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.priest">
+    <tu tuid="CharacterName.Philistine rulers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>priest</seg>
+        <seg>Philistine rulers</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>祭司</seg>
+        <seg>非利士 ***rulers***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proclamation">
@@ -2560,15 +2497,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>利坚．米勒</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>罗波安</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Reuben">
@@ -2931,6 +2859,15 @@
         <seg>书亚 ***(Judah's*** ***wife)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>书念妇人 ***woman***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.sign on the cross">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2947,15 +2884,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>《现》西缅</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>《现》西缅 ***(devout*** ***man*** ***in*** ***Jerusalem)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sisera">
@@ -3127,15 +3055,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>西底家</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Ziba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Ziba</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>洗巴</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">

--- a/DistFiles/localization/Glyssen.zh-hans.tmx
+++ b/DistFiles/localization/Glyssen.zh-hans.tmx
@@ -410,204 +410,6 @@
         <seg>＜阳＞天使；使者</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.angel (one of the seven)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel (one of the seven)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 (one of the seven)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 flying directly overhead</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, second">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 flying directly overhead, second</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, third">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 flying directly overhead, third</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel from the rising sun with seal of living God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 from the rising sun with seal of living God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel Gabriel, sent by God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel Gabriel, sent by God</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 Gabriel, sent by God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, an</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 of God, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 of God, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, an</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 of the LORD, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 of the LORD, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel or messenger (Greek variant: someone speaking to John)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel over waters">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel over waters</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 over waters</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing in sun">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing in sun</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 standing in sun</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing on sea and land">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 standing on sea and land</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 who talked with Zechariah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 who talked with Zechariah (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who wrestled with Jacob">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who wrestled with Jacob</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者 who wrestled with Jacob</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another (vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者, another (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another, coming down from heaven">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another, coming down from heaven</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者, another, coming down from heaven</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者, coming out of temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者, coming out of temple, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, powerful">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, powerful</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞天使；使者, powerful</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Anna, prophetess">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1004,15 +806,6 @@
         <seg>迦南人 ***(Syrophoenician)*** ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.chariot commanders of Aram">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>chariot commanders of Aram</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜中＞战车，四轮马车 commanders of Aram</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Cleopas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1047,6 +840,15 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>哥尼流</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.council of elders">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>council of elders</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜中＞长老团</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cretan prophet">
@@ -1166,33 +968,6 @@
         <seg>《现》底米特 ***the*** ***silversmith***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.disciple who wanted to bury his father">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple who wanted to bury his father</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞门徒，学生，追随者 who wanted to bury his father</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple whom Jesus loved">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple whom Jesus loved</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞门徒，学生，追随者 whom Jesus loved</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞门徒，学生，追随者, another</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1200,15 +975,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>多益 ***the*** 以东</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.donkey (female)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>donkey (female)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>公驴 (female)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Edom">
@@ -1871,24 +1637,6 @@
         <seg>希西家, 王 ***of*** 犹大</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.high priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest's servant (relative of the man whose ear Peter cut off)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜形＞高的；骄傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Hilkiah, high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1923,15 +1671,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>曷拉</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.holy one (in vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>holy one (in vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>圣洁／圣 one (in vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hosea">
@@ -2861,15 +2600,6 @@
         <seg>犹大, ***apostle*** ***(not*** 犹大 加略人)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.king of Bela">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>king of Bela</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>王 of Bela</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Kish, father of Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2913,15 +2643,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>拉麦 ***(descendent*** ***of*** 塞特)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.law of Moses where LORD commanded">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>law of Moses where LORD commanded</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞法律；条例，法则 of Moses where LORD commanded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Leah">
@@ -3320,294 +3041,6 @@
         <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people at cistern">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at cistern</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 at cistern</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at coronation of King Joash">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 at coronation of King Joash</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at Jairus' house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 at Jairus' house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Capernaum">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Capernaum</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in Capernaum</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in crowd by Sea of Galilee">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in crowd by Sea of Galilee</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Jericho, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in Jericho, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Pisidian Antioch synagogue">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in Pisidian Antioch synagogue</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in temple courts, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in temple courts, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in the temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in the temple</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 in the temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people near Jordan River">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people near Jordan River</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 near Jordan River</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Decapolis">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Decapolis</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of Decapolis</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of Jerusalem</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem, some</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of Jerusalem, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Samaria, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Samaria, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of Samaria, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of the region of the Gerasenes">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of the region of the Gerasenes</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of the region of the Gerasenes</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Tyre and Sidon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Tyre and Sidon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 of Tyre and Sidon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people praying at John Mark's mother's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 praying at John Mark's mother's house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people standing there">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people standing there</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 standing there</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who had known Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who had known Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 who had known Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民 who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, arrogant wicked">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, arrogant wicked</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, arrogant wicked</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, God's">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, God's</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, God's</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, hurried">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, hurried</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, hurried</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, Israel, tribes of">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, Israel, tribes of</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, Israel, tribes of</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, many (at Gennesaret)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, many (at Gennesaret)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, many (at Gennesaret)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, other">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, other</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, other</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, righteous">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, righteous</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, righteous</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, sick">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, sick</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, sick</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, some</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, still others">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, still others</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞人民，百姓，民间；群众；国家；犹太人或教会，常称为：上帝的子民, still others</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Pharisee (expert in religious law)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3716,42 +3149,6 @@
         <seg>先知</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.prophet in Bethel">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet in Bethel</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>先知 in Bethel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet of the LORD">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet of the LORD</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>先知 of the LORD</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet who confronts Ahab">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet who confronts Ahab</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>先知 who confronts Ahab</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet, a">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet, a</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>先知, a</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Puah (midwife)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3759,24 +3156,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>普瓦 ***(midwife)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.queen of Babylon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Babylon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>王后／主母 of Babylon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.queen of Sheba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Sheba</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>王后／主母 of Sheba</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rachel">
@@ -3914,132 +3293,6 @@
         <seg>《现》莎拉 (《现》莎莱) ***(old)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.saying (proverb)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying (proverb)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 (proverb)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Anakites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Anakites</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about Anakites</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about blind and lame">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about blind and lame</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about blind and lame</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about captivity and death by the sword">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about captivity and death by the sword</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about captivity and death by the sword</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Gentile nations">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Gentile nations</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about Gentile nations</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about going beyond what is written">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about going beyond what is written</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about going beyond what is written</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Nimrod">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Nimrod</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about Nimrod</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about seer">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about seer</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about seer</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about sow">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about sow</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about sow</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about what controls you">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about what controls you</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about what controls you</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about yeast">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about yeast</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about yeast</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Zion">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Zion</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说 about Zion</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying, true">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying, true</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>说, true</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Sennacherib, king of Assyria">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4047,105 +3300,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>西拿基立, 王 ***of*** ***Assyria***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.seraph, one of the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>seraph, one of the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>撒拉弗, one of the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 girl</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl at high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl at high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 girl at high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl who watched the door">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl who watched the door</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 girl who watched the door</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 girl, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of concubine's husband">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of concubine's husband</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of concubine's husband</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Elijah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Elijah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of Elijah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Naaman's wife (young girl)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Naaman's wife (young girl)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of Naaman's wife (young girl)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Nabal">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Nabal</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of Nabal</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of priest</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞仆人 of Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shaphan, secretary">
@@ -4292,15 +3446,6 @@
         <seg>书念妇人 ***woman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.sign on the cross">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>sign on the cross</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜中＞神迹，记号，暗号；凭据；笔迹；表征，预兆，异兆 on the cross</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Simeon">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4337,6 +3482,15 @@
         <seg>所罗门, 王</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.synagogue ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>synagogue ruler</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hans">
+        <seg>＜阳＞会堂主管</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Tamar, daughter of David">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4362,24 +3516,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>达乃, ***governor***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.tax collectors">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>tax collectors</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜阳＞税，贡钱 collectors</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.temple guards">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple guards</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>＜中＞圣殿；圣殿区 guards</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">
@@ -4461,15 +3597,6 @@
       </tuv>
       <tuv xml:lang="zh-Hans">
         <seg>乌利亚</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.vineyard owner (God?)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>vineyard owner (God?)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hans">
-        <seg>葡萄园 owner (God?)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zalmunna">

--- a/DistFiles/localization/Glyssen.zh-hans.tmx
+++ b/DistFiles/localization/Glyssen.zh-hans.tmx
@@ -1493,13 +1493,13 @@
         <seg>哈达 ***the*** 以东</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
       <tuv xml:lang="zh-Hans">
-        <seg>夏甲, ***Sarai’s*** ***maid***</seg>
+        <seg>夏甲, ***Sarai's*** ***maid***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">

--- a/DistFiles/localization/Glyssen.zh-hant.tmx
+++ b/DistFiles/localization/Glyssen.zh-hant.tmx
@@ -23,6 +23,15 @@
         <seg>《現》愛比該</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abijah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abijah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比雅, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abimelech">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -41,6 +50,42 @@
         <seg>亞比米勒 ***and*** 非各</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abimelech, King of Gerar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of Gerar</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比米勒, ***King*** ***of*** 基拉耳</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比米勒, ***King*** ***of*** ***the*** ***Philistines***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, King of the Philistines (in Gerar)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, King of the Philistines (in Gerar)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比米勒, ***King*** ***of*** ***the*** ***Philistines*** ***(in*** 基拉耳)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abimelech, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abimelech, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比米勒, ***son*** ***of*** 基甸 (《現》耶路‧巴力)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abiram">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -50,13 +95,40 @@
         <seg>亞比蘭</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Abishai, Joab's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abishai, Joab's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞比篩, ***Joab's*** ***brother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Abner, commander of Saul's army">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Abner, commander of Saul's army</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>押尼珥, ***commander*** ***of*** ***Saul's*** ***army***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Abraham (Abram)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>亞伯拉罕 ***(Abram)***</seg>
+        <seg>亞伯拉罕 (亞伯蘭)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Absalom, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Absalom, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>押沙龍, ***son*** ***of*** 大衛</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Achan">
@@ -66,6 +138,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞干</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Achish, king of Gath">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Achish, king of Gath</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞吉, 王 ***of*** 迦特</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -86,6 +167,24 @@
         <seg>亞多尼‧比色</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Adonijah, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adonijah, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞多尼雅, ***son*** ***of*** 大衛</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Adoni-Zedek, king of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Adoni-Zedek, king of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞多尼‧洗德, 王 ***of*** 耶路撒冷</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Agabus the prophet">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -93,6 +192,42 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞迦布 ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Agag, king of Amalekites">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Agag, king of Amalekites</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞甲, 王 ***of*** ***Amalekites***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahab, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahab, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞哈, 王 ***of*** 《現》以色列</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaz, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaz, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞哈斯, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahaziah, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahaziah, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞哈謝, 王 ***of*** 《現》以色列</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahijah the priest">
@@ -128,7 +263,7 @@
         <seg>Ahimelech the priest (son of Ahitub)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>亞希米勒 ***the*** 祭司 ***(son*** ***of*** ***Ahitub)***</seg>
+        <seg>亞希米勒 ***the*** 祭司 ***(son*** ***of*** 亞希突)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahithophel">
@@ -158,6 +293,42 @@
         <seg>亞瑪撒</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Amasa)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasa)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞瑪撒)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞瑪賽, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞瑪謝, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amaziah, priest of Bethel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amaziah, priest of Bethel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞瑪謝, 祭司 ***of*** 伯特利</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -165,6 +336,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞捫 ***nobles***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Amnon, son of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Amnon, son of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>暗嫩, ***son*** ***of*** 大衛</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -182,7 +362,7 @@
         <seg>Ananias (Annas), the high priest (father-in-law of Caiaphas)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>亞拿尼亞 ***(Annas),*** ***the*** ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司 ***(father-in-law*** ***of*** ***Caiaphas)***</seg>
+        <seg>亞拿尼亞 ***(Annas),*** ***the*** ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司 ***(father-in-law*** ***of*** 該亞法)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ananias of Damascus">
@@ -194,6 +374,15 @@
         <seg>亞拿尼亞 ***of*** 大馬士革</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ananias, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ananias, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞拿尼亞, ***the*** ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Andrew">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -201,6 +390,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>安得烈</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Andrew, Simon Peter's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Andrew, Simon Peter's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>安得烈, 西門 ***Peter's*** ***brother***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.angel">
@@ -365,6 +563,69 @@
         <seg>＜陽＞天使；使者 who wrestled with Jacob</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.angel, another (vision)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another (vision)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞天使；使者, another (vision)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, another, coming down from heaven">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, another, coming down from heaven</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞天使；使者, another, coming down from heaven</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞天使；使者, coming out of temple</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, coming out of temple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, coming out of temple, another</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞天使；使者, coming out of temple, another</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.angel, powerful">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>angel, powerful</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞天使；使者, powerful</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Anna, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Anna, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>安娜, ＜陰＞女先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Annas, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Annas, high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞那, ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Apollos">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -372,6 +633,42 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞波羅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Araunah, the Jebusite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Araunah, the Jebusite</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞勞拿, ***the*** 耶布斯人</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Artaxerxes, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Artaxerxes, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞達薛西, 王 ***of*** ***Persia***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asa, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asa, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞撒, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Asahel, brother of Joab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Asahel, brother of Joab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞撒黑, ***brother*** ***of*** 約押</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Asaph">
@@ -401,6 +698,24 @@
         <seg>亞她利雅</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Athaliah, mother of Ahaziah (Queen)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, mother of Ahaziah (Queen)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞她利雅, ***mother*** ***of*** 亞哈謝 ***(Queen)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Athaliah, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Athaliah, queen</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞她利雅, 王后／主母</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Azariah the chief priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -417,6 +732,42 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>《現》耶撒利雅 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, Johanan and all the arrogant men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, Johanan and all the arrogant men</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》耶撒利雅, 約哈難 ***and*** ***all*** ***the*** ***arrogant*** ***men***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Hoshaiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Hoshaiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》耶撒利雅, ***son*** ***of*** 何沙雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Jehohanan">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Jehohanan</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》耶撒利雅, ***son*** ***of*** 約哈難</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Azariah, son of Oded">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Azariah, son of Oded</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》耶撒利雅, ***son*** ***of*** 俄德</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Baanah">
@@ -518,6 +869,24 @@
         <seg>《現》拔示芭</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Benaiah, son of Jehoiada">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Benaiah, son of Jehoiada</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>比拿雅, ***son*** ***of*** 耶何耶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ben-Hadad, king of Aram">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ben-Hadad, king of Aram</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>便‧哈達, 王 ***of*** 亞蘭</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Benjamin">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -525,6 +894,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>便雅憫</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bera, king of Sodom">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bera, king of Sodom</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>比拉, 王 ***of*** 所多瑪</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Berekiah">
@@ -545,6 +923,24 @@
         <seg>《現》貝妮絲</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Bethlehem, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethlehem, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>伯利恆, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Bethuel, Rebekah's father">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bethuel, Rebekah's father</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>彼土利, ***Rebekah's*** ***father***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -554,6 +950,15 @@
         <seg>比勒達 ***the*** 書亞人</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Birsha, king of Gomorrah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Birsha, king of Gomorrah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>比沙, 王 ***of*** 蛾摩拉</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Boaz">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -561,6 +966,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>波阿斯</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Caiaphas, the high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Caiaphas, the high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>該亞法, ***the*** ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cain">
@@ -587,7 +1001,7 @@
         <seg>Canaanite (Syrophoenician) mother of possessed girl</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>迦南人 ***(Syrophoenician)*** ***mother*** ***of*** ***possessed*** ***girl***</seg>
+        <seg>迦南人 (《現》敘利亞) ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.chariot commanders of Aram">
@@ -614,7 +1028,16 @@
         <seg>Cleopas and his companion (on road to Emmaus)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>革流巴 ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** ***Emmaus)***</seg>
+        <seg>革流巴 ***and*** ***his*** ***companion*** ***(on*** ***road*** ***to*** 以馬忤斯)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cleopas' companion (on road to Emmaus)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cleopas' companion (on road to Emmaus)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>革流巴' ***companion*** ***(on*** ***road*** ***to*** 以馬忤斯)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cornelius">
@@ -633,6 +1056,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>克里特人 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Cyrus, king of Persia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Cyrus, king of Persia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>塞魯士, 王 ***of*** ***Persia***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Dan">
@@ -680,6 +1112,15 @@
         <seg>大衛 ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.David, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>大衛, 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Deborah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -687,6 +1128,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>底波拉</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Deborah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Deborah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>底波拉, ＜陰＞女先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Delaiah">
@@ -734,6 +1184,15 @@
         <seg>＜陽＞門徒，學生，追隨者 whom Jesus loved</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.disciple, another">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>disciple, another</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞門徒，學生，追隨者, another</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -761,13 +1220,40 @@
         <seg>以東</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eglon, king of Moab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eglon, king of Moab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>伊磯倫, 王 ***of*** 摩押</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Egyptian (slave of Amalekite)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Egyptian (slave of Amalekite)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>埃及 ***(slave*** ***of*** ***Amalekite)***</seg>
+        <seg>埃及 ***(slave*** ***of*** 亞瑪力人)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ehud, Israelite deliverer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ehud, Israelite deliverer</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以笏, 以色列 ***deliverer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ekron, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ekron, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以革倫, ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eleazar the priest, son of Aaron">
@@ -776,7 +1262,7 @@
         <seg>Eleazar the priest, son of Aaron</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>以利亞撒 ***the*** ***priest,*** ***son*** ***of*** 亞倫</seg>
+        <seg>以利亞撒 ***the*** 祭司, ***son*** ***of*** 亞倫</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Eli">
@@ -797,6 +1283,15 @@
         <seg>以利 ***(very*** ***old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Eliab, David's brother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliab, David's brother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以利押, ***David's*** ***brother***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Eliakim">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -804,6 +1299,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>以利亞敬</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Eliezer, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Eliezer, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以利以謝, 先知 ***of*** ***the*** ***Lord***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elihu, son of Barakel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elihu, son of Barakel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以利戶, ***son*** ***of*** ***Barakel***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elijah">
@@ -924,6 +1437,26 @@
 色列</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Ephraim, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以法蓮
+色列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ephraim, survivor of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ephraim, survivor of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以法蓮
+色列, ***survivor*** ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Ephron the Hittite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -940,6 +1473,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>以掃</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Esther, queen">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Esther, queen</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以斯帖, 王后／主母</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ethiopian officer of Queen Candace">
@@ -978,6 +1520,15 @@
         <seg>以西結 ***(in*** 異象／默示／鏡子 ***of*** ***God)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Felix, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Felix, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>腓力斯, ***governor*** ***of*** 猶太</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Festus">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -987,6 +1538,15 @@
         <seg>非斯都</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Festus, governor of Judea">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Festus, governor of Judea</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>非斯都, ***governor*** ***of*** 猶太</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.fool">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -994,6 +1554,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>愚妄／無知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaal, son of Ebed">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaal, son of Ebed</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>迦勒, ***son*** ***of*** 以別</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gabriel">
@@ -1014,6 +1583,15 @@
         <seg>加大拉人 ***(or*** ***Gerasenes)*** ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gallio, proconsul of Achaia">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gallio, proconsul of Achaia</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>迦流, ***proconsul*** ***of*** 亞該亞</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gamaliel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1023,6 +1601,42 @@
         <seg>迦瑪列</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Gamaliel, a Pharisee on Sanhedrin">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gamaliel, a Pharisee on Sanhedrin</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>迦瑪列, ***a*** 法利賽人 ***on*** ***Sanhedrin***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gaza, people of (wicked)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gaza, people of (wicked)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>迦薩, ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***of*** ***(wicked)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, governor of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, governor of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基大利, ***governor*** ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gedaliah, son of Pashur">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gedaliah, son of Pashur</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基大利, ***son*** ***of*** ***Pashur***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Gehazi">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1030,6 +1644,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>基哈西</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gehazi, servant of Elisha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gehazi, servant of Elisha</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基哈西, ＜陽＞僕人 ***of*** 以利沙</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Gemariah">
@@ -1047,7 +1670,43 @@
         <seg>Gideon (Jerubbaal)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>基甸 ***(Jerubbaal)***</seg>
+        <seg>基甸 (《現》耶路‧巴力)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基列, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基列, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Gilead, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Gilead, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Goliath, Philistine champion">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Goliath, Philistine champion</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>歌利亞, 非利士 ***champion***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Habakkuk">
@@ -1066,6 +1725,33 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>哈達 ***the*** 以東</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hagar, Sarai’s maid</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>夏甲, ***Sarai’s*** ***maid***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Haman, highest noble to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>哈曼, ***highest*** ***noble*** ***to*** ***Xerxes,*** 王</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hamor, Hivite ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hamor, Hivite ruler</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>哈抹, 希未人 ＜陰＞起初，首先，根源，第一因；統制的勢力，執政者</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1093,6 +1779,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>哈拿尼 ***the*** ***seer***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hanani, brother of Nehemiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hanani, brother of Nehemiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>哈拿尼, ***brother*** ***of*** 尼希米</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hananiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hananiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>哈拿尼雅, ***false*** 先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hannah">
@@ -1149,6 +1853,24 @@
         <seg>希羅底</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Herodias' daughter">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Herodias' daughter</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>希羅底' ***daughter***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hezekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hezekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>希西家, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1165,6 +1887,33 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest's servant (relative of the man whose ear Peter cut off)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hilkiah, high priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hilkiah, high priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>希勒家, ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hirah, the Adullamite">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hirah, the Adullamite</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>希拉, ***the*** 亞杜蘭人</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hobab, Moses brother-in-law">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hobab, Moses brother-in-law</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>何巴, ***Moses*** ***brother-in-law***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hoglah">
@@ -1221,6 +1970,33 @@
         <seg>何西阿 說 ***what*** ***wicked*** ***will*** ***say***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Huldah, prophetess">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Huldah, prophetess</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>戶勒大, ＜陰＞女先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Hushai, David's friend">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Hushai, David's friend</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>戶篩, ***David's*** ＜陽＞朋友</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Irijah, captain of the guard of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Irijah, captain of the guard of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>伊利雅, ***captain*** ***of*** ***the*** ***guard*** ***of*** 猶大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Isaac">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1248,6 +2024,33 @@
         <seg>以賽亞</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Isaiah, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Isaiah, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以賽亞, ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ish-Bosheth, son of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ish-Bosheth, son of Saul</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>伊施波設, ***son*** ***of*** 掃羅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ishmael, son of Nethaniah (murderer)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ishmael, son of Nethaniah (murderer)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以實瑪利, ***son*** ***of*** 尼探雅 ***(murderer)***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israel">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1255,6 +2058,60 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>《現》以色列</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***all*** ***the*** ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, all the tribes">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, all the tribes</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***all*** ***the*** ***tribes***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, leaders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, leaders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***leaders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Israel, the people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israel, the people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列, ***the*** ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite army commanding officers">
@@ -1320,15 +2177,6 @@
         <seg>以色列 ***foreman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite men">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite men</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>以色列 ***men***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1344,7 +2192,7 @@
         <seg>Israelite people, the</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>以色列 ***people,*** ***the***</seg>
+        <seg>以色列 ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, ***the***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite soldier in Saul's army">
@@ -1371,7 +2219,7 @@
         <seg>Israelite spies from Joshua, two men</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>以色列 ***spies*** ***from*** ***Joshua,*** ***two*** ***men***</seg>
+        <seg>以色列 ***spies*** ***from*** 約書亞, ***two*** ***men***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ittai">
@@ -1381,6 +2229,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>以太</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, elders of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, elders of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>雅比, ***elders*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jabesh, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jabesh, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>雅比, ***men*** ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jabez">
@@ -1398,7 +2264,7 @@
         <seg>Jacob (Israel)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>雅各 ***(Israel)***</seg>
+        <seg>雅各 (《現》以色列)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jael">
@@ -1446,6 +2312,15 @@
         <seg>希西家</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jehoash, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoash, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約阿施, 王 ***of*** 《現》以色列</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1453,6 +2328,42 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>耶何耶大 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehonadab, son of Recab">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehonadab, son of Recab</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約拿達, ***son*** ***of*** ***Recab***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehoshaphat, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehoshaphat, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約沙法, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Hanani">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Hanani</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶戶, ***son*** ***of*** 哈拿尼</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jehu, son of Nimshi">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jehu, son of Nimshi</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶戶, ***son*** ***of*** 寧示</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehucal">
@@ -1536,6 +2447,15 @@
         <seg>耶羅波安</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jeroboam, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jeroboam, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶羅波安, 王 ***of*** 《現》以色列</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jeshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1572,6 +2492,33 @@
         <seg>耶穌 ***(child)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Jesus' brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' brothers</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶穌' ***brothers***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' disciples">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' disciples</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶穌' ***disciples***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' family</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶穌' ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jesus in 2 John">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1588,6 +2535,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>耶穌 ***in*** ***Hebrews***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jesus' mother and brothers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jesus' mother and brothers</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>耶穌' ***mother*** ***and*** ***brothers***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jethro (Reuel), Moses' father-in-law">
@@ -1644,6 +2600,24 @@
         <seg>約亞</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joash, father of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, father of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約阿施, ***father*** ***of*** 基甸 (《現》耶路‧巴力)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joash, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joash, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約阿施, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Job">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1686,7 +2660,7 @@
         <seg>John (disciple whom Jesus loved)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>約翰 ***(disciple*** ***whom*** 耶穌 ***loved)***</seg>
+        <seg>約翰 (＜陽＞門徒，學生，追隨者 ***whom*** 耶穌 ***loved)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (sons of Zebedee)">
@@ -1695,7 +2669,7 @@
         <seg>John (sons of Zebedee)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>約翰 ***(sons*** ***of*** ***Zebedee)***</seg>
+        <seg>約翰 ***(sons*** ***of*** 西庇太)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.John (who had asked the Lord who was going to betray Him)">
@@ -1716,6 +2690,24 @@
         <seg>約翰 ***the*** ＜陽＞施洗者</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.John)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約翰)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.John, Alexander, and other men of the high priest's family">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>John, Alexander, and other men of the high priest's family</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約翰, 亞歷山大, ***and*** ***other*** ***men*** ***of*** ***the*** ＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 ***priest's*** ***family***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Jonah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1732,6 +2724,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>約拿單</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jonathan, son of Abiathar">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jonathan, son of Abiathar</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約拿單, ***son*** ***of*** 亞比亞他</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Joram, king of Israel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joram, king of Israel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約蘭, 王 ***of*** 《現》以色列</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Joseph">
@@ -1752,6 +2762,15 @@
         <seg>《現》以色列人 ***of*** 亞利馬太</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Joseph, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Joseph, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》以色列人, ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***of***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Joshua">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1770,6 +2789,24 @@
         <seg>約書亞 ***(old)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Josiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Josiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約西亞, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Jotham, son of Gideon (Jerubbaal)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Jotham, son of Gideon (Jerubbaal)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>約坦, ***son*** ***of*** 基甸 (《現》耶路‧巴力)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Judah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1777,6 +2814,33 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, all">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, all</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>猶大, ***all***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, men of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, men of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>猶大, ***men*** ***of***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Judah, people in">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judah, people in</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>猶大, ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***in***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Judas Iscariot">
@@ -1788,6 +2852,15 @@
         <seg>猶大 加略人</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Judas, apostle (not Judas Iscariot)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Judas, apostle (not Judas Iscariot)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>猶大, ***apostle*** ***(not*** 猶大 加略人)</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.king of Bela">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1795,6 +2868,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>王 of Bela</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Kish, father of Saul">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Kish, father of Saul</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>基士, ***father*** ***of*** 掃羅</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Korah">
@@ -1821,7 +2903,7 @@
         <seg>Lamech (descendent of Cain)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>拉麥 ***(descendent*** ***of*** ***Cain)***</seg>
+        <seg>拉麥 ***(descendent*** ***of*** 該隱)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Lamech (descendent of Seth)">
@@ -1830,7 +2912,7 @@
         <seg>Lamech (descendent of Seth)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>拉麥 ***(descendent*** ***of*** ***Seth)***</seg>
+        <seg>拉麥 ***(descendent*** ***of*** 塞特)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.law of Moses where LORD commanded">
@@ -1896,6 +2978,15 @@
         <seg>馬耳他 ***islanders***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Manoah, father of Samson">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Manoah, father of Samson</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>瑪挪亞, ***father*** ***of*** 參孫</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Martha">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1923,6 +3014,42 @@
         <seg>馬利亞 ***mother*** ***of*** 雅各</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mary, Jesus' mother">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, Jesus' mother</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>馬利亞, 耶穌' ***mother***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Mary, sister of Martha">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mary, sister of Martha</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>馬利亞, ***sister*** ***of*** 馬大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Melchizedek, king of Salem (priest of God Most High)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Melchizedek, king of Salem (priest of God Most High)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>麥基洗德, 王 ***of*** 《現》耶路撒冷 (祭司 ***of*** ***God*** ***Most*** ***High)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Memucan, noble advisor to Xerxes, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Memucan, noble advisor to Xerxes, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》米慕干, ***noble*** ***advisor*** ***to*** ***Xerxes,*** 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Mephibosheth">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1939,6 +3066,33 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>米迦</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Micaiah, prophet of the LORD">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Micaiah, prophet of the LORD</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>米該亞, 先知 ***of*** ***the*** ***LORD***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michael, archangel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michael, archangel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>米迦勒, ***archangel***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Michal, David's wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Michal, David's wife</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》米甲, ***David's*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
@@ -2004,6 +3158,15 @@
         <seg>摩押人 ***officials,*** ***more*** ***distinguished***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Mordecai, cousin of Esther">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Mordecai, cousin of Esther</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>末底改, ***cousin*** ***of*** 以斯帖</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Naaman">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2058,6 +3221,15 @@
         <seg>拿單</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Nathan, the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Nathan, the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>拿單, ***the*** 先知</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Nathanael">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2074,6 +3246,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>尼布撒拉旦</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Neco, king of Egypt">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Neco, king of Egypt</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>尼哥, 王 ***of*** 埃及</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Nehemiah">
@@ -2101,6 +3282,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>挪亞</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Obadiah, manager of Ahab's palace">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Obadiah, manager of Ahab's palace</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>俄巴底亞, ***manager*** ***of*** ***Ahab's*** 皇宮</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Oded, prophet of the Lord">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Oded, prophet of the Lord</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>俄德, 先知 ***of*** ***the*** ***Lord***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.On">
@@ -2337,13 +3536,112 @@
         <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 who saw healing of demon-possessed man who was blind and mute</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.people, all the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, all the</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, all the</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, arrogant wicked">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, arrogant wicked</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, arrogant wicked</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, God's">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, God's</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, God's</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, hurried">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, hurried</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, hurried</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, Israel, tribes of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, Israel, tribes of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, Israel, tribes of</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, many (at Gennesaret)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, many (at Gennesaret)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, many (at Gennesaret)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, other">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, other</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, other</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, righteous">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, righteous</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, righteous</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, sick">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, sick</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, sick</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, some">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, some</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, some</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.people, still others">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>people, still others</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, still others</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Peter (Simon)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Peter (Simon)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>彼得 ***(Simon)***</seg>
+        <seg>彼得 (西門)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon) and companions">
@@ -2352,7 +3650,7 @@
         <seg>Peter (Simon) and companions</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>彼得 ***(Simon)*** ***and*** ***companions***</seg>
+        <seg>彼得 (西門) ***and*** ***companions***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Peter (Simon), with Eleven">
@@ -2370,7 +3668,7 @@
         <seg>Peter and John's own people (church in Jerusalem)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>彼得 ***and*** ***John's*** ***own*** ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***(church*** ***in*** ***Jerusalem)***</seg>
+        <seg>彼得 ***and*** ***John's*** ***own*** ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***(church*** ***in*** 耶路撒冷)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Pharisee (expert in religious law)">
@@ -2379,7 +3677,7 @@
         <seg>Pharisee (expert in religious law)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>法利賽人 ***(expert*** ***in*** ***religious*** ***law)***</seg>
+        <seg>法利賽人 ***(expert*** ***in*** ***religious*** ＜陽＞法律；條例，法則)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Pharisee (Simon)">
@@ -2388,7 +3686,16 @@
         <seg>Pharisee (Simon)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>法利賽人 ***(Simon)***</seg>
+        <seg>法利賽人 (西門)</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Pharisee, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Pharisee, a</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>法利賽人, ***a***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Phicol">
@@ -2508,6 +3815,15 @@
         <seg>先知 who confronts Ahab</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.prophet, a">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>prophet, a</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>先知, a</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Puah (midwife)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2571,6 +3887,15 @@
         <seg>利堅‧米勒</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Rehoboam, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Rehoboam, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>羅波安, 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2614,6 +3939,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>撒羅米</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Samaria, people of">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Samaria, people of</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>撒馬利亞, ＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 ***of***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Samson">
@@ -2670,13 +4004,22 @@
         <seg>參巴拉 ***the*** 和倫人</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sapphira, wife of Ananias of Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sapphira, wife of Ananias of Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>撒非喇, ***wife*** ***of*** 亞拿尼亞 ***of*** 耶路撒冷</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Sarah (Sarai)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>《現》莎拉 ***(Sarai)***</seg>
+        <seg>《現》莎拉 (《現》莎萊)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai) (old)">
@@ -2685,7 +4028,7 @@
         <seg>Sarah (Sarai) (old)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>《現》莎拉 ***(Sarai)*** ***(old)***</seg>
+        <seg>《現》莎拉 (《現》莎萊) ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Satan (Devil)">
@@ -2712,7 +4055,7 @@
         <seg>Saul (Paul)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>掃羅 ***(Paul)***</seg>
+        <seg>掃羅 (保羅)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.saying (proverb)">
@@ -2832,6 +4175,33 @@
         <seg>說 about Zion</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.saying, true">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>saying, true</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>說, true</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Sennacherib, king of Assyria">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sennacherib, king of Assyria</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西拿基立, 王 ***of*** ***Assyria***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.seraph, one of the">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>seraph, one of the</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>撒拉弗, one of the</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.servant girl">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2922,6 +4292,15 @@
         <seg>＜陽＞僕人 of Saul</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shaphan, secretary">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shaphan, secretary</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>沙番, ***secretary***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sharezer">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2931,6 +4310,33 @@
         <seg>沙利色</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Sheba, son of Bicri">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Sheba, son of Bicri</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>示巴, ***son*** ***of*** ***Bicri***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shecaniah, son of Jehiel">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shecaniah, son of Jehiel</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>示迦尼, ***son*** ***of*** 耶歇</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shechem, son of Hamor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shechem, son of Hamor</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>示劍, ***son*** ***of*** 哈抹</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Shemaiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2938,6 +4344,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>示瑪雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemaiah, son of Delaiah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemaiah, son of Delaiah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>示瑪雅, ***son*** ***of*** 第萊雅, ***false*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shemeber, king of Zeboiim">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shemeber, king of Zeboiim</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>善以別, 王 ***of*** 《現》洗遍</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shephatiah">
@@ -2965,6 +4389,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>示每</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Shinab, king of Admah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shinab, king of Admah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>示納, 王 ***of*** 押瑪</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shiphrah (midwife)">
@@ -3030,6 +4463,24 @@
         <seg>《現》西緬</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Simeon, devout man in Jerusalem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simeon, devout man in Jerusalem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》西緬, ***devout*** ***man*** ***in*** 耶路撒冷</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Simon, sorcerer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Simon, sorcerer</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西門, ***sorcerer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Sisera">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3039,6 +4490,15 @@
         <seg>西西拉</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Solomon, king">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Solomon, king</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>所羅門, 王</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Stephen">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3046,6 +4506,33 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>司提反</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter of David">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter of David</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》塔瑪, ***daughter*** ***of*** 大衛</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tamar, daughter-in-law of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tamar, daughter-in-law of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>《現》塔瑪, ***daughter-in-law*** ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tattenai, governor">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tattenai, governor</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>達乃, ***governor***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.tax collectors">
@@ -3066,15 +4553,6 @@
         <seg>＜中＞聖殿；聖殿區 guards</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.temple police">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple police</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜中＞聖殿；聖殿區 police</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Tempter">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3093,6 +4571,15 @@
         <seg>德提</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Tertullus, lawyer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tertullus, lawyer</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>帖土羅, ***lawyer***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Thomas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3100,6 +4587,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>多馬</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Tirzah, daughters of Zelophehad">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Tirzah, daughters of Zelophehad</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>得撒, ***daughters*** ***of*** 西羅非哈</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Titus">
@@ -3165,6 +4661,15 @@
         <seg>西巴</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zebul, governor of Shechem">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zebul, governor of Shechem</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西布勒, ***governor*** ***of*** 示劍</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zechariah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3189,7 +4694,7 @@
         <seg>Zechariah (vision)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>撒迦利雅 ***(vision)***</seg>
+        <seg>撒迦利雅 (異象／默示／鏡子)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zechariah (word of the LORD)">
@@ -3201,6 +4706,15 @@
         <seg>撒迦利雅 ***(word*** ***of*** ***the*** ***LORD)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Zechariah, son of Jehoiada the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zechariah, son of Jehoiada the priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>撒迦利雅, ***son*** ***of*** 耶何耶大 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Zedekiah">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3208,6 +4722,60 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>西底家</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, king of Judah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, king of Judah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西底家, 王 ***of*** 猶大</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Hananiah">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Hananiah</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西底家, ***son*** ***of*** 哈拿尼雅</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zedekiah, son of Kenaanah, false prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zedekiah, son of Kenaanah, false prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西底家, ***son*** ***of*** ***Kenaanah,*** ***false*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zephaniah, priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zephaniah, priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西番雅, 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zeresh, wife of Haman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zeresh, wife of Haman</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>細利斯, ***wife*** ***of*** 哈曼</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ziba, servant of Saul's household">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ziba, servant of Saul's household</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>洗巴, ＜陽＞僕人 ***of*** ***Saul's*** ***household***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">
@@ -3226,6 +4794,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>西弗</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Zipporah, Moses' wife">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Zipporah, Moses' wife</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>西坡拉, ***Moses'*** ***wife***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zophar the Naamathite">

--- a/DistFiles/localization/Glyssen.zh-hant.tmx
+++ b/DistFiles/localization/Glyssen.zh-hant.tmx
@@ -194,13 +194,13 @@
         <seg>亞迦布 ***the*** 先知</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Agag, king of Amalekites">
+    <tu tuid="CharacterName.Agag, king of the Amalekites">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Agag, king of Amalekites</seg>
+        <seg>Agag, king of the Amalekites</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>亞甲, 王 ***of*** ***Amalekites***</seg>
+        <seg>亞甲, 王 ***of*** ***the*** ***Amalekites***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahab, king of Israel">
@@ -302,13 +302,13 @@
         <seg>亞瑪撒)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amasai, chief of thirty (Spirit came upon)">
+    <tu tuid="CharacterName.Amasai, chief of thirty">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Amasai, chief of thirty (Spirit came upon)</seg>
+        <seg>Amasai, chief of thirty</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>亞瑪賽, ***chief*** ***of*** ***thirty*** ***(Spirit*** ***came*** ***upon)***</seg>
+        <seg>亞瑪賽, ***chief*** ***of*** ***thirty***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amaziah, king of Judah">

--- a/DistFiles/localization/Glyssen.zh-hant.tmx
+++ b/DistFiles/localization/Glyssen.zh-hant.tmx
@@ -1493,13 +1493,13 @@
         <seg>哈達 ***the*** 以東</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Hagar, Sarai’s maid">
+    <tu tuid="CharacterName.Hagar, Sarai's maid">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Hagar, Sarai’s maid</seg>
+        <seg>Hagar, Sarai's maid</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>夏甲, ***Sarai’s*** ***maid***</seg>
+        <seg>夏甲, ***Sarai's*** ***maid***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Haman, highest noble to Xerxes, king">

--- a/DistFiles/localization/Glyssen.zh-hant.tmx
+++ b/DistFiles/localization/Glyssen.zh-hant.tmx
@@ -410,204 +410,6 @@
         <seg>＜陽＞天使；使者</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.angel (one of the seven)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel (one of the seven)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 (one of the seven)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 flying directly overhead</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, second">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, second</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 flying directly overhead, second</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel flying directly overhead, third">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel flying directly overhead, third</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 flying directly overhead, third</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel from the rising sun with seal of living God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel from the rising sun with seal of living God</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 from the rising sun with seal of living God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel Gabriel, sent by God">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel Gabriel, sent by God</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 Gabriel, sent by God</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, an</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 of God, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of God, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of God, the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 of God, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, an">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, an</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 of the LORD, an</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel of the LORD, the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel of the LORD, the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 of the LORD, the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel or messenger (Greek variant: someone speaking to John)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 or messenger (Greek variant: someone speaking to John)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel over waters">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel over waters</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 over waters</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing in sun">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing in sun</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 standing in sun</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel standing on sea and land">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel standing on sea and land</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 standing on sea and land</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 who talked with Zechariah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who talked with Zechariah (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who talked with Zechariah (vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 who talked with Zechariah (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel who wrestled with Jacob">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel who wrestled with Jacob</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者 who wrestled with Jacob</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another (vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another (vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者, another (vision)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, another, coming down from heaven">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, another, coming down from heaven</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者, another, coming down from heaven</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者, coming out of temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, coming out of temple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, coming out of temple, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者, coming out of temple, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.angel, powerful">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>angel, powerful</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞天使；使者, powerful</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Anna, prophetess">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1004,15 +806,6 @@
         <seg>迦南人 (《現》敘利亞) ***mother*** ***of*** ***possessed*** ***girl***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.chariot commanders of Aram">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>chariot commanders of Aram</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜中＞戰車，四輪馬車 commanders of Aram</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Cleopas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1047,6 +840,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>哥尼流</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.council of elders">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>council of elders</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜中＞長老團</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Cretan prophet">
@@ -1166,33 +968,6 @@
         <seg>《現》底米特 ***the*** ***silversmith***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.disciple who wanted to bury his father">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple who wanted to bury his father</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞門徒，學生，追隨者 who wanted to bury his father</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple whom Jesus loved">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple whom Jesus loved</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞門徒，學生，追隨者 whom Jesus loved</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.disciple, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>disciple, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞門徒，學生，追隨者, another</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Doeg the Edomite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1200,15 +975,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>多益 ***the*** 以東</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.donkey (female)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>donkey (female)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>公驢 (female)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Edom">
@@ -1871,24 +1637,6 @@
         <seg>希西家, 王 ***of*** 猶大</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.high priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.high priest's servant (relative of the man whose ear Peter cut off)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>high priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜形＞高的；驕傲的，高傲的；ἐν ὑψηλοῖς 在天上 priest's servant (relative of the man whose ear Peter cut off)</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Hilkiah, high priest">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1923,15 +1671,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>曷拉</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.holy one (in vision)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>holy one (in vision)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>聖潔／聖 one (in vision)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hosea">
@@ -2861,15 +2600,6 @@
         <seg>猶大, ***apostle*** ***(not*** 猶大 加略人)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.king of Bela">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>king of Bela</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>王 of Bela</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Kish, father of Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2913,15 +2643,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>拉麥 ***(descendent*** ***of*** 塞特)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.law of Moses where LORD commanded">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>law of Moses where LORD commanded</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞法律；條例，法則 of Moses where LORD commanded</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Leah">
@@ -3347,294 +3068,6 @@
         <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people at cistern">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at cistern</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 at cistern</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at coronation of King Joash">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at coronation of King Joash</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 at coronation of King Joash</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people at Jairus' house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people at Jairus' house</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 at Jairus' house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Capernaum">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Capernaum</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in Capernaum</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in crowd by Sea of Galilee">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in crowd by Sea of Galilee</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in crowd by Sea of Galilee</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Jericho, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Jericho, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in Jericho, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in Pisidian Antioch synagogue">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in Pisidian Antioch synagogue</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in Pisidian Antioch synagogue</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in temple courts, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in temple courts, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in temple courts, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people in the temple">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people in the temple</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 in the temple</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people near Jordan River">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people near Jordan River</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 near Jordan River</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Decapolis">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Decapolis</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of Decapolis</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of Jerusalem</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Jerusalem, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Jerusalem, some</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of Jerusalem, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Samaria, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Samaria, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of Samaria, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of the region of the Gerasenes">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of the region of the Gerasenes</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of the region of the Gerasenes</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people of Tyre and Sidon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people of Tyre and Sidon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 of Tyre and Sidon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people praying at John Mark's mother's house">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people praying at John Mark's mother's house</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 praying at John Mark's mother's house</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people standing there">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people standing there</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 standing there</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who had known Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who had known Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 who had known Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 who saw healing of demon-possessed man who was blind and mute</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, all the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, all the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, all the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, arrogant wicked">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, arrogant wicked</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, arrogant wicked</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, God's">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, God's</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, God's</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, hurried">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, hurried</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, hurried</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, Israel, tribes of">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, Israel, tribes of</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, Israel, tribes of</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, many (at Gennesaret)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, many (at Gennesaret)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, many (at Gennesaret)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, other">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, other</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, other</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, righteous">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, righteous</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, righteous</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, sick">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, sick</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, sick</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, some">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, some</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, some</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.people, still others">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>people, still others</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民, still others</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Peter (Simon)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3788,42 +3221,6 @@
         <seg>先知</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.prophet in Bethel">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet in Bethel</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>先知 in Bethel</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet of the LORD">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet of the LORD</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>先知 of the LORD</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet who confronts Ahab">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet who confronts Ahab</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>先知 who confronts Ahab</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.prophet, a">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>prophet, a</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>先知, a</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Puah (midwife)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3831,24 +3228,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>普瓦 ***(midwife)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.queen of Babylon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Babylon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>王后／主母 of Babylon</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.queen of Sheba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>queen of Sheba</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>王后／主母 of Sheba</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Rachel">
@@ -4058,132 +3437,6 @@
         <seg>掃羅 (保羅)</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.saying (proverb)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying (proverb)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 (proverb)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Anakites">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Anakites</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about Anakites</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about blind and lame">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about blind and lame</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about blind and lame</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about captivity and death by the sword">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about captivity and death by the sword</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about captivity and death by the sword</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Gentile nations">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Gentile nations</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about Gentile nations</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about going beyond what is written">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about going beyond what is written</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about going beyond what is written</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Nimrod">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Nimrod</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about Nimrod</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about Saul</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about seer">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about seer</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about seer</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about sow">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about sow</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about sow</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about what controls you">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about what controls you</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about what controls you</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about yeast">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about yeast</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about yeast</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying about Zion">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying about Zion</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說 about Zion</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.saying, true">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>saying, true</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>說, true</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Sennacherib, king of Assyria">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4191,105 +3444,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>西拿基立, 王 ***of*** ***Assyria***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.seraph, one of the">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>seraph, one of the</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>撒拉弗, one of the</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 girl</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl at high priest's courtyard">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl at high priest's courtyard</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 girl at high priest's courtyard</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl who watched the door">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl who watched the door</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 girl who watched the door</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant girl, another">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant girl, another</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 girl, another</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of concubine's husband">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of concubine's husband</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of concubine's husband</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Elijah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Elijah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of Elijah</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Naaman's wife (young girl)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Naaman's wife (young girl)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of Naaman's wife (young girl)</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Nabal">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Nabal</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of Nabal</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of priest</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of priest</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.servant of Saul">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>servant of Saul</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞僕人 of Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Shaphan, secretary">
@@ -4436,15 +3590,6 @@
         <seg>書念婦人 ***woman***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.sign on the cross">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>sign on the cross</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜中＞神蹟，記號，暗號；憑據；筆跡；表徵，預兆，異兆 on the cross</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Silas">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4508,6 +3653,15 @@
         <seg>司提反</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.synagogue ruler">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>synagogue ruler</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>＜陽＞會堂主管</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Tamar, daughter of David">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -4533,24 +3687,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>達乃, ***governor***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.tax collectors">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>tax collectors</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞稅，貢錢 collectors</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.temple guards">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>temple guards</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>＜中＞聖殿；聖殿區 guards</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Tempter">
@@ -4632,15 +3768,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>烏利亞</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.vineyard owner (God?)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>vineyard owner (God?)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>葡萄園 owner (God?)</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zalmunna">

--- a/DistFiles/localization/Glyssen.zh-hant.tmx
+++ b/DistFiles/localization/Glyssen.zh-hant.tmx
@@ -50,15 +50,6 @@
         <seg>亞比蘭</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Abner">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Abner</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>押尼珥</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Abraham (Abram)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -68,15 +59,6 @@
         <seg>亞伯拉罕 ***(Abram)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Absalom">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Absalom</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>押沙龍</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Achan">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -84,15 +66,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞干</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Achish">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Achish</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>亞吉</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Adam">
@@ -120,6 +93,24 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞迦布 ***the*** 先知</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the priest">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the priest</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞希亞 ***the*** 祭司</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Ahijah the prophet">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Ahijah the prophet</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>亞希亞 ***the*** 先知</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Ahimaaz (messenger)">
@@ -167,15 +158,6 @@
         <seg>亞瑪撒</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Amaziah">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amaziah</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>亞瑪謝</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Ammonite nobles">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -183,15 +165,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>亞捫 ***nobles***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Amnon">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Amnon</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>暗嫩</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Amos">
@@ -572,15 +545,6 @@
         <seg>《現》貝妮絲</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Bethuel (Laban's father)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Bethuel (Laban's father)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>彼土利 ***(Laban's*** ***father)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Bildad the Shuhite">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -615,15 +579,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>迦勒</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Caleb (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Caleb (old)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>迦勒 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Canaanite (Syrophoenician) mother of possessed girl">
@@ -714,6 +669,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>大衛</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.David (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>David (old)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>大衛 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Deborah">
@@ -876,6 +840,15 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>以利沙 ***(had*** ***said)***</seg>
+      </tuv>
+    </tu>
+    <tu tuid="CharacterName.Elisha (old)">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Elisha (old)</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以利沙 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Elisha (the LORD says)">
@@ -1077,15 +1050,6 @@
         <seg>基甸 ***(Jerubbaal)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Goliath">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Goliath</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>歌利亞</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Habakkuk">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1102,15 +1066,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>哈達 ***the*** 以東</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Hamor">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Hamor</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>哈抹</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Hanamel (Jeremiah's cousin)">
@@ -1365,6 +1320,15 @@
         <seg>以色列 ***foreman***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Israelite men">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Israelite men</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>以色列 ***men***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Israelite officers">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1383,22 +1347,13 @@
         <seg>以色列 ***people,*** ***the***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Israelite soldier (in Saul's army)">
+    <tu tuid="CharacterName.Israelite soldier in Saul's army">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Israelite soldier (in Saul's army)</seg>
+        <seg>Israelite soldier in Saul's army</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>以色列 ***soldier*** ***(in*** ***Saul's*** ***army)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Israelite soldiers">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Israelite soldiers</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>以色列 ***soldiers***</seg>
+        <seg>以色列 ***soldier*** ***in*** ***Saul's*** ***army***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Israelite spies from house of Joseph">
@@ -1489,15 +1444,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>希西家</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Jehoiada">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Jehoiada</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>耶何耶大</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Jehoiada the priest">
@@ -1995,15 +1941,6 @@
         <seg>米迦</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Michael (archangel)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Michael (archangel)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>米迦勒 ***(archangel)***</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Midianite soldier who had a dream">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2382,13 +2319,13 @@
         <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 standing there</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.people who knew Saul">
+    <tu tuid="CharacterName.people who had known Saul">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>people who knew Saul</seg>
+        <seg>people who had known Saul</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 who knew Saul</seg>
+        <seg>＜陽＞人民，百姓，民間；群眾；國家；猶太人或教會，常稱為：上帝的子民 who had known Saul</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.people who saw healing of demon-possessed man who was blind and mute">
@@ -2472,22 +2409,22 @@
         <seg>腓力</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (apostle)">
+    <tu tuid="CharacterName.Philip the apostle">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (apostle)</seg>
+        <seg>Philip the apostle</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>腓力 ***(apostle)***</seg>
+        <seg>腓力 ***the*** ***apostle***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Philip (the evangelist)">
+    <tu tuid="CharacterName.Philip the evangelist">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Philip (the evangelist)</seg>
+        <seg>Philip the evangelist</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>腓力 ***(the*** ***evangelist)***</seg>
+        <seg>腓力 ***the*** ***evangelist***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Philistine commanders">
@@ -2508,6 +2445,15 @@
         <seg>非利士 ***priests*** ***and*** ***fortune*** ***tellers***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Philistine rulers">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Philistine rulers</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>非利士 ***rulers***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.Pilate">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2515,15 +2461,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>彼拉多</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.priest">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>priest</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>祭司</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.proclamation">
@@ -2634,15 +2571,6 @@
         <seg>利堅‧米勒</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Rehoboam">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Rehoboam</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>羅波安</seg>
-      </tuv>
-    </tu>
     <tu tuid="CharacterName.Reuben">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -2715,13 +2643,13 @@
         <seg>撒母耳 ***(boy)***</seg>
       </tuv>
     </tu>
-    <tu tuid="CharacterName.Samuel (old)">
+    <tu tuid="CharacterName.Samuel (dead)">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
-        <seg>Samuel (old)</seg>
+        <seg>Samuel (dead)</seg>
       </tuv>
       <tuv xml:lang="zh-Hant">
-        <seg>撒母耳 ***(old)***</seg>
+        <seg>撒母耳 ***(dead)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sanballat">
@@ -2740,15 +2668,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>參巴拉 ***the*** 和倫人</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Sapphira (wife of Ananias of Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Sapphira (wife of Ananias of Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>撒非喇 ***(wife*** ***of*** 亞拿尼亞 ***of*** ***Jerusalem)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sarah (Sarai)">
@@ -2785,15 +2704,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>掃羅</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Saul (old)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Saul (old)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>掃羅 ***(old)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Saul (Paul)">
@@ -3084,6 +2994,15 @@
         <seg>書亞 ***(Judah's*** ***wife)***</seg>
       </tuv>
     </tu>
+    <tu tuid="CharacterName.Shunammite woman">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Shunammite woman</seg>
+      </tuv>
+      <tuv xml:lang="zh-Hant">
+        <seg>書念婦人 ***woman***</seg>
+      </tuv>
+    </tu>
     <tu tuid="CharacterName.sign on the cross">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3109,24 +3028,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>《現》西緬</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simeon (devout man in Jerusalem)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simeon (devout man in Jerusalem)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>《現》西緬 ***(devout*** ***man*** ***in*** ***Jerusalem)***</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Simon (sorcerer)">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Simon (sorcerer)</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>西門 ***(sorcerer)***</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Sisera">
@@ -3307,15 +3208,6 @@
       </tuv>
       <tuv xml:lang="zh-Hant">
         <seg>西底家</seg>
-      </tuv>
-    </tu>
-    <tu tuid="CharacterName.Ziba">
-      <prop type="x-dynamic">true</prop>
-      <tuv xml:lang="en">
-        <seg>Ziba</seg>
-      </tuv>
-      <tuv xml:lang="zh-Hant">
-        <seg>洗巴</seg>
       </tuv>
     </tu>
     <tu tuid="CharacterName.Zion">

--- a/Glyssen/Resources/CharacterDetail.txt
+++ b/Glyssen/Resources/CharacterDetail.txt
@@ -26,7 +26,7 @@ Adonijah, son of David	1	Male
 Adoni-Zedek, king of Jerusalem	1	Male			
 advisers to king	-1	Male			
 Agabus the prophet	1	Male			
-Agag, king of Amalekites	1	Male			
+Agag, king of the Amalekites	1	Male			
 Ahab, king of Israel	1	Male			
 Ahaz, king of Judah	1	Male			
 Ahaziah, king of Israel	1	Male			
@@ -42,7 +42,7 @@ all the elders	-1	Male			elders of the church in Jerusalem
 all who heard (in synagogues)	-1				
 altar	1	Neuter			
 Amasa	1	Male			leader in Ephraim
-Amasai, chief of thirty (Spirit came upon)	1	Male			
+Amasai, chief of thirty	1	Male			
 Amaziah, king of Judah	1	Male			
 Amaziah, priest of Bethel	1	Male			
 Ammonite nobles	-1	Male			
@@ -366,7 +366,7 @@ Greeks	-1
 guards at high priests' house	-1	Male			
 Habakkuk	1	Male			
 Hadad the Edomite	1	Male			
-Hagar, the Egyptian	1	Female			
+Hagar, Sarai’s maid	1	Female			
 Haggai (word of the LORD)	1	Male			
 half-tribe of Manasseh	-1	Male			
 Haman, highest noble to Xerxes, king	1	Male			
@@ -434,7 +434,7 @@ Israelite assembly, elders of	-1	Male
 Israelite community	-1				
 Israelite fighting men	-1	Male			
 Israelite foreman	1	Male			
-Israelite men	-1	Male			
+Israelites (soldiers)	-1	Male			
 Israelite officers	-1	Male			
 Israelite soldier in Saul's army	1	Male			
 Israelite spies from house of Joseph	-1	Male			
@@ -632,6 +632,7 @@ men of Gerar	-1	Male
 men of Jabesh	-1				
 men of Jericho	-1	Male			
 men of Sodom (wicked)	-1	Male			
+men (soldiers) standing near David	-1	Male			
 men who have gone astray	-1	Male			
 men with leprosy, four	4	Male			
 men, large force of	-1	Male			
@@ -724,6 +725,7 @@ officer of King Jehoshaphat of Israel	1	Male
 officer of King Joram of Israel	1	Male			
 officer of king of Israel, on whose arm the king leaned	1	Male			
 officer of king of Israel, on whose arm the king leaned (post mortem)	1	Male			
+officers	-1	Male			
 officers of King of Aram	-1	Male			
 officers of magistrates	-1	Male			
 officers of temple guard	-1	Male			
@@ -1014,7 +1016,6 @@ teacher (Preacher)	1	Male
 teacher of religious law	1	Male			
 teachers of religious law	-1	Male			
 temple guards	-1	Male			
-temple police	-1	Male			
 Tertius	1	Male			
 Tertullus, lawyer	1	Male			
 Thomas	1	Male			

--- a/Glyssen/Resources/CharacterDetail.txt
+++ b/Glyssen/Resources/CharacterDetail.txt
@@ -366,7 +366,7 @@ Greeks	-1
 guards at high priests' house	-1	Male			
 Habakkuk	1	Male			
 Hadad the Edomite	1	Male			
-Hagar, Sarai’s maid	1	Female			
+Hagar, Sarai's maid	1	Female			
 Haggai (word of the LORD)	1	Male			
 half-tribe of Manasseh	-1	Male			
 Haman, highest noble to Xerxes, king	1	Male			

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -163,13 +163,13 @@ GEN	15	21	God		God (word of the LORD came in a vision)	Normal
 GEN	16	2	Sarah (Sarai)			Normal		
 GEN	16	5	Sarah (Sarai)			Normal		
 GEN	16	6	Abraham (Abram)			Normal		
-GEN	16	8	Hagar, the Egyptian			Normal		
+GEN	16	8	Hagar, Sarai’s maid			Normal		
 GEN	16	8	angel of the LORD, the			Normal	Jesus	
 GEN	16	9	angel of the LORD, the			Normal	Jesus	
 GEN	16	10	angel of the LORD, the			Normal	Jesus	
 GEN	16	11	angel of the LORD, the			Normal	Jesus	
 GEN	16	12	angel of the LORD, the			Normal	Jesus	
-GEN	16	13	Hagar, the Egyptian			Normal		
+GEN	16	13	Hagar, Sarai’s maid			Normal		
 GEN	17	1	God		God (the LORD)	Normal		
 GEN	17	2	God		God (the LORD)	Normal		
 GEN	17	4	God		God (the LORD)	Normal		
@@ -261,7 +261,7 @@ GEN	21	7	Sarah (Sarai) (old)			Normal
 GEN	21	10	Sarah (Sarai) (old)			Normal		
 GEN	21	12	God		God (the LORD)	Normal		
 GEN	21	13	God		God (the LORD)	Normal		
-GEN	21	16	Hagar, the Egyptian			Normal		
+GEN	21	16	Hagar, Sarai’s maid			Normal		
 GEN	21	17	angel of the LORD, the		angel of God, the	Normal	Jesus	
 GEN	21	18	angel of the LORD, the		angel of God, the	Normal	Jesus	
 GEN	21	22	Abimelech, King of Gerar/Phicol		Abimelech and Phicol	Normal		
@@ -4232,20 +4232,20 @@ RUT	4	17	women of Bethlehem			Normal
 1SA	14	33	messengers to Saul			Normal		
 1SA	14	33	Saul			Normal		
 1SA	14	34	Saul			Normal		
-1SA	14	36	Israelite men			Normal		
+1SA	14	36	Israelites (soldiers)			Normal		
 1SA	14	36	Ahijah the priest			Normal		
 1SA	14	36	Saul			Normal		
 1SA	14	37	Saul			Normal		
 1SA	14	38	Saul			Normal		
 1SA	14	39	Saul			Normal		
-1SA	14	40	Israelite men			Normal		
+1SA	14	40	Israelites (soldiers)			Normal		
 1SA	14	40	Saul			Normal		
 1SA	14	41	Saul			Normal		
 1SA	14	42	Saul			Normal		
 1SA	14	43	Jonathan			Normal		
 1SA	14	43	Saul			Normal		
 1SA	14	44	Saul			Normal		
-1SA	14	45	Israelite men			Normal		
+1SA	14	45	Israelites (soldiers)			Normal		
 1SA	15	1	Samuel			Normal		
 1SA	15	2	Samuel			Normal		
 1SA	15	3	Samuel			Normal		
@@ -4270,7 +4270,7 @@ RUT	4	17	women of Bethlehem			Normal
 1SA	15	28	Samuel			Normal		
 1SA	15	29	Samuel			Normal		
 1SA	15	30	Saul			Normal		
-1SA	15	32	Agag, king of Amalekites			Normal		
+1SA	15	32	Agag, king of the Amalekites			Normal		
 1SA	15	32	Samuel			Normal		
 1SA	15	33	Samuel			Normal		
 1SA	16	1	God		God (the LORD)	Normal		
@@ -4299,9 +4299,9 @@ RUT	4	17	women of Bethlehem			Normal
 1SA	17	17	Jesse			Normal		
 1SA	17	18	Jesse			Normal		
 1SA	17	19	Jesse			Normal		
-1SA	17	25	Israelites			Normal		
+1SA	17	25	Israelites (soldiers)			Normal		
 1SA	17	26	David			Normal		
-1SA	17	27	Israelite men			Normal		
+1SA	17	27	men (soldiers) standing near David			Normal		
 1SA	17	28	Eliab, David's brother			Normal		
 1SA	17	29	David			Normal		
 1SA	17	32	David			Normal		
@@ -5669,8 +5669,8 @@ RUT	4	17	women of Bethlehem			Normal
 2KI	18	36	Hezekiah, king of Judah			Normal		
 2KI	19	3	Eliakim/Shebna/chief priests			Normal	Eliakim	
 2KI	19	4	Eliakim/Shebna/chief priests			Normal	Eliakim	
-2KI	19	6	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	7	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
+2KI	19	6	Isaiah			Normal		
+2KI	19	7	Isaiah			Normal		
 2KI	19	10	Sennacherib, king of Assyria			Normal		
 2KI	19	11	Sennacherib, king of Assyria			Normal		
 2KI	19	12	Sennacherib, king of Assyria			Normal		
@@ -5680,36 +5680,36 @@ RUT	4	17	women of Bethlehem			Normal
 2KI	19	17	Hezekiah, king of Judah			Normal		
 2KI	19	18	Hezekiah, king of Judah			Normal		
 2KI	19	19	Hezekiah, king of Judah			Normal		
-2KI	19	20	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	21	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	22	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	23	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	24	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	25	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	26	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	27	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	28	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	29	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	30	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	31	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	32	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	33	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	19	34	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-2KI	20	1	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
+2KI	19	20	Isaiah			Normal		
+2KI	19	21	Isaiah			Normal		
+2KI	19	22	Isaiah			Normal		
+2KI	19	23	Isaiah			Normal		
+2KI	19	24	Isaiah			Normal		
+2KI	19	25	Isaiah			Normal		
+2KI	19	26	Isaiah			Normal		
+2KI	19	27	Isaiah			Normal		
+2KI	19	28	Isaiah			Normal		
+2KI	19	29	Isaiah			Normal		
+2KI	19	30	Isaiah			Normal		
+2KI	19	31	Isaiah			Normal		
+2KI	19	32	Isaiah			Normal		
+2KI	19	33	Isaiah			Normal		
+2KI	19	34	Isaiah			Normal		
+2KI	20	1	Isaiah			Normal		
 2KI	20	3	Hezekiah, king of Judah			Normal		
 2KI	20	5	God		word of the LORD	Normal		
 2KI	20	6	God		word of the LORD	Normal		
 2KI	20	7	Isaiah		Isaiah, the prophet	Normal		
 2KI	20	8	Hezekiah, king of Judah			Normal		
-2KI	20	9	Isaiah		Isaiah, the prophet (sign)	Normal		
+2KI	20	9	Isaiah			Normal		
 2KI	20	10	Hezekiah, king of Judah			Normal		
 2KI	20	14	Hezekiah, king of Judah			Normal		
 2KI	20	14	Isaiah		Isaiah, the prophet	Normal		
 2KI	20	15	Hezekiah, king of Judah			Normal		
 2KI	20	15	Isaiah		Isaiah, the prophet	Normal		
-2KI	20	16	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
-2KI	20	17	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
-2KI	20	18	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
+2KI	20	16	Isaiah			Normal		
+2KI	20	17	Isaiah			Normal		
+2KI	20	18	Isaiah			Normal		
 2KI	20	19	Hezekiah, king of Judah			Normal		
 2KI	21	4	God		God (the LORD)	Quotation		
 2KI	21	7	God		God (the LORD)	Quotation		
@@ -5727,12 +5727,12 @@ RUT	4	17	women of Bethlehem			Normal
 2KI	22	9	Shaphan, secretary			Normal		
 2KI	22	10	Shaphan, secretary			Normal		
 2KI	22	13	Josiah, king of Judah			Normal		
-2KI	22	15	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
-2KI	22	16	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
-2KI	22	17	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
-2KI	22	18	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
-2KI	22	19	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
-2KI	22	20	Huldah, prophetess		Huldah, prophetess (the LORD says)	Normal		
+2KI	22	15	Huldah, prophetess			Normal		
+2KI	22	16	Huldah, prophetess			Normal		
+2KI	22	17	Huldah, prophetess			Normal		
+2KI	22	18	Huldah, prophetess			Normal		
+2KI	22	19	Huldah, prophetess			Normal		
+2KI	22	20	Huldah, prophetess			Normal		
 2KI	23	17	Josiah, king of Judah			Normal		
 2KI	23	17	men of Bethel			Normal		
 2KI	23	18	Josiah, king of Judah			Normal		
@@ -5749,7 +5749,7 @@ RUT	4	17	women of Bethlehem			Normal
 1CH	11	17	David			Normal		
 1CH	11	19	David			Normal		
 1CH	12	17	David			Normal		
-1CH	12	18	Amasai, chief of thirty (Spirit came upon)			Normal		
+1CH	12	18	Amasai, chief of thirty			Normal		
 1CH	12	19	Philistine rulers			Normal		
 1CH	13	2	David		David, king	Normal		
 1CH	13	3	David		David, king	Normal		
@@ -5973,7 +5973,7 @@ RUT	4	17	women of Bethlehem			Normal
 2CH	10	16	Israel, all			Normal		
 2CH	11	3	God		word of the LORD came to Shemaiah	Normal		
 2CH	11	4	God		word of the LORD came to Shemaiah	Normal		
-2CH	12	5	Shemaiah		Shemaiah, prophet (the LORD says)	Normal		
+2CH	12	5	Shemaiah			Normal		
 2CH	12	6	Israel, leaders of/Rehoboam, king		leaders of Israel and the king (Rehoboam)	Normal		
 2CH	12	7	God		word of the LORD came to Shemaiah	Normal		
 2CH	12	8	God		word of the LORD came to Shemaiah	Normal		
@@ -7896,7 +7896,7 @@ ISA	19	3	God		God (the LORD, the LORD Almighty)	Normal
 ISA	19	4	God		God (the LORD, the LORD Almighty)	Normal		
 ISA	19	11	wise men of Pharaoh			Hypothetical		
 ISA	19	25	God		God (the LORD Almighty)	Normal		
-ISA	20	2	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
+ISA	20	2	God		God (the LORD)	Normal		
 ISA	20	3	God		God (the LORD)	Normal		
 ISA	20	4	God		God (the LORD)	Normal		
 ISA	20	5	God		God (the LORD)	Normal		
@@ -8010,27 +8010,27 @@ ISA	37	17	Hezekiah, king of Judah			Normal
 ISA	37	18	Hezekiah, king of Judah			Normal		
 ISA	37	19	Hezekiah, king of Judah			Normal		
 ISA	37	20	Hezekiah, king of Judah			Normal		
-ISA	37	21	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
-ISA	37	22	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	23	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	24	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	25	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	26	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	27	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	28	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	29	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	30	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	31	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	32	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	33	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	34	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	37	35	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
-ISA	38	1	Isaiah		Isaiah, the prophet (the LORD says)	Normal		
+ISA	37	21	Isaiah			Normal		
+ISA	37	22	Isaiah			Normal		
+ISA	37	23	Isaiah			Normal		
+ISA	37	24	Isaiah			Normal		
+ISA	37	25	Isaiah			Normal		
+ISA	37	26	Isaiah			Normal		
+ISA	37	27	Isaiah			Normal		
+ISA	37	28	Isaiah			Normal		
+ISA	37	29	Isaiah			Normal		
+ISA	37	30	Isaiah			Normal		
+ISA	37	31	Isaiah			Normal		
+ISA	37	32	Isaiah			Normal		
+ISA	37	33	Isaiah			Normal		
+ISA	37	34	Isaiah			Normal		
+ISA	37	35	Isaiah			Normal		
+ISA	38	1	Isaiah			Normal		
 ISA	38	3	Hezekiah, king of Judah			Normal		
-ISA	38	5	Isaiah		Isaiah, the prophet (word of the LORD came)	Normal		
-ISA	38	6	Isaiah		Isaiah, the prophet (word of the LORD came)	Normal		
-ISA	38	7	Isaiah		Isaiah, the prophet (word of the LORD came)	Normal		
-ISA	38	8	Isaiah		Isaiah, the prophet (word of the LORD came)	Normal		
+ISA	38	5	God		God (the LORD)	Normal		
+ISA	38	6	God		God (the LORD)	Normal		
+ISA	38	7	God		God (the LORD)	Normal		
+ISA	38	8	God		God (the LORD)	Normal		
 ISA	38	10	Hezekiah, king of Judah	writing		Normal		
 ISA	38	11	Hezekiah, king of Judah	writing		Normal		
 ISA	38	12	Hezekiah, king of Judah	writing		Normal		
@@ -8050,9 +8050,9 @@ ISA	39	3	Hezekiah, king of Judah			Normal
 ISA	39	3	Isaiah		Isaiah, the prophet	Normal		
 ISA	39	4	Hezekiah, king of Judah			Normal		
 ISA	39	4	Isaiah		Isaiah, the prophet	Normal		
-ISA	39	5	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
-ISA	39	6	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
-ISA	39	7	Isaiah		Isaiah, the prophet (word of the LORD)	Normal		
+ISA	39	5	Isaiah			Normal		
+ISA	39	6	Isaiah			Normal		
+ISA	39	7	Isaiah			Normal		
 ISA	39	8	Hezekiah, king of Judah	response to Isaiah		Normal		
 ISA	39	8	Hezekiah, king of Judah	thought		Normal		
 ISA	40	3	voice of one calling, a (preparing way for Christ)			Normal		
@@ -9219,14 +9219,14 @@ JER	38	23	Jeremiah			Normal
 JER	38	24	Zedekiah, king of Judah			Normal		
 JER	38	25	Zedekiah, king of Judah			Normal		
 JER	38	26	Zedekiah, king of Judah			Normal		
-JER	39	12	Nebuzaradan		Nebuzaradan, Babylonian commander of imperial guard	Normal		
+JER	39	12	Nebuzaradan		 guard	Normal		
 JER	39	16	God		God (the LORD)(word of the LORD came)	Normal		
 JER	39	17	God		God (the LORD)(word of the LORD came)	Normal		
 JER	39	18	God		God (the LORD)(word of the LORD came)	Normal		
-JER	40	2	Nebuzaradan		Nebuzaradan, commander for king of Babylon	Normal		
-JER	40	3	Nebuzaradan		Nebuzaradan, commander for king of Babylon	Normal		
-JER	40	4	Nebuzaradan		Nebuzaradan, commander for king of Babylon	Normal		
-JER	40	5	Nebuzaradan		Nebuzaradan, commander for king of Babylon	Normal		
+JER	40	2	Nebuzaradan			Normal		
+JER	40	3	Nebuzaradan			Normal		
+JER	40	4	Nebuzaradan			Normal		
+JER	40	5	Nebuzaradan			Normal		
 JER	40	9	Gedaliah, governor of Judah			Normal		
 JER	40	10	Gedaliah, governor of Judah			Normal		
 JER	40	14	Johanan/army officers			Normal	Johanan	
@@ -14608,7 +14608,7 @@ ACT	5	8	Peter (Simon)			Dialogue
 ACT	5	8	Sapphira, wife of Ananias of Jerusalem			Dialogue		
 ACT	5	9	Peter (Simon)			Dialogue		
 ACT	5	20	angel of the LORD, an	commanding		Normal		
-ACT	5	23	temple police	perplexed		Normal		
+ACT	5	23	officers	perplexed		Normal		
 ACT	5	24	captain of the temple guard/chief priests			Indirect		
 ACT	5	25	person who told the guards and priests where the apostles were	excited		Normal		
 ACT	5	28	Ananias (Annas), the high priest (father-in-law of Caiaphas)		high priest	Dialogue		

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -163,13 +163,13 @@ GEN	15	21	God		God (word of the LORD came in a vision)	Normal
 GEN	16	2	Sarah (Sarai)			Normal		
 GEN	16	5	Sarah (Sarai)			Normal		
 GEN	16	6	Abraham (Abram)			Normal		
-GEN	16	8	Hagar, Sarai’s maid			Normal		
+GEN	16	8	Hagar, Sarai's maid			Normal		
 GEN	16	8	angel of the LORD, the			Normal	Jesus	
 GEN	16	9	angel of the LORD, the			Normal	Jesus	
 GEN	16	10	angel of the LORD, the			Normal	Jesus	
 GEN	16	11	angel of the LORD, the			Normal	Jesus	
 GEN	16	12	angel of the LORD, the			Normal	Jesus	
-GEN	16	13	Hagar, Sarai’s maid			Normal		
+GEN	16	13	Hagar, Sarai's maid			Normal		
 GEN	17	1	God		God (the LORD)	Normal		
 GEN	17	2	God		God (the LORD)	Normal		
 GEN	17	4	God		God (the LORD)	Normal		
@@ -261,7 +261,7 @@ GEN	21	7	Sarah (Sarai) (old)			Normal
 GEN	21	10	Sarah (Sarai) (old)			Normal		
 GEN	21	12	God		God (the LORD)	Normal		
 GEN	21	13	God		God (the LORD)	Normal		
-GEN	21	16	Hagar, Sarai’s maid			Normal		
+GEN	21	16	Hagar, Sarai's maid			Normal		
 GEN	21	17	angel of the LORD, the		angel of God, the	Normal	Jesus	
 GEN	21	18	angel of the LORD, the		angel of God, the	Normal	Jesus	
 GEN	21	22	Abimelech, King of Gerar/Phicol		Abimelech and Phicol	Normal		
@@ -9219,7 +9219,7 @@ JER	38	23	Jeremiah			Normal
 JER	38	24	Zedekiah, king of Judah			Normal		
 JER	38	25	Zedekiah, king of Judah			Normal		
 JER	38	26	Zedekiah, king of Judah			Normal		
-JER	39	12	Nebuzaradan		 guard	Normal		
+JER	39	12	Nebuzaradan			Normal		
 JER	39	16	God		God (the LORD)(word of the LORD came)	Normal		
 JER	39	17	God		God (the LORD)(word of the LORD came)	Normal		
 JER	39	18	God		God (the LORD)(word of the LORD came)	Normal		


### PR DESCRIPTION
This now works correctly for processing proper names with explanatory text following a comma. It also prevents attempting of word-for-word translation of terms that do not begin with a proper name. Did a bunch of cleanup to localization files related to the latter issue. Also, now a few of the translations for French and Portuguese are human-edited (with a lot of help from Google translate and my *limited* knowledge o.those languages).