### PR TITLE
PG-525: Automatically disambiguate second character in verse when possible

### DIFF
--- a/Glyssen/BookScript.cs
+++ b/Glyssen/BookScript.cs
@@ -259,8 +259,11 @@ namespace Glyssen
 				if (block.InitialStartVerseNumber < verse && block.InitialEndVerseNumber < verse)
 					continue;
 				iFirstBlockToExamine = index;
-				if (block.InitialStartVerseNumber > verse || !(block.BlockElements.First() is Verse))
+				if (block.InitialStartVerseNumber > verse ||
+					(iFirstBlockToExamine > 0 && !(block.BlockElements.First() is Verse) && m_blocks[iFirstBlockToExamine - 1].LastVerse == verse))
+				{
 					iFirstBlockToExamine--;
+				}
 				break;
 			}
 

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -279,20 +279,9 @@ namespace Glyssen.Dialogs
 
 		private void SelectCharacter()
 		{
-			Block currentBlock = m_viewModel.CurrentBlock;
-			if (currentBlock.CharacterIs(m_viewModel.CurrentBookId, CharacterVerseData.StandardCharacter.Narrator))
-				m_listBoxCharacters.SelectedItem = AssignCharacterViewModel.Character.Narrator;
-			else if (!currentBlock.CharacterIsUnclear())
-			{
-				foreach (var item in CurrentContextCharacters)
-				{
-					if (item.CharacterId == currentBlock.CharacterId)
-					{
-						m_listBoxCharacters.SelectedItem = item;
-						return;
-					}
-				}
-			}
+			var character = m_viewModel.GetCharacterToSelectForCurrentBlock(CurrentContextCharacters);
+			if (character != null)
+				m_listBoxCharacters.SelectedItem = character;
 		}
 
 		private IEnumerable<AssignCharacterViewModel.Character> CurrentContextCharacters
@@ -828,5 +817,6 @@ namespace Glyssen.Dialogs
 		}
 
 		#endregion
+
 	}
 }

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -616,5 +616,30 @@ namespace Glyssen.Dialogs
 			}
 		}
 		#endregion
+
+		public Character GetCharacterToSelectForCurrentBlock(IEnumerable<Character> currentCharacters)
+		{
+			if (CurrentBlock.CharacterIs(CurrentBookId, CharacterVerseData.StandardCharacter.Narrator))
+				return Character.Narrator;
+			if (CurrentBlock.CharacterIsUnclear())
+			{
+				if (!CurrentBlock.BlockElements.OfType<Verse>().Any())
+				{
+					var charactersForCurrentVerse = GetUniqueCharactersForCurrentReference();
+					// ENHANCE: Some "Quotations" in the control file may represent text that is typically rendered as
+					// indirect speech (and should therefore be marked as Indirect|Quotation). We really don't want to
+					// include these, but in practice it probably won't matter much.
+					charactersForCurrentVerse.RemoveWhere(c => !c.IsExpected && c.QuoteType != QuoteType.Quotation);
+					if (charactersForCurrentVerse.Count != 2)
+						return null;
+					var blocks = CurrentBook.GetBlocksForVerse(CurrentBlock.ChapterNumber, CurrentBlock.InitialStartVerseNumber).Where(b => b.UserConfirmed).ToList();
+					if (blocks.Count != 1)
+						return null;
+					charactersForCurrentVerse.RemoveWhere(c => c.Character == blocks[0].CharacterId);
+					return currentCharacters.FirstOrDefault(item => item.LocalizedCharacterId == charactersForCurrentVerse.Single().LocalizedCharacter);
+				}
+			}
+			return currentCharacters.FirstOrDefault(item => item.CharacterId == CurrentBlock.CharacterId);
+		}
 	}
 }

--- a/GlyssenTests/BookScriptTests.cs
+++ b/GlyssenTests/BookScriptTests.cs
@@ -296,6 +296,25 @@ namespace GlyssenTests
 			Assert.AreEqual(3, list.Count);
 			Assert.AreEqual(expected, list[0]);
 		}
+
+		[Test]
+		public void GetBlocksForVerse_VerseNumberPrecededBySquareBracket_ReturnsBlocksForVerse()
+		{
+			var blocks = new List<Block>();
+			blocks.Add(NewChapterBlock(8));
+			blocks.Add(NewSingleVersePara(36, "Ka guwoto kacel i yo, ci guo ka ma pii tye iye. Laco ma gikolo owacci, "));
+			blocks.Add(NewBlock("“Nen pii doŋ ene! Gin aŋo ma geŋa limo batija?” "));
+			Block expected;
+			blocks.Add(expected = NewSingleVersePara(37, "Ci Pilipo owacce ni, "));
+			expected.BlockElements.Insert(0, new ScriptText("[ "));
+			blocks.Add(NewBlock("“Ka iye ki cwinyi ducu ci itwero.” "));
+			blocks.Add(NewBlock("En odok iye ni, "));
+			blocks.Add(NewBlock("“An aye Yecu Kricito, ni en Wod pa Lubaŋa.”] "));
+			var bookScript = new BookScript("ACT", blocks);
+			var list = bookScript.GetBlocksForVerse(8, 37).ToList();
+			Assert.AreEqual(4, list.Count);
+			Assert.AreEqual(expected, list[0]);
+		}
 		#endregion
 
 		#region GetScriptBlocks Tests


### PR DESCRIPTION
Select the second character when a verse has two expected speakers and two identified quotations and the user assigns the first one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/205)
<!-- Reviewable:end -->
