### PR TITLE
PG-761: Added code to split English reference text when primary RT is split

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -584,6 +584,109 @@ namespace Glyssen
 
 			return string.Format(s_characterSelect, splitId);
 		}
+
+		internal Block SplitBlock(string verseToSplit, int characterOffsetToSplit)
+		{
+			var currVerse = InitialVerseNumberOrBridge;
+
+			Block newBlock = null;
+			int indexOfFirstElementToRemove = -1;
+
+			for (int i = 0; i < BlockElements.Count; i++)
+			{
+				var blockElement = BlockElements[i];
+
+				if (newBlock != null)
+				{
+					newBlock.BlockElements.Add(blockElement);
+					continue;
+				}
+
+				Verse verse = blockElement as Verse;
+				if (verse != null)
+					currVerse = verse.Number;
+				else if (verseToSplit == currVerse)
+				{
+					ScriptText text = blockElement as ScriptText;
+
+					string content;
+					if (text == null)
+					{
+						if (BlockElements.Count > i + 1 && BlockElements[i + 1] is Verse)
+						{
+							content = string.Empty;
+							characterOffsetToSplit = 0;
+							indexOfFirstElementToRemove = i + 1;
+						}
+						else
+							continue;
+					}
+					else
+					{
+						content = text.Content;
+
+						if (BlockElements.Count > i + 1)
+						{
+							if (!(BlockElements[i + 1] is Verse) &&
+								(characterOffsetToSplit == BookScript.kSplitAtEndOfVerse || characterOffsetToSplit > content.Length))
+							{
+								// Some kind of annotation. We can skip this. If we're splitting at
+								continue;
+							}
+							indexOfFirstElementToRemove = i + 1;
+						}
+
+						if (characterOffsetToSplit == BookScript.kSplitAtEndOfVerse)
+							characterOffsetToSplit = content.Length;
+
+						if (characterOffsetToSplit <= 0 || characterOffsetToSplit > content.Length)
+						{
+							throw new ArgumentOutOfRangeException("characterOffsetToSplit", characterOffsetToSplit,
+								@"Value must be greater than 0 and less than or equal to the length (" + content.Length +
+								@") of the text of verse " + currVerse + @".");
+						}
+						if (characterOffsetToSplit == content.Length && indexOfFirstElementToRemove < 0)
+							return null;
+					}
+
+					int initialStartVerse, initialEndVerse;
+					if (characterOffsetToSplit == content.Length)
+					{
+						var firstVerseAfterSplit = (Verse)BlockElements[indexOfFirstElementToRemove];
+						initialStartVerse = firstVerseAfterSplit.StartVerse;
+						initialEndVerse = firstVerseAfterSplit.EndVerse;
+					}
+					else
+					{
+						var verseNumParts = verseToSplit.Split(new[] {'-'}, 2, StringSplitOptions.None);
+						initialStartVerse = int.Parse(verseNumParts[0]);
+						initialEndVerse = verseNumParts.Length == 2 ? int.Parse(verseNumParts[1]) : 0;
+					}
+					newBlock = new Block(StyleTag, ChapterNumber,
+						initialStartVerse, initialEndVerse)
+					{
+						CharacterId = CharacterId,
+						CharacterIdOverrideForScript = CharacterIdOverrideForScript,
+						Delivery = Delivery,
+						UserConfirmed = UserConfirmed
+					};
+					if (characterOffsetToSplit < content.Length)
+						newBlock.BlockElements.Add(new ScriptText(content.Substring(characterOffsetToSplit)));
+					if (text != null)
+						text.Content = content.Substring(0, characterOffsetToSplit);
+				}
+			}
+
+			if (newBlock == null)
+				throw new ArgumentException(String.Format("Verse {0} not found in given block: {1}", verseToSplit, GetText(true)), "verseToSplit");
+
+			if (indexOfFirstElementToRemove >= 0)
+			{
+				while (indexOfFirstElementToRemove < BlockElements.Count)
+					BlockElements.RemoveAt(indexOfFirstElementToRemove);
+			}
+			return newBlock;
+		}
 	}
 
 	public class BlockComparer : IEqualityComparer<Block>

