### PR TITLE
Fixed crash caused by trying to set the first displayed row index to a value that is out of range.

### DIFF
--- a/Glyssen/Controls/ScriptBlocksGridView.cs
+++ b/Glyssen/Controls/ScriptBlocksGridView.cs
@@ -31,8 +31,14 @@ namespace Glyssen.Controls
 			if (!m_updatingContext && SelectedRows.Count > 0)
 			{
 				var firstRow = SelectedRows[SelectedRows.Count - 1].Index;
+				// When first initializing or moving to a different row (in a different book?), we
+				// can briefly get into a state where the selected row is out of range. I'd like to
+				// understand this better to prevent it higher up by clearing the SelectedRows
+				// collection, but this first check seems like a safe/robust way to prevent a crash.
+				if (firstRow >= RowCount || e.Row.Index < firstRow - 5)
+					return;
 				var lastRow = SelectedRows[0].Index;
-				if (e.Row.Index > firstRow - 5 && e.Row.Index < lastRow + 2)
+				if (e.Row.Index < lastRow + 2)
 					this.SafeInvoke(() => ScrollDesiredRowsIntoView(firstRow, lastRow), true);
 			}
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/240)
<!-- Reviewable:end -->
