### PR TITLE
PG-651: Changed Voice Actor List dialog to offer both OK and Cancel b…

### DIFF
--- a/Glyssen/Character/CharacterGroupList.cs
+++ b/Glyssen/Character/CharacterGroupList.cs
@@ -27,7 +27,7 @@ namespace Glyssen.Character
 		public ObservableList<CharacterGroup> CharacterGroups
 		{
 			get { return m_characterGroups; }
-			set 
+			private set 
 			{
 				m_characterGroups = value;
 				m_characterGroups.CollectionChanged += CharacterGroups_CollectionChanged;

--- a/Glyssen/Controls/CastSizePlanningOptions.cs
+++ b/Glyssen/Controls/CastSizePlanningOptions.cs
@@ -40,9 +40,10 @@ namespace Glyssen.Controls
 
 			if ((e.Male < small.Male) ||
 			    (e.Female < small.Female) ||
-			    (e.Child < small.Child))
+				(e.Child < small.Child))
 			{
-				SelectedCastSizeRow = CastSizeRow.Recommended;
+				if (SelectedCastSizeRow == CastSizeRow.MatchVoiceActorList)
+					SelectedCastSizeRow = CastSizeRow.Recommended;
 			}
 			else
 			{

--- a/Glyssen/Dialogs/CastSizePlanningDlg.cs
+++ b/Glyssen/Dialogs/CastSizePlanningDlg.cs
@@ -111,9 +111,10 @@ namespace Glyssen.Dialogs
 		private void ShowVoiceActorList(bool keepSelection)
 		{
 			var actorInfoViewModel = new VoiceActorInformationViewModel(m_viewModel.Project);
-			using (var actorDlg = new VoiceActorInformationDlg(actorInfoViewModel, false, false))
+			using (var actorDlg = new VoiceActorInformationDlg(actorInfoViewModel, false, false, !keepSelection))
 			{
-				actorDlg.ShowDialog(this);
+				if (actorDlg.ShowDialog(this) == DialogResult.Cancel)
+					keepSelection = true; // Even though Cancel doesn't actually discard changes, it should at least reflect the user's desire not to have any changes result in a change to the c
 
 				var male = actorInfoViewModel.Actors.Count(a => a.Gender == ActorGender.Male && a.Age != ActorAge.Child && !a.IsInactive);
 				var female = actorInfoViewModel.Actors.Count(a => a.Gender == ActorGender.Female && a.Age != ActorAge.Child && !a.IsInactive);
@@ -188,9 +189,9 @@ namespace Glyssen.Dialogs
 			if (actorCount < m_viewModel.MinimumActorCount)
 			{
 				var msg = LocalizationManager.GetString("DialogBoxes.CastSizePlanning.CastTooSmallWarning",
-					"The recommended minimum cast size is {0}. Below this there could be proximity issues. Do you want to continue and generate groups using just {1} voice actors?");
+					"Using a cast size smaller than {0} will probably introduce proximity issues. Do you want to continue and generate groups using just {1} voice actors?");
 
-				if (MessageBox.Show(this, string.Format(msg, m_viewModel.RecommendedActorCount, actorCount), ProductName, MessageBoxButtons.YesNo) == DialogResult.No)
+				if (MessageBox.Show(this, string.Format(msg, m_viewModel.MinimumActorCount, actorCount), ProductName, MessageBoxButtons.YesNo) == DialogResult.No)
 					return;
 			}
 
@@ -226,7 +227,7 @@ namespace Glyssen.Dialogs
 		private void CastSizePlanningDlg_Shown(object sender, EventArgs e)
 		{
 			if (m_viewModel.VoiceActorCount > 1)
-				ShowVoiceActorList(false);
+				ShowVoiceActorList(m_viewModel.CastSizeOption == CastSizeRow.MatchVoiceActorList);
 		}
 	}
 }

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.cs
@@ -16,7 +16,7 @@ namespace Glyssen.Dialogs
 
 		private string m_tallyFmt;
 
-		public VoiceActorInformationDlg(VoiceActorInformationViewModel viewModel, bool initialEntry, bool changeOkToGenerateGroups)
+		public VoiceActorInformationDlg(VoiceActorInformationViewModel viewModel, bool initialEntry, bool changeOkToGenerateGroups, bool enableOkButtonEvenIfNoChanges = false)
 		{
 			InitializeComponent();
 
@@ -25,6 +25,8 @@ namespace Glyssen.Dialogs
 			m_viewModel = viewModel;
 			m_changeOkToGenerateGroups = changeOkToGenerateGroups;
 			m_dataGrid.Initialize(m_viewModel, !initialEntry);
+			if (enableOkButtonEvenIfNoChanges)
+				m_btnOk.Enabled = m_viewModel.ActiveActors.Any();
 
 			HandleStringsLocalized();
 			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -68,6 +68,7 @@ namespace Glyssen
 		public event EventHandler<ProjectStateChangedEventArgs> ProjectStateChanged;
 		public event EventHandler QuoteParseCompleted;
 		public event EventHandler AnalysisCompleted;
+		public event EventHandler CharacterGroupCollectionChanged;
 
 		private Func<string, string> GetBookName { get; set; }
 
@@ -1075,7 +1076,7 @@ namespace Glyssen
 				AnalysisCompleted(this, new EventArgs());
 		}
 
-		public void Save()
+		public void Save(bool saveCharacterGroups = false)
 		{
 			if (!m_projectFileIsWritable) return;
 
@@ -1096,6 +1097,8 @@ namespace Glyssen
 			SaveProjectCharacterVerseData();
 			SaveProjectCharacterDetailData();
 			SaveWritingSystem();
+			if (saveCharacterGroups)
+				SaveCharacterGroupData();
 			ProjectState = !IsQuoteSystemReadyForParse ? ProjectState.NeedsQuoteSystemConfirmation : ProjectState.FullyInitialized;
 		}
 
@@ -1127,12 +1130,19 @@ namespace Glyssen
 			m_voiceActorList.SaveToFile(Path.Combine(ProjectFolder, kVoiceActorInformationFileName));
 		}
 
