### PR TITLE
Fixed null reference exception during export

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -254,6 +254,8 @@ namespace Glyssen
 
 		public void SetMatchedReferenceBlock(Block referenceBlock)
 		{
+			if (referenceBlock == null)
+				throw new ArgumentNullException("referenceBlock");
 			ReferenceBlocks = new List<Block> { referenceBlock };
 			MatchesReferenceText = true;
 		}

--- a/Glyssen/PortionScript.cs
+++ b/Glyssen/PortionScript.cs
@@ -142,14 +142,24 @@ namespace Glyssen
 				var newBlock = SplitBlock(vernBlock, verseString, kSplitAtEndOfVerse, false);
 				if (vernBlock.MatchesReferenceText)
 				{
+					// REVIEW: Should this be First or Single, or do we need to possibly handle the case of a sequence?
+					// For now, at least, matching implies there is exactly one reference block.
+					var refBlock = vernBlock.ReferenceBlocks.Single();
 					try
 					{
-						// For now, at least, matching implies there is exactly one reference block.
-						newBlock.SetMatchedReferenceBlock(vernBlock.ReferenceBlocks.Single().SplitBlock(verseString, kSplitAtEndOfVerse));
+						newBlock.SetMatchedReferenceBlock(refBlock.SplitBlock(verseString, kSplitAtEndOfVerse));
 					}
 					catch (ArgumentException)
 					{
-						// TODO: Handle English Reference block with different verse number from primary reference block
+						while (refBlock != null)
+						{
+							var lastVerseOfRefBlock = refBlock.LastVerse;
+							var newRefBlock = new Block(newBlock.StyleTag, newBlock.ChapterNumber, lastVerseOfRefBlock.StartVerse, lastVerseOfRefBlock.EndVerse);
+							newRefBlock.BlockElements.Add(new ScriptText(""));
+							newBlock.SetMatchedReferenceBlock(newRefBlock);
+							newBlock = newRefBlock;
+							refBlock = refBlock.ReferenceBlocks.FirstOrDefault();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This bug was reported in a comment in PG-810. (This fix has already been made in 0.11, but I'm just doing it quick here to get Connie up and running again.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/246)
<!-- Reviewable:end -->
