### PR TITLE
PG-734: Fixed logic for splitting vernacular to match the reference text breaks

### DIFF
--- a/Glyssen/BookScript.cs
+++ b/Glyssen/BookScript.cs
@@ -581,6 +581,30 @@ namespace Glyssen
 			return newBlock;
 		}
 
+		public bool TrySplitBlockAtEndOfVerse(Block vernBlock, int verseNum)
+		{
+			var verseString = verseNum.ToString();
+
+			if (vernBlock.BlockElements.First() is Verse ||
+				!(vernBlock.InitialEndVerseNumber == verseNum || (vernBlock.InitialEndVerseNumber == 0 && vernBlock.InitialStartVerseNumber == verseNum)))
+			{
+				foreach (var verse in vernBlock.BlockElements.OfType<Verse>())
+				{
+					if (verse.Number == verseString)
+						break;
+					if (verse.EndVerse == verseNum)
+					{
+						verseString = verse.Number;
+						break;
+					}
+					if (verse.StartVerse >= verseNum)
+						return false;
+				}
+			}
+			SplitBlock(vernBlock, verseString, kSplitAtEndOfVerse, false);
+			return true;
+		}
+
 		private void SplitBeforeBlock(int indexOfBlockToSplit, int splitId)
 		{
 			if (indexOfBlockToSplit == 0 || m_blocks[indexOfBlockToSplit].MultiBlockQuote == MultiBlockQuote.None || m_blocks[indexOfBlockToSplit - 1].MultiBlockQuote == MultiBlockQuote.None)

--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -400,7 +400,13 @@ namespace Glyssen
 				if (vernInitEndVerse.CompareTo(vernLastVerse) != 0 && vernLastVerse >= versesToSplitBefore[iSplit])
 				{
 					vernacularVersification.ChangeVersification(verseToSplitAfter);
-					vernacularBook.SplitBlock(vernBlock, verseToSplitAfter.VerseNum.ToString(), BookScript.kSplitAtEndOfVerse, false);
+					if (!vernacularBook.TrySplitBlockAtEndOfVerse(vernBlock, verseToSplitAfter.VerseNum))
+					{
+						if (iSplit == versesToSplitAfter.Count - 1)
+							return;
+						verseToSplitAfter = versesToSplitAfter[++iSplit];
+						index--;
+					}
 				}
 			}
 		}

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -546,6 +546,45 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void ApplyTo_VernacularHasVerseBridgeNotAtStartOfBlock_ReferenceBrokenAtVerses_VernacularSplitForNonBridgedVerses()
+		{
+			var vernacularBlocks = new List<Block>();
+			var block = new Block("p", 1, 1, 1)
+			{
+				IsParagraphStart = true,
+				CharacterId = CharacterVerseData.GetStandardCharacterId("MAT", CharacterVerseData.StandardCharacter.Narrator)
+			};
+			block.BlockElements.Add(new Verse("1"));
+			block.BlockElements.Add(new ScriptText("Entonces Jesús dijo que los reducirían un burro. "));
+			block.BlockElements.Add(new Verse("2-3"));
+			block.BlockElements.Add(new ScriptText("El número de ellos dónde encontrarlo. Y todo salió bien. "));
+			block.BlockElements.Add(new Verse("4"));
+			block.BlockElements.Add(new ScriptText("El cuarto versiculo."));
+			vernacularBlocks.Add(block);
+			var vernBook = new BookScript("MAT", vernacularBlocks);
+
+			var referenceBlocks = new List<Block>();
+			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Jesus told them where to find a donkey. ", true));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(2, "He said that they should bring it, and it would all work out. "));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "It did. "));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Fourth verse."));
+
+			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+
+			var result = vernBook.GetScriptBlocks();
+			Assert.AreEqual(3, result.Count);
+			Assert.AreEqual(1, result[0].ReferenceBlocks.Count);
+			Assert.IsTrue(result[0].MatchesReferenceText);
+			Assert.AreEqual("[1]\u00A0Jesus told them where to find a donkey. ", result[0].PrimaryReferenceText);
+			Assert.AreEqual(2, result[1].ReferenceBlocks.Count);
+			Assert.IsTrue(result[1].ReferenceBlocks.Select(r => r.GetText(true)).SequenceEqual(referenceBlocks.Skip(1).Take(2).Select(r => r.GetText(true))));
+			Assert.IsNull(result[1].PrimaryReferenceText);
+			Assert.AreEqual(1, result[2].ReferenceBlocks.Count);
+			Assert.IsTrue(result[2].MatchesReferenceText);
+			Assert.AreEqual("[4]\u00A0Fourth verse.", result[2].PrimaryReferenceText);
+		}
+
+		[Test]
 		public void ApplyTo_ReferenceHasVerseBridge_VernacularBrokenAtEndOfBridge()
 		{
 			var vernacularBlocks = new List<Block>();


### PR DESCRIPTION
Bug caused it to crash because of failure to split verse bridges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/183)
<!-- Reviewable:end -->