-		public CharacterGroupList LoadCharacterGroupData()
+		private CharacterGroupList LoadCharacterGroupData()
 		{
 			string path = Path.Combine(ProjectFolder, kCharacterGroupFileName);
-			if (File.Exists(path))
-				return CharacterGroupList.LoadCharacterGroupListFromFile(path, this);
-			return new CharacterGroupList();
+			CharacterGroupList list;
+			list = File.Exists(path) ? CharacterGroupList.LoadCharacterGroupListFromFile(path, this) : new CharacterGroupList();
+			list.CharacterGroups.CollectionChanged += CharacterGroups_CollectionChanged;
+			return list;
+		}
+
+		void CharacterGroups_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			if (CharacterGroupCollectionChanged != null)
+				CharacterGroupCollectionChanged(this, new EventArgs());
 		}
 
 		private VoiceActorList LoadVoiceActorInformationData()

--- a/Glyssen/Rules/CharacterGroupGenerator.cs
+++ b/Glyssen/Rules/CharacterGroupGenerator.cs
@@ -50,6 +50,8 @@ namespace Glyssen.Rules
 		public void ApplyGeneratedGroupsToProject(bool attemptToPreserveActorAssignments = true)
 		{
 			// Create a copy. Cameos are handled in the generation code (because we always maintain those assignments).
+			// REVIEW: Would it still work (and potentially be more efficient) if we only included groups with a voice
+ 			// actor assigned, or would there be some weird edge cases where this might result in the wrong assignment?
 			List<CharacterGroup> previousGroups = attemptToPreserveActorAssignments ?
 				ProjectCharacterGroups.Where(g => !g.AssignedToCameoActor).ToList() : new List<CharacterGroup>();
 

--- a/GlyssenTests/ProjectExportTests.cs
+++ b/GlyssenTests/ProjectExportTests.cs
@@ -4,6 +4,7 @@ using Glyssen;
 using Glyssen.Bundle;
 using Glyssen.Character;
 using NUnit.Framework;
+using SIL.Extensions;
 using SIL.ObjectModel;
 using SIL.Windows.Forms;
 
@@ -43,11 +44,11 @@ namespace GlyssenTests
 			{
 				new Glyssen.VoiceActor.VoiceActor { Id = 1 }
 			};
-			project.CharacterGroupList.CharacterGroups = new BulkObservableList<CharacterGroup>
+			project.CharacterGroupList.CharacterGroups.AddRange(new []
 			{
 				new CharacterGroup(project),
 				new CharacterGroup(project)
-			};
+			});
 			project.CharacterGroupList.CharacterGroups[0].AssignVoiceActor(1);
 
 			var exporter = new ProjectExporter(project);
@@ -133,11 +134,11 @@ namespace GlyssenTests
 			{
 				new Glyssen.VoiceActor.VoiceActor { Id = 1, Name = "Marlon" }
 			};
-			project.CharacterGroupList.CharacterGroups = new BulkObservableList<CharacterGroup>
+			project.CharacterGroupList.CharacterGroups.AddRange(new[]
 			{
 				new CharacterGroup(project),
 				new CharacterGroup(project)
-			};
+			});
 			project.CharacterGroupList.CharacterGroups[0].CharacterIds.Add("Michael, archangel");
 			project.CharacterGroupList.CharacterGroups[0].AssignVoiceActor(1);
 


### PR DESCRIPTION
…uttons when initially displayed via Cast Size Planning dialog. Clicking OK attempts to select Actual Cast Size option (if there are enough actors). Clicking Cancel leaves the pre-existing cast size option selected.

PG-653: Cast size on main form reflects actual number of groups in Project
PG-654: When user generates groups, the new groups are saved (replacing previously generated groups).
Also fixed wording (and the minimum cast size number shown) in the warning message when the number of actors is below the minimum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/120)
<!-- Reviewable:end -->
