### PR TITLE
PG-736: Completed work to handle splitting around verse bridges and sub-verse letters.

### DIFF
--- a/DevTools/ReferenceTextUtility.cs
+++ b/DevTools/ReferenceTextUtility.cs
@@ -556,7 +556,7 @@ namespace DevTools
 
 						try
 						{
-							ReferenceText.ApplyTo(book, referenceBook.GetScriptBlocks(), s_existingEnglish.GetFormattedChapterAnnouncement, refText.Versification, s_existingEnglish.Versification, true);
+							s_existingEnglish.ApplyTo(book, s_existingEnglish.Versification, true);
 							var bookXmlFile = FileLocator.GetFileDistributedWithApplication(ReferenceText.kDistFilesReferenceTextDirectoryName, language.ToString(), Path.ChangeExtension(book.BookId, "xml"));
 							XmlSerializationHelper.SerializeToFile(bookXmlFile, book, out error);
 						}

--- a/Glyssen/Bundle/GlyssenDblTextMetadata.cs
+++ b/Glyssen/Bundle/GlyssenDblTextMetadata.cs
@@ -144,9 +144,6 @@ namespace Glyssen.Bundle
 		[DefaultValue("English")]
 		public string Versification;
 
-		/// <summary>
-		/// If a project does not come with a versification file, this is the name of the standard versification to be used.
-		/// </summary>
 		[XmlAttribute("chapterannouncement")]
 		[DefaultValue(ChapterAnnouncement.PageHeader)]
 		public ChapterAnnouncement ChapterAnnouncementStyle;

--- a/GlyssenTests/BookScriptTests.cs
+++ b/GlyssenTests/BookScriptTests.cs
@@ -1640,6 +1640,29 @@ namespace GlyssenTests
 			Assert.AreEqual(3, blocks[3].InitialStartVerseNumber);
 			Assert.AreEqual(0, blocks[3].InitialEndVerseNumber);
 		}
+
+		[Test]
+		public void TrySplitBlockAtEndOfVerse_VerseToSplitAfterHasABridgeAndASubVerseLetter_SplitsAtEndOfLastPartOfVerse()
+		{
+			var mrkBlocks = new List<Block>();
+			mrkBlocks.Add(NewChapterBlock(1));
+			var blockToSplit = new Block("p", m_curSetupChapter, 1, 2) { IsParagraphStart = true }.AddVerse(
+				"1-2a", "This is the bridge that has the first part of verse 2. ")
+				.AddVerse("2b", "This is the rest of verse two. ")
+				.AddVerse("3", "This is the text of the following verse.");
+			mrkBlocks.Add(blockToSplit);
+			var bookScript = new BookScript("MRK", mrkBlocks);
+			Assert.IsTrue(bookScript.TrySplitBlockAtEndOfVerse(blockToSplit, 2));
+			var blocks = bookScript.GetScriptBlocks();
+			Assert.AreEqual(3, blocks.Count);
+			Assert.AreEqual("[1-2a]\u00A0This is the bridge that has the first part of verse 2. [2b]\u00A0This is the rest of verse two. ",
+				blocks[1].GetText(true));
+			Assert.AreEqual(1, blocks[1].InitialStartVerseNumber);
+			Assert.AreEqual(2, blocks[1].InitialEndVerseNumber);
+			Assert.AreEqual("[3]\u00A0This is the text of the following verse.", blocks[2].GetText(true));
+			Assert.AreEqual(3, blocks[2].InitialStartVerseNumber);
+			Assert.AreEqual(0, blocks[2].InitialEndVerseNumber);
+		}
 		#endregion
 
 		#region CleanUpMultiBlockQuotes Tests

