### PR TITLE
PG-639: Out of range exception when adding actor is canceled

### DIFF
--- a/Glyssen/Controls/VoiceActorInformationGrid.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.cs
@@ -234,6 +234,10 @@ namespace Glyssen.Controls
 
 		private void m_dataGrid_CellEndEdit(object sender, DataGridViewCellEventArgs e)
 		{
+			// PG-639: has the new row been removed by m_dataGrid.CancelEdit?
+			if (!m_dataGrid.IsDirty && (m_dataGrid.RowCountLessNewRow == e.RowIndex))
+				return;
+
 			if (m_actorInformationViewModel.ValidateActor(e.RowIndex) == VoiceActorInformationViewModel.ActorValidationState.Valid)
 				SaveVoiceActorInformation();
 		}


### PR DESCRIPTION
CellEndEdit is being called with a RowIndex that is no longer valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/109)
<!-- Reviewable:end -->
