### PR TITLE
Update how Voice Actor List option is set

### DIFF
--- a/Glyssen/Controls/CastSizePlanningOptions.cs
+++ b/Glyssen/Controls/CastSizePlanningOptions.cs
@@ -32,7 +32,7 @@ namespace Glyssen.Controls
 		{
 			SetRowValues(e.Row, e.RowValues);
 
-			if (e.Row != CastSizeRow.MatchVoiceActorList)
+			if (e.KeepSelection || (e.Row != CastSizeRow.MatchVoiceActorList))
 				return;
 
 			// if there are too few actors, make sure "Match Voice Actor List" is not selected
@@ -205,7 +205,7 @@ namespace Glyssen.Controls
 			SetControlValue(m_tableLayout.GetControlFromPosition(5, rowIndex), male + female + child);
 
 			if (CastSizeCustomValueChanged != null)
-				CastSizeCustomValueChanged(sender, new CastSizeValueChangedEventArgs(CastSizeRow.Custom, male, female, child));
+				CastSizeCustomValueChanged(sender, new CastSizeValueChangedEventArgs(CastSizeRow.Custom, male, female, child, false));
 		}
 	}
 }

--- a/Glyssen/Dialogs/CastSizePlanningDlg.cs
+++ b/Glyssen/Dialogs/CastSizePlanningDlg.cs
@@ -105,10 +105,10 @@ namespace Glyssen.Dialogs
 
 		private void m_linkVloiceActorList_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			ShowVoiceActorList();
+			ShowVoiceActorList(true);
 		}
 
-		private void ShowVoiceActorList()
+		private void ShowVoiceActorList(bool keepSelection)
 		{
 			var actorInfoViewModel = new VoiceActorInformationViewModel(m_viewModel.Project);
 			using (var actorDlg = new VoiceActorInformationDlg(actorInfoViewModel, false, false))
@@ -119,7 +119,7 @@ namespace Glyssen.Dialogs
 				var female = actorInfoViewModel.Actors.Count(a => a.Gender == ActorGender.Female && a.Age != ActorAge.Child && !a.IsInactive);
 				var child = actorInfoViewModel.Actors.Count(a => a.Age == ActorAge.Child && !a.IsInactive);
 
-				m_viewModel.SetVoiceActorListValues(male, female, child);
+				m_viewModel.SetVoiceActorListValues(male, female, child, keepSelection);
 			}
 			m_castSizePlanningOptions.Refresh();
 			UpdateButtonState();
@@ -226,7 +226,7 @@ namespace Glyssen.Dialogs
 		private void CastSizePlanningDlg_Shown(object sender, EventArgs e)
 		{
 			if (m_viewModel.VoiceActorCount > 1)
-				ShowVoiceActorList();
+				ShowVoiceActorList(false);
 		}
 	}
 }

--- a/Glyssen/Dialogs/CastSizePlanningViewModel.cs
+++ b/Glyssen/Dialogs/CastSizePlanningViewModel.cs
@@ -162,17 +162,17 @@ namespace Glyssen.Dialogs
 			m_updatedCustomChildActors = child;
 
 			if (CastSizeRowValuesChanged != null)
-				CastSizeRowValuesChanged(this, new CastSizeValueChangedEventArgs(CastSizeRow.Custom, male, female, child));
+				CastSizeRowValuesChanged(this, new CastSizeValueChangedEventArgs(CastSizeRow.Custom, male, female, child, false));
 		}
 
-		internal void SetVoiceActorListValues(int male, int female, int child)
+		internal void SetVoiceActorListValues(int male, int female, int child, bool keepSelection)
 		{
 			m_actualMaleActorCount = male;
 			m_actualFemaleActorCount = female;
 			m_actualChildActorCount = child;
 
 			if (CastSizeRowValuesChanged != null)
-				CastSizeRowValuesChanged(this, new CastSizeValueChangedEventArgs(CastSizeRow.MatchVoiceActorList, male, female, child));
+				CastSizeRowValuesChanged(this, new CastSizeValueChangedEventArgs(CastSizeRow.MatchVoiceActorList, male, female, child, keepSelection));
 		}
 
 		private bool ValueChanged(int newValue, int oldValue)
