### PR TITLE
Issue PG-386: don't make the user select the only book

### DIFF
--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -265,7 +265,17 @@ namespace Glyssen
 
 		public BookSelectionStatus BookSelectionStatus
 		{
-			get { return m_metadata.ProjectStatus.BookSelectionStatus; }
+			get
+			{
+				// don't make the user open the select books dialog if there is only 1 book
+				if ((m_metadata.ProjectStatus.BookSelectionStatus == BookSelectionStatus.UnReviewed) &&
+					(AvailableBooks.Count == 1) && (IncludedBooks.Count == 1))
+				{
+					m_metadata.ProjectStatus.BookSelectionStatus = BookSelectionStatus.Reviewed;
+				}
+
+				return m_metadata.ProjectStatus.BookSelectionStatus;
+			}
 			set { m_metadata.ProjectStatus.BookSelectionStatus = value; }
 		}
 

--- a/GlyssenTests/ProjectTests.cs
+++ b/GlyssenTests/ProjectTests.cs
@@ -555,6 +555,19 @@ namespace GlyssenTests
 			Assert.AreEqual(resultFemale, testProject.CharacterGroupGenerationPreferences.NumberOfFemaleNarrators);
 		}
 
+		[Test]
+		public void Load_JustOneBookAvailableAndOneIncluded_AutomaticallyFlagAsReviewed()
+		{
+			var project = TestProject.CreateBasicTestProject();
+			var metadata = (GlyssenDblTextMetadata)ReflectionHelper.GetField(project, "m_metadata");
+			metadata.AvailableBooks.Insert(0, new Book { Code = "GEN" });
+			project.Save();
+
+			project = TestProject.LoadExistingTestProject();
+
+			Assert.AreEqual(BookSelectionStatus.Reviewed, project.BookSelectionStatus);
+		}
+
 		private void WaitForProjectInitializationToFinish(Project project, ProjectState projectState)
 		{
 			const int maxCyclesAllowed = 100;


### PR DESCRIPTION
If there is only one book in the bundle, don't make the user select it before continuing.

Resolves #PG-386

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/75)
<!-- Reviewable:end -->
