### PR TITLE
PG-526: Mark blocks as user-confirmed when assigning during split

### DIFF
--- a/Glyssen/BookScript.cs
+++ b/Glyssen/BookScript.cs
@@ -467,7 +467,8 @@ namespace Glyssen
 			return combinedBlock;
 		}
 
-		public Block SplitBlock(Block blockToSplit, string verseToSplit, int characterOffsetToSplit, bool userSplit = true, string characterId = null)
+		public Block SplitBlock(Block blockToSplit, string verseToSplit, int characterOffsetToSplit, bool userSplit = true,
+			string characterId = null, ScrVers versification = null)
 		{
 			var iBlock = m_blocks.IndexOf(blockToSplit);
 
@@ -567,7 +568,15 @@ namespace Glyssen
 						initialStartVerse, initialEndVerse);
 					if (userSplit)
 					{
-						newBlock.CharacterId = string.IsNullOrEmpty(characterId) ? CharacterVerseData.kUnknownCharacter : characterId;
+						if (string.IsNullOrEmpty(characterId))
+							newBlock.CharacterId = CharacterVerseData.kUnknownCharacter;
+						else
+						{
+							if (versification == null)
+								throw new ArgumentNullException("versification");
+							newBlock.SetCharacterAndCharacterIdInScript(characterId, BCVRef.BookToNumber(BookId), versification);
+							newBlock.UserConfirmed = true;
+						}
 					}
 					else
 					{

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -373,7 +373,7 @@ namespace Glyssen.Dialogs
 					var characterId = characters.First(c => c.Key == blockSplitData.Id).Value;
 
 					var newBlock = CurrentBook.SplitBlock(blockSplitData.BlockToSplit, blockSplitData.VerseToSplit, 
-						blockSplitData.CharacterOffsetToSplit, true, characterId);
+						blockSplitData.CharacterOffsetToSplit, true, characterId, m_project.Versification);
 
 					AddToRelevantBlocksIfNeeded(newBlock);
 				}

--- a/GlyssenTests/BlockTests.cs
+++ b/GlyssenTests/BlockTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Glyssen;
 using Glyssen.Character;
 using NUnit.Framework;
@@ -8,6 +9,7 @@ using SIL.Scripture;
 using SIL.Xml;
 using GlyssenTests.Properties;
 using Paratext;
+using SIL.IO;
 using ScrVers = Paratext.ScrVers;
 
 namespace GlyssenTests
@@ -15,10 +17,19 @@ namespace GlyssenTests
 	[TestFixture]
 	class BlockTests
 	{
+		private ScrVers m_testVersification;
+
 		[TestFixtureSetUp]
 		public void FixtureSetup()
 		{
-			ScrTextCollection.Initialize();
+			// Use a test version of the file so the tests won't break every time we fix a problem in the production control file.
+			ControlCharacterVerseData.TabDelimitedCharacterVerseData = Resources.TestCharacterVerse;
+
+			using (TempFile tempFile = new TempFile())
+			{
+				File.WriteAllText(tempFile.Path, Resources.TestVersification);
+				m_testVersification = Versification.Table.Load(tempFile.Path);
+			}
 		}
 
 		[SetUp]
@@ -559,13 +570,13 @@ namespace GlyssenTests
 		public void UseDefaultForMultipleChoiceCharacter_ExplicitDefault_UseDefault()
 		{
 			var block = new Block("p", 9, 11);
-			block.CharacterId = "Peter (Simon)/James, the disciple/John";
+			block.CharacterId = "Peter (Simon)/James/John";
 			block.UseDefaultForMultipleChoiceCharacter(BCVRef.BookToNumber("MRK"));
 			Assert.AreEqual("John", block.CharacterIdInScript);
 		}
 
 		[Test]
-		public void UseDefaultForMultipleChoiceCharacter_AlreadySetToAnotherVlaue_OverwriteWithDefault()
+		public void UseDefaultForMultipleChoiceCharacter_AlreadySetToAnotherValue_OverwriteWithDefault()
 		{
 			var block = new Block("p", 40, 8);
 			block.CharacterId = "chief cupbearer/chief baker";
@@ -630,8 +641,8 @@ namespace GlyssenTests
 			// MRK 9:10 in the Vulgate should translate to 9:11 in the "original"
 			// The control file overrides the default speaker in MRK 9:11 to be John.
 			var block = new Block("p", 9, 10);
-			block.SetCharacterAndCharacterIdInScript("Peter (Simon)/James, the disciple/John", BCVRef.BookToNumber("MRK"), ScrVers.Vulgate);
-			Assert.AreEqual("Peter (Simon)/James, the disciple/John", block.CharacterId);
+			block.SetCharacterAndCharacterIdInScript("Peter (Simon)/James/John", BCVRef.BookToNumber("MRK"), m_testVersification);
+			Assert.AreEqual("Peter (Simon)/James/John", block.CharacterId);
 			Assert.AreEqual("John", block.CharacterIdInScript);
 		}
 

--- a/GlyssenTests/BlockTests.cs
+++ b/GlyssenTests/BlockTests.cs
@@ -6,12 +6,21 @@ using NUnit.Framework;
 using SIL.TestUtilities;
 using SIL.Scripture;
 using SIL.Xml;
+using GlyssenTests.Properties;
+using Paratext;
+using ScrVers = Paratext.ScrVers;
 
 namespace GlyssenTests
 {
 	[TestFixture]
 	class BlockTests
 	{
+		[TestFixtureSetUp]
+		public void FixtureSetup()
+		{
+			ScrTextCollection.Initialize();
+		}
+
 		[SetUp]
 		public void Setup()
 		{
@@ -613,6 +622,17 @@ namespace GlyssenTests
 			block.SetCharacterAndCharacterIdInScript("chief cupbearer/chief baker", BCVRef.BookToNumber("GEN"));
 			Assert.AreEqual("chief cupbearer/chief baker", block.CharacterId);
 			Assert.AreEqual("dead frog", block.CharacterIdInScript);
+		}
+
+		[Test]
+		public void SetCharacterAndCharacterIdInScript_ControlFileHasOverriddenDefault_VersificationShift_CharacterIdInScriptBasedOnOverride()
+		{
+			// MRK 9:10 in the Vulgate should translate to 9:11 in the "original"
+			// The control file overrides the default speaker in MRK 9:11 to be John.
+			var block = new Block("p", 9, 10);
+			block.SetCharacterAndCharacterIdInScript("Peter (Simon)/James, the disciple/John", BCVRef.BookToNumber("MRK"), ScrVers.Vulgate);
+			Assert.AreEqual("Peter (Simon)/James, the disciple/John", block.CharacterId);
+			Assert.AreEqual("John", block.CharacterIdInScript);
 		}
 
 		[Test]

--- a/GlyssenTests/Resources/TestVersification.txt
+++ b/GlyssenTests/Resources/TestVersification.txt
@@ -18,3 +18,4 @@ GEN 1:31 2:25 3:24 4:26 5:32 6:22 7:24 8:22 9:29 10:32 11:32 12:20 13:18 14:24 1
 #
 # (Note: ranges must not span a chapter, e.g. 4:10-5:11 is illegal)
 #
+MRK 9:1-49 = MRK 9:2-50


### PR DESCRIPTION
When splitting a block and assigning a character, made it mark the block as user confirmed, to prevent inserting a block that appears to have had its character ID set by Glyssen (which messes up the block indices in the navigator). We now also assign the override to use in the script if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/206)
<!-- Reviewable:end -->
