### PR TITLE
Issue PG-544: Don't show test results until until quote parser runs

### DIFF
--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -117,6 +117,15 @@ namespace Glyssen.Dialogs
 			Mode = BlocksToDisplay.AllScripture;
 		}
 
+		internal BlockNavigator BlockNavigator
+		{
+			set
+			{
+				m_navigator = value;
+				ResetFilter(null);
+			}
+		}
+
 		#region IDisposable Members
 		public void Dispose()
 		{

--- a/Glyssen/Dialogs/QuotationMarksDlg.Designer.cs
+++ b/Glyssen/Dialogs/QuotationMarksDlg.Designer.cs
@@ -128,7 +128,6 @@ namespace Glyssen.Dialogs
 			this.m_btnCancel.Text = "Cancel";
 			this.glyssenColorPalette.SetUsePaletteColors(this.m_btnCancel, false);
 			this.m_btnCancel.UseVisualStyleBackColor = false;
-			this.m_btnCancel.Click += new System.EventHandler(this.m_btnCancel_Click);
 			// 
 			// m_btnOk
 			// 
@@ -181,7 +180,6 @@ namespace Glyssen.Dialogs
 			this.m_chkDialogueQuotations.BackColor = System.Drawing.SystemColors.Control;
 			this.m_chkDialogueQuotations.FlatAppearance.BorderColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetFlatAppearanceBorderColor(this.m_chkDialogueQuotations, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_chkDialogueQuotations.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_chkDialogueQuotations, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_chkDialogueQuotations.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_chkDialogueQuotations, null);
@@ -244,13 +242,11 @@ namespace Glyssen.Dialogs
 			// m_lblEndDialogueQuote
 			// 
 			this.m_lblEndDialogueQuote.AutoSize = true;
-			this.m_lblEndDialogueQuote.BackColor = System.Drawing.SystemColors.Control;
 			this.glyssenColorPalette.SetBackColor(this.m_lblEndDialogueQuote, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.m_lblEndDialogueQuote.BackColor = System.Drawing.SystemColors.Control;
 			this.m_lblEndDialogueQuote.Enabled = false;
 			this.m_lblEndDialogueQuote.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_lblEndDialogueQuote, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_lblEndDialogueQuote.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_lblEndDialogueQuote, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_lblEndDialogueQuote, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.m_lblEndDialogueQuote, "DialogBoxes.QuotationMarksDlg.EndDialogueQuote");
@@ -269,7 +265,6 @@ namespace Glyssen.Dialogs
 			this.m_chkAlternateSpeakersInFirstLevelQuotes.Enabled = false;
 			this.m_chkAlternateSpeakersInFirstLevelQuotes.FlatAppearance.BorderColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetFlatAppearanceBorderColor(this.m_chkAlternateSpeakersInFirstLevelQuotes, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_chkAlternateSpeakersInFirstLevelQuotes.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_chkAlternateSpeakersInFirstLevelQuotes, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_chkAlternateSpeakersInFirstLevelQuotes.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_chkAlternateSpeakersInFirstLevelQuotes, null);
@@ -444,8 +439,8 @@ namespace Glyssen.Dialogs
 			// 
 			// m_scriptureReference
 			// 
-			this.glyssenColorPalette.SetBackColor(this.m_scriptureReference, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.m_scriptureReference.BackColor = System.Drawing.Color.Transparent;
+			this.glyssenColorPalette.SetBackColor(this.m_scriptureReference, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.glyssenColorPalette.SetForeColor(this.m_scriptureReference, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_scriptureReference, "");
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_scriptureReference, null);
@@ -517,12 +512,10 @@ namespace Glyssen.Dialogs
 			// 
 			// label1
 			// 
-			this.label1.BackColor = System.Drawing.SystemColors.Control;
 			this.glyssenColorPalette.SetBackColor(this.label1, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.label1.BackColor = System.Drawing.SystemColors.Control;
 			this.label1.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.label1, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.label1.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.label1, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.label1, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.label1, "DialogBoxes.QuotationMarksDlg.SwitchFirstLevel");
@@ -540,13 +533,11 @@ namespace Glyssen.Dialogs
 			// m_lblStartDialogueQuote
 			// 
 			this.m_lblStartDialogueQuote.AutoSize = true;
-			this.m_lblStartDialogueQuote.BackColor = System.Drawing.SystemColors.Control;
 			this.glyssenColorPalette.SetBackColor(this.m_lblStartDialogueQuote, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.m_lblStartDialogueQuote.BackColor = System.Drawing.SystemColors.Control;
 			this.m_lblStartDialogueQuote.Enabled = false;
 			this.m_lblStartDialogueQuote.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_lblStartDialogueQuote, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_lblStartDialogueQuote.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_lblStartDialogueQuote, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_lblStartDialogueQuote, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.m_lblStartDialogueQuote, "DialogBoxes.QuotationMarksDlg.DialogueQuotationDash");
@@ -603,7 +594,6 @@ namespace Glyssen.Dialogs
 			this.m_blocksViewer.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.m_blocksViewer.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_blocksViewer, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_blocksViewer.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_blocksViewer, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_blocksViewer, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.m_blocksViewer, "DialogBoxes.QuotationMarksDlg.ScriptBlocksViewer");
@@ -624,7 +614,6 @@ namespace Glyssen.Dialogs
 			this.glyssenColorPalette.SetFlatAppearanceBorderColor(this.m_chkPairedQuotations, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_chkPairedQuotations.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.glyssenColorPalette.SetForeColor(this.m_chkPairedQuotations, Glyssen.Utilities.GlyssenColors.ForeColor);
-			this.m_chkPairedQuotations.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_chkPairedQuotations, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_chkPairedQuotations, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.m_chkPairedQuotations, "DialogBoxes.QuotationMarksDlg.PairedQuotationMarks");
@@ -901,8 +890,8 @@ namespace Glyssen.Dialogs
 			// m_testResults
 			// 
 			this.m_testResults.AutoSize = true;
-			this.glyssenColorPalette.SetBackColor(this.m_testResults, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.m_testResults.BackColor = System.Drawing.SystemColors.Control;
+			this.glyssenColorPalette.SetBackColor(this.m_testResults, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.glyssenColorPalette.SetForeColor(this.m_testResults, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_testResults.ForeColor = System.Drawing.SystemColors.WindowText;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_testResults, null);
@@ -917,6 +906,7 @@ namespace Glyssen.Dialogs
 			this.m_testResults.TabIndex = 33;
 			this.m_testResults.Text = "0% of expected quotes were found";
 			this.glyssenColorPalette.SetUsePaletteColors(this.m_testResults, true);
+			this.m_testResults.Visible = false;
 			// 
 			// m_pnlDialogeQuotes
 			// 

--- a/Glyssen/Dialogs/QuotationMarksDlg.resx
+++ b/Glyssen/Dialogs/QuotationMarksDlg.resx
@@ -123,14 +123,8 @@
   <metadata name="m_l10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="m_l10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="m_toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>303, 17</value>
-  </metadata>
-  <metadata name="glyssenColorPalette.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>417, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>63</value>

--- a/GlyssenTests/TestProject.cs
+++ b/GlyssenTests/TestProject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Xml;
@@ -78,6 +79,17 @@ namespace GlyssenTests
 		public static Project CreateBasicTestProject()
 		{
 			return CreateTestProject(TestBook.JUD);
+		}
+
+		public static List<BookScript> BooksBeforeQuoteParse(params TestBook[] booksToInclude)
+		{
+			var sampleMetadata = new GlyssenDblTextMetadata {AvailableBooks = new List<Book>()};
+			var books = new List<UsxDocument>();
+
+			foreach (var testBook in booksToInclude)
+				AddBook(testBook, sampleMetadata, books);
+
+			return UsxParser.ParseProject(books, SfmLoader.GetUsfmStylesheet(), new BackgroundWorker { WorkerReportsProgress = true });
 		}
 
 		private static QuoteSystem GetTestQuoteSystem()


### PR DESCRIPTION
Changed QuoteParser so changes can be tested can be run without updating the project.

Changed BlockNavigatorViewModel so it can show blocks that are not part of a project (output from the Quoteparser changes).

Resolves #PG-544

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/76)
<!-- Reviewable:end -->