--- a/GlyssenTests/BookScriptTests.cs
+++ b/GlyssenTests/BookScriptTests.cs
@@ -1619,6 +1619,19 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void TrySplitBlockAtEndOfVerse_NoVerseElementsInBlock_ReturnsFalse()
+		{
+			var mrkBlocks = new List<Block>();
+			mrkBlocks.Add(NewChapterBlock(1));
+			var blockToSplit = new Block("p", m_curSetupChapter, 1) { IsParagraphStart = true };
+			blockToSplit.BlockElements.Add(new ScriptText("Blah."));
+			mrkBlocks.Add(blockToSplit);
+			var bookScript = new BookScript("MRK", mrkBlocks);
+			Assert.IsFalse(bookScript.TrySplitBlockAtEndOfVerse(blockToSplit, 1));
+			Assert.AreEqual(2, bookScript.GetScriptBlocks().Count);
+		}
+
+		[Test]
 		public void TrySplitBlockAtEndOfVerse_BlockStartsInTheMiddleOfAVerseBridgeThatEndsWithTheVerseNumberToSplitAfter_SplitsAtEndOfVerseBridge()
 		{
 			var mrkBlocks = new List<Block>();
@@ -1662,6 +1675,51 @@ namespace GlyssenTests
 			Assert.AreEqual("[3]\u00A0This is the text of the following verse.", blocks[2].GetText(true));
 			Assert.AreEqual(3, blocks[2].InitialStartVerseNumber);
 			Assert.AreEqual(0, blocks[2].InitialEndVerseNumber);
+		}
+
+		[Test]
+		public void TrySplitBlockAtEndOfVerse_VerseToSplitAfterHasABridgeAndASubVerseLetterButSecondOPartOfVerseIsInFollowingBlock_ReturnsFalse()
+		{
+			var mrkBlocks = new List<Block>();
+			mrkBlocks.Add(NewChapterBlock(1));
+			var blockToSplit = new Block("p", m_curSetupChapter, 1, 2) { IsParagraphStart = true }
+				.AddVerse("1-2a", "This is the bridge that has the first part of verse 2. ");
+			mrkBlocks.Add(blockToSplit);
+			var followingBlock = new Block("p", m_curSetupChapter, 2) { CharacterId = "Jesus" }
+				.AddVerse("2b", "This is the rest of verse two. ")
+				.AddVerse("3", "This is the text of the following verse.");
+			mrkBlocks.Add(followingBlock);
+			var bookScript = new BookScript("MRK", mrkBlocks);
+			Assert.IsFalse(bookScript.TrySplitBlockAtEndOfVerse(blockToSplit, 2));
+			Assert.AreEqual(3, bookScript.GetScriptBlocks().Count);
+		}
+
+		[Test]
+		public void TrySplitBlockAtEndOfVerse_VerseToSplitBeginsWithSecondOPartOfVerseToSplit_SplitsAtEndOfLastPartOfVerse()
+		{
+			var mrkBlocks = new List<Block>();
+			mrkBlocks.Add(NewChapterBlock(1));
+			var precedingBlock = new Block("p", m_curSetupChapter, 1, 2) { IsParagraphStart = true }
+				.AddVerse("1-2a", "This is the bridge that has the first part of verse 2. ");
+			mrkBlocks.Add(precedingBlock);
+			var blockToSplit = new Block("p", m_curSetupChapter, 2) { CharacterId = "Jesus" }
+				.AddVerse("2b", "This is the rest of verse two. ")
+				.AddVerse("3", "This is the text of the following verse.");
+			mrkBlocks.Add(blockToSplit);
+			var bookScript = new BookScript("MRK", mrkBlocks);
+			Assert.IsTrue(bookScript.TrySplitBlockAtEndOfVerse(blockToSplit, 2));
+			var blocks = bookScript.GetScriptBlocks();
+			Assert.AreEqual(4, blocks.Count);
+			Assert.AreEqual("[1-2a]\u00A0This is the bridge that has the first part of verse 2. ",
+				blocks[1].GetText(true));
+			Assert.AreEqual(1, blocks[1].InitialStartVerseNumber);
+			Assert.AreEqual(2, blocks[1].InitialEndVerseNumber);
+			Assert.AreEqual("[2b]\u00A0This is the rest of verse two. ", blocks[2].GetText(true));
+			Assert.AreEqual(2, blocks[2].InitialStartVerseNumber);
+			Assert.AreEqual(0, blocks[2].InitialEndVerseNumber);
+			Assert.AreEqual("[3]\u00A0This is the text of the following verse.", blocks[3].GetText(true));
+			Assert.AreEqual(3, blocks[3].InitialStartVerseNumber);
+			Assert.AreEqual(0, blocks[3].InitialEndVerseNumber);
 		}
 		#endregion
 

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -585,6 +585,47 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void ApplyTo_VernacularHasVerseBridgeWithSubVerseLetter_ReferenceBrokenAtVerses_VernacularSplitAtEndOfLastSubVerseChunk()
+		{
+			var vernacularBlocks = new List<Block>();
+			var block = new Block("p", 1, 1, 1)
+			{
+				IsParagraphStart = true,
+				CharacterId = CharacterVerseData.GetStandardCharacterId("MAT", CharacterVerseData.StandardCharacter.Narrator)
+			};
+			block.BlockElements.Add(new Verse("1"));
+			block.BlockElements.Add(new ScriptText("Entonces Jesús dijo que los reducirían un burro. "));
+			block.BlockElements.Add(new Verse("2-3a"));
+			block.BlockElements.Add(new ScriptText("El número de ellos dónde encontrarlo. Y todo salió bien. "));
+			block.BlockElements.Add(new Verse("3f")); // Using "f" instead of "b" just to demonstrate that we aren't hardcoding "b"
+			block.BlockElements.Add(new ScriptText("La segunda parte del versiculo."));
+			block.BlockElements.Add(new Verse("4"));
+			block.BlockElements.Add(new ScriptText("El cuarto versiculo."));
+			vernacularBlocks.Add(block);
+			var vernBook = new BookScript("MAT", vernacularBlocks);
+
+			var referenceBlocks = new List<Block>();
+			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Jesus told them where to find a donkey. ", true));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(2, "He said that they should bring it, and it would all work out. "));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "It did. "));
+			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Fourth verse."));
+
+			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+
+			var result = vernBook.GetScriptBlocks();
+			Assert.AreEqual(3, result.Count);
+			Assert.AreEqual(1, result[0].ReferenceBlocks.Count);
+			Assert.IsTrue(result[0].MatchesReferenceText);
+			Assert.AreEqual("[1]\u00A0Jesus told them where to find a donkey. ", result[0].PrimaryReferenceText);
+			Assert.AreEqual(2, result[1].ReferenceBlocks.Count);
+			Assert.IsTrue(result[1].ReferenceBlocks.Select(r => r.GetText(true)).SequenceEqual(referenceBlocks.Skip(1).Take(2).Select(r => r.GetText(true))));
+			Assert.IsNull(result[1].PrimaryReferenceText);
+			Assert.AreEqual(1, result[2].ReferenceBlocks.Count);
+			Assert.IsTrue(result[2].MatchesReferenceText);
+			Assert.AreEqual("[4]\u00A0Fourth verse.", result[2].PrimaryReferenceText);
+		}
+
+		[Test]
 		public void ApplyTo_ReferenceHasVerseBridge_VernacularBrokenAtEndOfBridge()
 		{
 			var vernacularBlocks = new List<Block>();

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -96,8 +96,9 @@ namespace GlyssenTests
 			};
 			block.AddVerse(3, "This is verse three.");
 			referenceBlocks.Add(block);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(3, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -129,7 +130,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "I hope you enjoy your flight. "));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "The end. "));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(4, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -175,8 +178,9 @@ namespace GlyssenTests
 			block.BlockElements.Add(new ScriptText("Section head text (the English version)"));
 			referenceBlocks.Add(block);
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "The end."));
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(5, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -200,7 +204,7 @@ namespace GlyssenTests
 			vernacularBlocks.Add(CreateNarratorBlockForVerse(31, "But eagerly desire the greater gifts.", false, 12, "1CO"));
 			var block = new Block("s", 12, 31)
 			{
-				CharacterId = CharacterVerseData.GetStandardCharacterId("MAT", CharacterVerseData.StandardCharacter.ExtraBiblical),
+				CharacterId = CharacterVerseData.GetStandardCharacterId("1CO", CharacterVerseData.StandardCharacter.ExtraBiblical),
 			};
 			block.BlockElements.Add(new ScriptText("Love"));
 			vernacularBlocks.Add(block);
@@ -211,7 +215,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(31, "In this version, there is no section head.", false, 12, "1CO"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(32, "The verse that was never supposed to exist.", false, 12, "1CO"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(2, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -243,7 +249,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(31, "In this version, there is no paragraph break.", false, 12, "1CO"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(32, "The verse that was never supposed to exist.", false, 12, "1CO"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(2, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -301,7 +309,9 @@ namespace GlyssenTests
 			block.AddVerse(3, "Got it?”");
 			referenceBlocks.Add(block);
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(2, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -427,7 +437,9 @@ namespace GlyssenTests
 			block.AddVerse(1, "The robot grabbed the ball.");
 			referenceBlocks.Add(block);
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(referenceBlocks.Count, result.Count);
@@ -510,7 +522,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(block);
 			Assert.AreEqual(referenceBlocks.Count, vernacularBlocks.Count); // Sanity check
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(referenceBlocks.Count, result.Count);
@@ -536,7 +550,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(2, "He said that they should bring it, and it would all work out. "));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "It did."));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -569,7 +585,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "It did. "));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Fourth verse."));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(3, result.Count);
@@ -610,7 +628,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(3, "It did. "));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Fourth verse."));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(3, result.Count);
@@ -645,7 +665,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(block);
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Jesus told them where to find a donkey.", true));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(2, result.Count);
@@ -681,7 +703,9 @@ namespace GlyssenTests
 
 			Assert.AreEqual(referenceBlocks.Count, vernacularBlocks.Count); // Sanity check
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -713,7 +737,9 @@ namespace GlyssenTests
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 			AddNarratorBlockForVerseInProgress(referenceBlocks, "thus he spake. ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -738,7 +764,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(2, "Then Jesus said, ", true));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -766,7 +794,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(2, "Then Jesus said, ", true));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -793,7 +823,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Then Jesus said, ", true, 1, "PSA", "q"));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -821,7 +853,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Then Jesus said, ", true, 1, "PSA", "q"));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -848,7 +882,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Then Jesus said, ", true, 1, "PSA", "q"));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -884,7 +920,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Then Jesus said, ", true, 1, "PSA", "q"));
 			AddBlockForVerseInProgress(referenceBlocks, "Jesus", "Why do you kick the cat? ");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -911,7 +949,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(9, "Hey, who added these verse to the Bible? ", true, 16, "MRK"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(10, "remember what God said about that!", false, 16, "MRK"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -931,7 +971,9 @@ namespace GlyssenTests
 			var referenceBlocks = new List<Block>();
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Trembling and bewildered...", true));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -953,7 +995,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateBlockForVerse(CharacterVerseData.GetStandardCharacterId("MAT", CharacterVerseData.StandardCharacter.Intro), 0, "Introduction", true));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Trembling and bewildered...", true));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -973,7 +1017,9 @@ namespace GlyssenTests
 			var referenceBlocks = new List<Block>();
 			referenceBlocks.Add(CreateNarratorBlockForVerse(1, "Verse 1.", true).AddVerse(2, "Verse 2."));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -996,7 +1042,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(8, "Verse 8. ", true));
 			AddBlockForVerseInProgress(referenceBlocks, "Herod", "What Herod says in verse 8.");
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(3, result.Count);
@@ -1037,7 +1085,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(25, "But when the crowd was put out, he entered in, took her by the hand, and the girl arose.", false, 9));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(26, "The report of this went out into all that land.", false, 9));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(5, result.Count);
@@ -1067,7 +1117,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(6, "Verse 6. ", true, 32, "GEN"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(7, "Verse 7.", false, 32, "GEN"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -1094,7 +1146,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(4, "Verse 4. ", true, 8, "EXO"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(5, "Verse 5.", false, 8, "EXO"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			var result = vernBook.GetScriptBlocks();
 			Assert.AreEqual(vernacularBlocks.Count, result.Count);
@@ -1126,7 +1180,9 @@ namespace GlyssenTests
 			referenceBlocks.Add(CreateNarratorBlockForVerse(7, "I hope you enjoy your flight. ", false, 8, "EXO"));
 			referenceBlocks.Add(CreateNarratorBlockForVerse(8, "The end. ", false, 8, "EXO"));
 
-			ReferenceText.ApplyTo(vernBook, referenceBlocks, GetFormattedChapterAnnouncement, m_vernVersification, ScrVers.English);
+			var refText = TestReferenceText.CreateTestReferenceText(vernBook.BookId, referenceBlocks);
+
+			refText.ApplyTo(vernBook, m_vernVersification);
 
 			Assert.AreEqual(4, referenceBlocks.Count);
 			var result = vernBook.GetScriptBlocks();
@@ -1323,13 +1379,6 @@ namespace GlyssenTests
 			return referenceText;
 		}
 
-		private string GetFormattedChapterAnnouncement(string bookCode, int chapterNumber)
-		{
-			StringBuilder bldr = new StringBuilder("The Gospel According to Thomas ");
-			bldr.Append(chapterNumber);
-			return bldr.ToString();
-		}
-
 		private Block CreateBlockForVerse(string characterId, int verseNumber, string text, bool paraStart = false, int chapter = 1, string styleTag = "p")
 		{
 			var block = new Block(styleTag, chapter, verseNumber)
@@ -1373,5 +1422,23 @@ namespace GlyssenTests
 				verseNumber, text, paraStart, chapter, styleTag);
 		}
 		#endregion
+	}
+
+	public class TestReferenceText : ReferenceText
+	{
+		private TestReferenceText(GlyssenDblTextMetadata metadata, string bookId, IList<Block> blocks)
+			: base(metadata, ReferenceTextType.Custom)
+		{
+			m_books.Add(new BookScript(bookId, blocks));
+			m_vers = ScrVers.English;
+			GetBookName = b => "The Gospel According to Thomas";
+		}
+
+		public static TestReferenceText CreateTestReferenceText(string bookId, IList<Block> blocks)
+		{
+			var metadata = new GlyssenDblTextMetadata();
+			metadata.Language = new GlyssenDblMetadataLanguage { Iso = "~tst~", Name = "Test Language" };
+			return new TestReferenceText(metadata, bookId, blocks);
+		}
 	}
 }


### PR DESCRIPTION
As part of this, I made some of the previously static methods in ReferenceText into members. This allows proper error reporting (and positions us to deal with PG-699: the need to split blocks in the reference guide to match end-of-verse splits in the vernacular).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/187)
<!-- Reviewable:end -->
