### PR TITLE
Fix two edge cases in UsxParser (PG-593 & PG-594)

### DIFF
--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -62,7 +62,7 @@
     <applicationSettings>
         <Glyssen.Properties.Settings>
             <setting name="ParserVersion" serializeAs="String">
-                <value>33</value>
+                <value>34</value>
             </setting>
             <setting name="DataFormatVersion" serializeAs="String">
                 <value>3</value>

--- a/Glyssen/Properties/Settings.Designer.cs
+++ b/Glyssen/Properties/Settings.Designer.cs
@@ -73,7 +73,7 @@ namespace Glyssen.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("33")]
+        [global::System.Configuration.DefaultSettingValueAttribute("34")]
         public int ParserVersion {
             get {
                 return ((int)(this["ParserVersion"]));

--- a/Glyssen/Properties/Settings.settings
+++ b/Glyssen/Properties/Settings.settings
@@ -15,7 +15,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ParserVersion" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">33</Value>
+      <Value Profile="(Default)">34</Value>
     </Setting>
     <Setting Name="DefaultFontSize" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">10</Value>

--- a/Glyssen/UsxParser.cs
+++ b/Glyssen/UsxParser.cs
@@ -172,6 +172,7 @@ namespace Glyssen
 										block.BlockElements.Add(new ScriptText(sb.ToString()));
 										sb.Clear();
 									}
+									RemoveLastElementIfVerse(block);
 									var verseNumStr = childNode.Attributes.GetNamedItem("number").Value;
 									m_currentStartVerse = ScrReference.VerseToIntStart(verseNumStr);
 									m_currentEndVerse = ScrReference.VerseToIntEnd(verseNumStr);
@@ -192,8 +193,8 @@ namespace Glyssen
 									sb.Append(childNode.InnerText);
 									break;
 								case "#whitespace":
-									if (sb.Length > 0)
-										sb.Append(childNode.InnerText);
+									if (sb.Length > 0 && sb[sb.Length - 1] != ' ')
+										sb.Append(" ");
 									break;
 							}
 						}
@@ -203,11 +204,23 @@ namespace Glyssen
 							block.BlockElements.Add(new ScriptText(sb.ToString()));
 							sb.Clear();
 						}
+						RemoveLastElementIfVerse(block);
 						break;
 				}
-				blocks.Add(block);
+				if (block != null && block.BlockElements.Count > 0)
+					blocks.Add(block);
 			}
 			return blocks;
+		}
+
+		private static void RemoveLastElementIfVerse(Block block)
+		{
+			if (block.BlockElements.Count > 0)
+			{
+				var lastBlockElement = block.BlockElements.Last();
+				if (lastBlockElement is Verse)
+					block.BlockElements.Remove(block.BlockElements.Last());
+			}
 		}
 
 		private void AddMainTitleIfApplicable(ICollection<Block> blocks, StringBuilder titleBuilder)


### PR DESCRIPTION
Properly handle extraneous whitespace between char and note elements (PG-593)
Ignore a verse with no text (PG-594)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/87)
<!-- Reviewable:end -->