--- a/Glyssen/BookScript.cs
+++ b/Glyssen/BookScript.cs
@@ -487,128 +487,38 @@ namespace Glyssen
 				return blockToSplit;
 			}
 
-			var currVerse = blockToSplit.InitialVerseNumberOrBridge;
-
-			Block newBlock = null;
-			int indexOfFirstElementToRemove = -1;
-
-			for (int i = 0; i < blockToSplit.BlockElements.Count; i++)
-			{
-				var blockElement = blockToSplit.BlockElements[i];
-
-				if (newBlock != null)
-				{
-					newBlock.BlockElements.Add(blockElement);
-					continue;
-				}
-
-				Verse verse = blockElement as Verse;
-				if (verse != null)
-					currVerse = verse.Number;
-				else if (verseToSplit == currVerse)
-				{
-					ScriptText text = blockElement as ScriptText;
-
-					string content;
-					if (text == null)
-					{
-						if (blockToSplit.BlockElements.Count > i + 1 && blockToSplit.BlockElements[i + 1] is Verse)
-						{
-							content = string.Empty;
-							characterOffsetToSplit = 0;
-							indexOfFirstElementToRemove = i + 1;
-						}
-						else
-							continue;
-					}
-					else
-					{
-						content = text.Content;
-
-						if (blockToSplit.BlockElements.Count > i + 1)
-						{
-							if (!(blockToSplit.BlockElements[i + 1] is Verse) && (characterOffsetToSplit == kSplitAtEndOfVerse || characterOffsetToSplit > content.Length))
-							{
-								// Some kind of annotation. We can skip this. If we're splitting at
-								continue;
-							}
-							indexOfFirstElementToRemove = i + 1;
-						}
-
-						if (characterOffsetToSplit == kSplitAtEndOfVerse)
-							characterOffsetToSplit = content.Length;
-
-						if (characterOffsetToSplit <= 0 || characterOffsetToSplit > content.Length)
-						{
-							throw new ArgumentOutOfRangeException("characterOffsetToSplit", characterOffsetToSplit,
-								@"Value must be greater than 0 and less than or equal to the length (" + content.Length +
-								@") of the text of verse " + currVerse + @".");
-						}
-						if (characterOffsetToSplit == content.Length && indexOfFirstElementToRemove < 0)
-						{
-							SplitBeforeBlock(iBlock + 1, splitId);
-							return m_blocks[iBlock + 1];
-						}
-					}
-
-					int initialStartVerse, initialEndVerse;
-					if (characterOffsetToSplit == content.Length)
-					{
-						var firstVerseAfterSplit = ((Verse)blockToSplit.BlockElements[indexOfFirstElementToRemove]);
-						initialStartVerse = firstVerseAfterSplit.StartVerse;
-						initialEndVerse = firstVerseAfterSplit.EndVerse;
-					}
-					else
-					{
-						var verseNumParts = verseToSplit.Split(new[] { '-' }, 2, StringSplitOptions.None);
-						initialStartVerse = int.Parse(verseNumParts[0]);
-						initialEndVerse = verseNumParts.Length == 2 ? int.Parse(verseNumParts[1]) : 0;
-					}
-					newBlock = new Block(blockToSplit.StyleTag, blockToSplit.ChapterNumber,
-						initialStartVerse, initialEndVerse);
-					if (userSplit)
-					{
-						if (string.IsNullOrEmpty(characterId))
-							newBlock.CharacterId = CharacterVerseData.kUnknownCharacter;
-						else
-						{
-							if (versification == null)
-								throw new ArgumentNullException("versification");
-							newBlock.SetCharacterAndCharacterIdInScript(characterId, BCVRef.BookToNumber(BookId), versification);
-							newBlock.UserConfirmed = true;
-						}
-					}
-					else
-					{
-						newBlock.CharacterId = blockToSplit.CharacterId;
-						newBlock.CharacterIdOverrideForScript = blockToSplit.CharacterIdOverrideForScript;
-						newBlock.Delivery = blockToSplit.Delivery;
-						newBlock.UserConfirmed = blockToSplit.UserConfirmed;
-					}
-					if (characterOffsetToSplit < content.Length)
-						newBlock.BlockElements.Add(new ScriptText(content.Substring(characterOffsetToSplit)));
-					if (text != null)
-						text.Content = content.Substring(0, characterOffsetToSplit);
-					m_blocks.Insert(iBlock + 1, newBlock);
-					var chapterNumbersToIncrement = m_chapterStartBlockIndices.Keys.Where(chapterNum => chapterNum > blockToSplit.ChapterNumber).ToList();
-					foreach (var chapterNum in chapterNumbersToIncrement)
-						m_chapterStartBlockIndices[chapterNum]++;
-
-					m_blockCount++;
-				}
-			}
+			Block newBlock = blockToSplit.SplitBlock(verseToSplit, characterOffsetToSplit);
 
 			if (newBlock == null)
