### PR TITLE
PG-612: renaming text bundle erases character assignments

### DIFF
--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -486,6 +486,9 @@ namespace Glyssen
 
 			bundle.Metadata.CopyGlyssenModifiableSettings(m_metadata);
 
+			// PG-612: renaming bundle causes loss of assignments
+			bundle.Metadata.ControlFileVersion = m_metadata.ControlFileVersion;
+
 			CopyQuoteMarksIfAppropriate(bundle.WritingSystemDefinition, bundle.Metadata);
 
 			return new Project(bundle, m_recordingProjectName, this);


### PR DESCRIPTION
The project ControlFileVersion was being reset to 0, which triggered a re-parsing of the entire text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/112)
<!-- Reviewable:end -->
