### PR TITLE
Issue PG-201: In Open Project dialog, improve column width behavior

### DIFF
--- a/Glyssen/Dialogs/OpenProjectDlg.Designer.cs
+++ b/Glyssen/Dialogs/OpenProjectDlg.Designer.cs
@@ -73,12 +73,12 @@
 			this.m_linkTextReleaseBundle.AutoSize = true;
 			this.glyssenColorPalette.SetBackColor(this.m_linkTextReleaseBundle, Glyssen.Utilities.GlyssenColors.BackColor);
 			this.m_linkTextReleaseBundle.BackColor = System.Drawing.SystemColors.Control;
-			this.glyssenColorPalette.SetDisabledLinkColor(this.m_linkTextReleaseBundle, Glyssen.Utilities.GlyssenColors.DisabledLinkColor);
 			this.m_linkTextReleaseBundle.DisabledLinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(133)))), ((int)(((byte)(133)))), ((int)(((byte)(133)))));
+			this.glyssenColorPalette.SetDisabledLinkColor(this.m_linkTextReleaseBundle, Glyssen.Utilities.GlyssenColors.DisabledLinkColor);
 			this.glyssenColorPalette.SetForeColor(this.m_linkTextReleaseBundle, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.m_linkTextReleaseBundle.ForeColor = System.Drawing.SystemColors.WindowText;
-			this.m_linkTextReleaseBundle.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.glyssenColorPalette.SetLinkColor(this.m_linkTextReleaseBundle, Glyssen.Utilities.GlyssenColors.LinkColor);
+			this.m_linkTextReleaseBundle.LinkColor = System.Drawing.SystemColors.HotTrack;
 			this.m_l10NSharpExtender.SetLocalizableToolTip(this.m_linkTextReleaseBundle, null);
 			this.m_l10NSharpExtender.SetLocalizationComment(this.m_linkTextReleaseBundle, null);
 			this.m_l10NSharpExtender.SetLocalizingId(this.m_linkTextReleaseBundle, "DialogBoxes.OpenProjectDlg.CreateNewProject");
@@ -174,6 +174,9 @@
 			this.glyssenColorPalette.SetUsePaletteColors(this.m_listExistingProjects, false);
 			this.m_listExistingProjects.SelectedProjectChanged += new System.EventHandler(this.HandleSelectedProjectChanged);
 			this.m_listExistingProjects.ListLoaded += new System.EventHandler(this.HandleExistingProjectsListLoaded);
+			this.m_listExistingProjects.ColumnWidthChanged += new System.EventHandler<System.Windows.Forms.DataGridViewColumnEventArgs>(this.HandleColumnWidthChanged);
+			this.m_listExistingProjects.ColumnDisplayIndexChanged += new System.EventHandler<System.Windows.Forms.DataGridViewColumnEventArgs>(this.m_listExistingProjects_ColumnDisplayIndexChanged);
+			this.m_listExistingProjects.ProjectListSorted += new System.EventHandler(this.HandleProjectListSorted);
 			this.m_listExistingProjects.DoubleClick += new System.EventHandler(this.HandleExistingProjectsDoubleClick);
 			// 
 			// m_tableLayoutPanelMain

--- a/Glyssen/Dialogs/OpenProjectDlg.cs
+++ b/Glyssen/Dialogs/OpenProjectDlg.cs
@@ -9,6 +9,8 @@ namespace Glyssen.Dialogs
 {
 	public partial class OpenProjectDlg : FormWithPersistedSettings
 	{
+		private bool m_gridSettingsChanged;
+
 		public enum ProjectType
 		{
 			ExistingProject,
@@ -72,11 +74,14 @@ namespace Glyssen.Dialogs
 				m_listExistingProjects.ScrollToSelected();
 				m_btnOk.Enabled = true;
 			}
+
+			m_gridSettingsChanged = false;
 		}
 
 		protected override void OnClosing(CancelEventArgs e)
 		{
-			Settings.Default.OpenProjectDlgGridSettings = m_listExistingProjects.GridSettings;
+			if (m_gridSettingsChanged)
+				Settings.Default.OpenProjectDlgGridSettings = m_listExistingProjects.GridSettings;
 			base.OnClosing(e);
 		}
 
@@ -103,6 +108,24 @@ namespace Glyssen.Dialogs
 		private void HandleExistingProjectsListLoaded(object sender, EventArgs e)
 		{
 			m_chkShowInactiveProjects.Visible = m_listExistingProjects.HiddenProjectsExist;
+		}
+
+		private void HandleProjectListSorted(object sender, EventArgs e)
+		{
+			m_gridSettingsChanged = true;
+		}
+
+		private void HandleColumnWidthChanged(object sender, DataGridViewColumnEventArgs e)
+		{
+			if (e.Column.AutoSizeMode == DataGridViewAutoSizeColumnMode.Fill)
+				return;
+
+			m_gridSettingsChanged = true;
+		}
+
+		private void m_listExistingProjects_ColumnDisplayIndexChanged(object sender, DataGridViewColumnEventArgs e)
+		{
+			m_gridSettingsChanged = true;
 		}
 	}
 }


### PR DESCRIPTION
Wait until the user changes something before saving the grid settings.

Have the columns still automatically fill the width of the grid while allowing the user to change the columns widths.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/79)
<!-- Reviewable:end -->
