### PR TITLE
PG-528: Fixed Keyboard Shortcut for Jesus and Narrator

### DIFF
--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -116,11 +116,11 @@ namespace GlyssenTests.Dialogs
 			FindRefInMark(5, 9);
 			var characters = m_model.GetCharactersForCurrentReference().ToList();
 			Assert.AreEqual(3, characters.Count);
-			Assert.AreEqual("demons (Legion)/man delivered from Legion of demons", characters[0].CharacterId);
+			Assert.IsTrue(characters[0].IsNarrator);
 			Assert.IsFalse(characters[0].ProjectSpecific);
 			Assert.AreEqual("Jesus", characters[1].CharacterId);
 			Assert.IsFalse(characters[1].ProjectSpecific);
-			Assert.IsTrue(characters[2].IsNarrator);
+			Assert.AreEqual("demons (Legion)/man delivered from Legion of demons", characters[2].CharacterId);
 			Assert.IsFalse(characters[2].ProjectSpecific);
 		}
 
@@ -153,11 +153,11 @@ namespace GlyssenTests.Dialogs
 			FindRefInMark(6, 24);
 			var characters = m_model.GetCharactersForCurrentReference().ToList();
 			Assert.AreEqual(3, characters.Count);
-			Assert.AreEqual("Herodias' daughter", characters[0].CharacterId);
-			Assert.AreEqual("alias", characters[0].Alias);
-			Assert.AreEqual("Herodias", characters[1].CharacterId);
-			Assert.IsNull(characters[1].Alias);
-			Assert.IsTrue(characters[2].IsNarrator);
+			Assert.IsTrue(characters[0].IsNarrator);
+			Assert.AreEqual("Herodias' daughter", characters[1].CharacterId);
+			Assert.AreEqual("alias", characters[1].Alias);
+			Assert.AreEqual("Herodias", characters[2].CharacterId);
+			Assert.IsNull(characters[2].Alias);
 		}
 
 		[Test]

--- a/GlyssenTests/Rules/CharacterGroupGeneratorTests.cs
+++ b/GlyssenTests/Rules/CharacterGroupGeneratorTests.cs
@@ -1132,8 +1132,8 @@ namespace GlyssenTests.Rules
 			m_testProject.CharacterGroupGenerationPreferences.IsSetByUser = false;
 		}
 
-		[TestCase(2, 0, true)]
-		[TestCase(1, 1, true)]
+		[TestCase(2, 0)]
+		[TestCase(1, 1)]
 		public void GenerateCharacterGroups_ExplicitlyRequestTwoNarrators_AllLinesForLukeAreNarratorAndLukeNarratorHandlesSomeMaleRolesInActs(int numMale, int numFemale)
 		{
 			m_testProject.CharacterGroupGenerationPreferences.NumberOfMaleNarrators = numMale;


### PR DESCRIPTION
Narrator will always be at the top of the list (key 1) and Jesus, if he speaks, will be second (key 2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/153)
<!-- Reviewable:end -->
