### PR TITLE
Fix false invalid value error message

### DIFF
--- a/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
@@ -799,6 +799,23 @@ namespace Glyssen.Dialogs
 
 		private void m_characterGroupGrid_DataError(object sender, DataGridViewDataErrorEventArgs e)
 		{
+			// ignore most ArgumentExceptions in the VoiceActorCol
+			// this can happen if you type in the name of an existing cameo actor
+			if (e.Exception.GetType().Name == "ArgumentException")
+			{
+				var src = (DataGridView)sender;
+				if (src.CurrentCell.OwningColumn == VoiceActorCol)
+				{
+					int currentVal;
+					var success = int.TryParse(src.CurrentCell.Value.ToString(), out currentVal);
+					if (success && (currentVal > -1))
+					{
+						e.Cancel = true;
+						return;
+					}
+				}
+			}
+
 			Analytics.ReportException(e.Exception);
 			ErrorReport.ReportFatalException(e.Exception);
 			throw e.Exception;


### PR DESCRIPTION
Prevent "DataGridViewComboBoxCell value is not valid" message when user types the name of a cameo actor into the voice actor assignment grid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/146)
<!-- Reviewable:end -->
