### PR TITLE
Put sanity checks inside SafeInvoke call to prevent crash when row count is changing.

### DIFF
--- a/Glyssen/Controls/ScriptBlocksGridView.cs
+++ b/Glyssen/Controls/ScriptBlocksGridView.cs
@@ -28,19 +28,22 @@ namespace Glyssen.Controls
 		protected override void OnRowHeightChanged(DataGridViewRowEventArgs e)
 		{
 			base.OnRowHeightChanged(e);
-			if (!m_updatingContext && SelectedRows.Count > 0)
+			this.SafeInvoke(() =>
 			{
-				var firstRow = SelectedRows[SelectedRows.Count - 1].Index;
-				// When first initializing or moving to a different row (in a different book?), we
-				// can briefly get into a state where the selected row is out of range. I'd like to
-				// understand this better to prevent it higher up by clearing the SelectedRows
-				// collection, but this first check seems like a safe/robust way to prevent a crash.
-				if (firstRow >= RowCount || e.Row.Index <= firstRow - 5)
-					return;
-				var lastRow = SelectedRows[0].Index;
-				if (e.Row.Index < lastRow + 2)
-					this.SafeInvoke(() => ScrollDesiredRowsIntoView(firstRow, lastRow), true);
-			}
+				if (!m_updatingContext && SelectedRows.Count > 0)
+				{
+					var firstRow = SelectedRows[SelectedRows.Count - 1].Index;
+					// When first initializing or moving to a different row (in a different book?), we
+					// can briefly get into a state where the selected row is out of range. I'd like to
+					// understand this better to prevent it higher up by clearing the SelectedRows
+					// collection, but this first check seems like a safe/robust way to prevent a crash.
+					if (firstRow >= RowCount || e.Row.Index <= firstRow - 5)
+						return;
+					var lastRow = SelectedRows[0].Index;
+					if (e.Row.Index < lastRow + 2)
+						ScrollDesiredRowsIntoView(firstRow, lastRow);
+				}
+			}, true);
 		}
 
 		protected override void OnCellMouseDown(DataGridViewCellMouseEventArgs e)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/244)
<!-- Reviewable:end -->
