### PR TITLE
PG-478: Update voice actor info dropdowns when UI language changes

### DIFF
--- a/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Glyssen.Controls
+﻿using L10NSharp.UI;
+
+namespace Glyssen.Controls
 {
 	partial class VoiceActorInformationGrid
 	{
@@ -15,6 +17,7 @@
 		{
 			if (disposing && (components != null))
 			{
+				LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
 				if (ParentForm != null)
 					ParentForm.Closing -= ParentForm_Closing;
 				components.Dispose();

--- a/Glyssen/Controls/VoiceActorInformationGrid.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.cs
@@ -9,6 +9,7 @@ using Glyssen.Properties;
 using Glyssen.Utilities;
 using Glyssen.VoiceActor;
 using L10NSharp;
+using L10NSharp.UI;
 using SIL.Reporting;
 
 namespace Glyssen.Controls
@@ -62,6 +63,15 @@ namespace Glyssen.Controls
 			// We can't set this in the designer because L10NSharp is squashing it when the header is localized.
 			Cameo.ToolTipText = LocalizationManager.GetString("DialogBoxes.VoiceActorInformation.CameoTooltip",
 															"Distinguished actor to play minor character role.");
+
+			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+		}
+
+		private void HandleStringsLocalized()
+		{
+			ActorGender.DataSource = VoiceActorInformationViewModel.GetGenderDataTable();
+			ActorAge.DataSource = VoiceActorInformationViewModel.GetAgeDataTable();
+			ActorQuality.DataSource = VoiceActorInformationViewModel.GetVoiceQualityDataTable();
 		}
 
 		void m_dataGrid_DataError(object sender, DataGridViewDataErrorEventArgs e)


### PR DESCRIPTION
UI strings in Voice Actor Information drop-down combos do not update if localized strings are changed.

Resolves #PG-478

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/82)
<!-- Reviewable:end -->
