### PR TITLE
PG-639.2: Need to ignore IsDirty

### DIFF
--- a/Glyssen/Controls/VoiceActorInformationGrid.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.cs
@@ -235,7 +235,7 @@ namespace Glyssen.Controls
 		private void m_dataGrid_CellEndEdit(object sender, DataGridViewCellEventArgs e)
 		{
 			// PG-639: has the new row been removed by m_dataGrid.CancelEdit?
-			if (!m_dataGrid.IsDirty && (m_dataGrid.RowCountLessNewRow == e.RowIndex))
+			if (e.RowIndex == m_dataGrid.RowCountLessNewRow)
 				return;
 
 			if (m_actorInformationViewModel.ValidateActor(e.RowIndex) == VoiceActorInformationViewModel.ActorValidationState.Valid)


### PR DESCRIPTION
If RowIndex >= RowCountLessNewRow, this always indicates the current row was deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/114)
<!-- Reviewable:end -->
