### PR TITLE
PG-778: Fixed crash caused by using *only* quotation dashes (no paire…

### DIFF
--- a/Glyssen/Quote/QuoteParser.cs
+++ b/Glyssen/Quote/QuoteParser.cs
@@ -346,7 +346,7 @@ namespace Glyssen.Quote
 								if (specialOpeningPunctuationLen == 0)
 									atBeginningOfBlock = false;
 
-								if (m_quoteLevel > 0 && token.StartsWith(ContinuerForCurrentLevel))
+								if (m_quoteLevel > 0 && s_quoteSystem.NormalLevels.Count > m_quoteLevel - 1 && token.StartsWith(ContinuerForCurrentLevel))
 								{
 									thisBlockStartsWithAContinuer = true;
 									int i = ContinuerForCurrentLevel.Length;
@@ -357,7 +357,7 @@ namespace Glyssen.Quote
 										continue;
 									token = token.Substring(i);
 								}
-								if ((m_quoteLevel == 0) && (s_quoteSystem.NormalLevels.Count > 0))
+								if (m_quoteLevel == 0 && s_quoteSystem.NormalLevels.Count > 0)
 								{
 									string continuerForNextLevel = ContinuerForNextLevel;
 									if (string.IsNullOrEmpty(continuerForNextLevel) || !token.StartsWith(continuerForNextLevel))
@@ -869,7 +869,7 @@ namespace Glyssen.Quote
 			public int Compare(char x, char y)
 			{
 				// Putting regular dash at the beginning makes the regex not try to treat it as a range operator
-				if (x.Equals('-'))
+				if (x.Equals('-') && !y.Equals('-'))
 					return -1;
 				return x.CompareTo(y);
 			}


### PR DESCRIPTION
…d quotation marks) and a quote continues into a poetry paragraph, but then the following \m paragraph has the same quotation dash at the begging of it (which is actually supposed to be a closer, but could be interpreted as a new opener, depending on the settings.

PG-787: Fixed bug when trying to create a regular expression in quote parser when a normal dash is used for both the opening and closing dialogue quote mark.
(cherry picked from commit a05589ccbe79567d6af4059f4e26fd961baf9764)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/225)
<!-- Reviewable:end -->
