### PR TITLE
PG-767: Crash viewing recording script if UI language not English

### DIFF
--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -479,11 +479,11 @@ namespace Glyssen
 						"This string is filled in as a parameter in MainForm.ActorsAssignedPlural or MainForm.ActorsAssignedSingle");
 					break;
 				case 1:
-					assignedParameter = LocalizationManager.GetString("MainForm.NoneAssigned", "1 assigned",
+					assignedParameter = LocalizationManager.GetString("MainForm.OneAssigned", "1 assigned",
 						"This string is filled in as a parameter in MainForm.ActorsAssignedPlural or MainForm.ActorsAssignedSingle");
 					break;
 				default:
-					assignedParameter = String.Format(LocalizationManager.GetString("MainForm.NoneAssigned", "{0} assigned",
+					assignedParameter = String.Format(LocalizationManager.GetString("MainForm.MoreThanOneAssigned", "{0} assigned",
 						"{0} is the number of actors assigned. The resulting string is filled in as a parameter in MainForm.ActorsAssignedPlural or MainForm.ActorsAssignedSingle"),
 						assigned);
 					break;

--- a/Glyssen/ProjectExporter.cs
+++ b/Glyssen/ProjectExporter.cs
@@ -391,6 +391,8 @@ namespace Glyssen
 				if (!Project.ReferenceText.HasSecondaryReferenceText)
 					columnNumber--;
 			}
+			if (LocalizationManager.UILanguageId != "en")
+				columnNumber++;
 			return columnNumber;
 		}
 


### PR DESCRIPTION
This fix as cherry-picked from master branch (PG-759)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/220)
<!-- Reviewable:end -->
