### PR TITLE
Ensure userconfirmed is false when characterId is Unknown or Ambiguous (PG-739)

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -420,7 +420,9 @@ namespace Glyssen
 			else if (characterList.Count == 0)
 			{
 				CharacterId = CharacterVerseData.UnknownCharacter;
+				CharacterIdOverrideForScript = null;
 				Delivery = null;
+				UserConfirmed = false;
 			}
 			else
 			{
@@ -434,7 +436,9 @@ namespace Glyssen
 				else
 				{
 					CharacterId = CharacterVerseData.AmbiguousCharacter;
+					CharacterIdOverrideForScript = null;
 					Delivery = null;
+					UserConfirmed = false;
 				}
 			}
 		}

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -37,8 +37,10 @@ namespace Glyssen
 				{
 					MigrateInvalidMultiBlockQuoteData(project.Books);
 					CleanUpOrphanedMultiBlockQuoteStati(project.Books);
-					MigrateInvalidCharacterIdForScriptData(project.Books);
 				}
+				if (fromControlFileVersion < 102)
+					MigrateInvalidCharacterIdForScriptData(project.Books);
+
 				MigrateDeprecatedCharacterIds(project);
 			}
 
@@ -144,6 +146,7 @@ namespace Glyssen
 				block.CharacterIdOverrideForScript != null)))
 			{
 				block.CharacterIdInScript = null;
+				block.UserConfirmed = false;
 			}
 		}
 

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	101
+Control File Version	102
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5								
 # PSA will be handled as complete units, each psalm will be spoken by one voice								


### PR DESCRIPTION
The symptom was that disambiguation was at 100% but there were still blocks
which needed to be assigned.

Also cleaned up one scenario in which characterId was Unknown or Ambiguous
but characterIdInScript was non-null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/188)
<!-- Reviewable:end -->