-				throw new ArgumentException(String.Format("Verse {0} not found in given block: {1}", verseToSplit, blockToSplit.GetText(true)), "verseToSplit");
-
-			if (indexOfFirstElementToRemove >= 0)
 			{
-				while (indexOfFirstElementToRemove < blockToSplit.BlockElements.Count)
-					blockToSplit.BlockElements.RemoveAt(indexOfFirstElementToRemove);
+				SplitBeforeBlock(iBlock + 1, splitId);
+				return m_blocks[iBlock + 1];
 			}
+
+			m_blocks.Insert(iBlock + 1, newBlock);
+			var chapterNumbersToIncrement = m_chapterStartBlockIndices.Keys.Where(chapterNum => chapterNum > blockToSplit.ChapterNumber).ToList();
+			foreach (var chapterNum in chapterNumbersToIncrement)
+				m_chapterStartBlockIndices[chapterNum]++;
+
+			m_blockCount++;
 
 			if (userSplit)
 			{
+				newBlock.Delivery = null;
+				if (string.IsNullOrEmpty(characterId))
+				{
+					newBlock.CharacterId = CharacterVerseData.kUnknownCharacter;
+					newBlock.CharacterIdOverrideForScript = null;
+					newBlock.UserConfirmed = false;
+				}
+				else
+				{
+					if (versification == null)
+						throw new ArgumentNullException("versification");
+					newBlock.SetCharacterAndCharacterIdInScript(characterId, BCVRef.BookToNumber(BookId), versification);
+					newBlock.UserConfirmed = true;
+				}
+
 				if (blockToSplit.MultiBlockQuote == MultiBlockQuote.Start)
 				{
 					blockToSplit.MultiBlockQuote = MultiBlockQuote.None;
@@ -667,12 +577,25 @@ namespace Glyssen
 			}
 			try
 			{
-				SplitBlock(vernBlock, verseString, kSplitAtEndOfVerse, false);
+				var newBlock = SplitBlock(vernBlock, verseString, kSplitAtEndOfVerse, false);
+				if (vernBlock.MatchesReferenceText)
+				{
+					try
+					{
+						// REVIEW: Should this be First or Single, or do we need to possibly handle the case of a sequence?
+						newBlock.SetMatchedReferenceBlock(vernBlock.ReferenceBlocks.First().SplitBlock(verseString, kSplitAtEndOfVerse));
+					}
+					catch (ArgumentException)
+					{
+						// TODO: Handle English Reference block with different verse number from primary reference block
+					}
+				}
 			}
 			catch (ArgumentException)
 			{
 				return false;
 			}
+
 			return true;
 		}
 


### PR DESCRIPTION
This involved major refactoring to move much of the SplitBlock logic into the Block class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/216)
<!-- Reviewable:end -->
