### PR TITLE
PG-671: crash when multi-splitting

### DIFF
--- a/Glyssen/BlockSplitData.cs
+++ b/Glyssen/BlockSplitData.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Glyssen
 {
@@ -40,7 +39,14 @@ namespace Glyssen
 					return -1;
 				return x.CharacterOffsetToSplit < y.CharacterOffsetToSplit ? -1 : 1;
 			}
-			return Int32.Parse(x.VerseToSplit) < Int32.Parse(y.VerseToSplit) ? -1 : 1;
+
+			// PG-671: VerseToSplit can be null
+			if (x.VerseToSplit == null)
+				return -1;
+			if (y.VerseToSplit == null)
+				return 1;
+
+			return int.Parse(x.VerseToSplit) < int.Parse(y.VerseToSplit) ? -1 : 1;
 		}
 	}
 


### PR DESCRIPTION
If a split is placed between blocks of a multi-block quote, VerseToSplit will be null. The comparer was trying to convert this to an int which was the cause of the crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/134)
<!-- Reviewable:end -->