@@ -264,6 +264,7 @@ namespace Glyssen.Dialogs
 		public int Male;
 		public int Female;
 		public int Child;
+		public bool KeepSelection;
 
 		public CastSizeRowValues RowValues
 		{
@@ -275,12 +276,13 @@ namespace Glyssen.Dialogs
 			get { return Male + Female + Child; }
 		}
 
-		public CastSizeValueChangedEventArgs(CastSizeRow row, int male, int female, int child)
+		public CastSizeValueChangedEventArgs(CastSizeRow row, int male, int female, int child, bool keepSelection)
 		{
 			Row = row;
 			Male = male;
 			Female = female;
 			Child = child;
+			KeepSelection = keepSelection;
 		}
 	}
 

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
@@ -178,6 +178,7 @@ namespace Glyssen.Dialogs
 			this.m_btnOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.m_btnOk.AutoSize = true;
 			this.glyssenColorPalette.SetBackColor(this.m_btnOk, Glyssen.Utilities.GlyssenColors.BackColor);
+			this.m_btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
 			this.m_btnOk.Enabled = false;
 			this.glyssenColorPalette.SetFlatAppearanceBorderColor(this.m_btnOk, Glyssen.Utilities.GlyssenColors.ForeColor);
 			this.glyssenColorPalette.SetForeColor(this.m_btnOk, Glyssen.Utilities.GlyssenColors.ForeColor);
@@ -192,7 +193,6 @@ namespace Glyssen.Dialogs
 			this.m_btnOk.Text = "OK";
 			this.glyssenColorPalette.SetUsePaletteColors(this.m_btnOk, false);
 			this.m_btnOk.UseVisualStyleBackColor = true;
-			this.m_btnOk.Click += new System.EventHandler(this.BtnOk_Click);
 			// 
 			// m_lblInstructions
 			// 
@@ -230,7 +230,6 @@ namespace Glyssen.Dialogs
 			this.m_btnCancelClose.Text = "Cancel";
 			this.glyssenColorPalette.SetUsePaletteColors(this.m_btnCancelClose, false);
 			this.m_btnCancelClose.UseVisualStyleBackColor = true;
-			this.m_btnCancelClose.Click += new System.EventHandler(this.HandleCancelOrCloseButtonClicked);
 			// 
 			// tableLayoutPanel1
 			// 

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.cs
@@ -81,41 +81,5 @@ namespace Glyssen.Dialogs
 
 			m_btnOk.Enabled = m_viewModel.ActiveActors.Any();
 		}
-
-		private void HandleCancelOrCloseButtonClicked(object sender, EventArgs e)
-		{
-			Close(DialogResult.Cancel);
-		}
-
-		private void BtnOk_Click(object sender, EventArgs e)
-		{
-			Close(DialogResult.OK);
-		}
-
-		private void Close(DialogResult dialogResult)
-		{
-			DialogResult = dialogResult;
-			Close();
-		}
-
-		// Don't think this is needed anymore.
-		//private void VoiceActorInformationDlg_FormClosing(object sender, FormClosingEventArgs e)
-		//{
-		//	if (!m_initialEntry && !m_viewModel.Actors.Any())
-		//	{
-		//		string msg = LocalizationManager.GetString("DialogBoxes.VoiceActorInformation.CloseWithoutActors.Message", "If this dialog is closed without actors, character groups will be removed.");
-		//		string caption = LocalizationManager.GetString("DialogBoxes.VoiceActorInformation.CloseWithoutActors.Caption", "No Actors");
-		//		if (MessageBox.Show(msg, caption, MessageBoxButtons.OKCancel) == DialogResult.OK)
-		//		{
-// This method has been moved to VoiceActorAssignmentViewModel (where it eventually might not be needed either):
-		//			m_viewModel.ResetActorAndCharacterGroupState();
-		//			CloseParent = true;
-		//		}
-		//		else
-		//		{
-		//			e.Cancel = true;
-		//		}
-		//	}
-		//}
 	}
 }


### PR DESCRIPTION
Set the "Match Voice Actor List" option automatically only when the Voice Actor List dialog was displayed automatically, not after it was displayed because the user clicked the link which has instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/116)
<!-- Reviewable:end -->
