### PR TITLE
PG-743: Prevented failure message when splitting blocks with verse bridges

### DIFF
--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -444,7 +444,7 @@ namespace Glyssen
 				else
 					initEndVerse = initStartVerse;
 
-				while (initStartVerse > verseToSplitAfter)
+				while (initEndVerse > verseToSplitAfter)
 				{
 					if (iSplit == verseSplitLocations.Count - 1)
 						return splitsMade;


### PR DESCRIPTION
… to match verse breaks in the Reference Text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/194)
<!-- Reviewable:end -->
