### PR TITLE
PG 805 & PG-820, etc.

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -590,7 +590,7 @@ namespace Glyssen
 
 		public bool CharacterIsUnclear()
 		{
-			return CharacterId == CharacterVerseData.kAmbiguousCharacter || CharacterId == CharacterVerseData.kUnknownCharacter;
+			return CharacterVerseData.IsCharacterUnclear(CharacterId);
 		}
 
 		public void SetStandardCharacter(string bookId, CharacterVerseData.StandardCharacter standardCharacterType)

--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -144,9 +144,11 @@ namespace Glyssen
 				if (!CorrelatedBlocks[i].MatchesReferenceText) // e.g., section head
 					continue;
 				var vernBlock = origBlocks[m_iStartBlock + i];
+
 				var refBlock = CorrelatedBlocks[i].ReferenceBlocks.Single();
 				vernBlock.SetMatchedReferenceBlock(refBlock);
 				vernBlock.SetCharacterAndDeliveryInfo(CorrelatedBlocks[i], bookNum, versification);
+
 				if (CorrelatedBlocks[i].UserConfirmed)
 					vernBlock.UserConfirmed = true;
 

--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -150,7 +150,11 @@ namespace Glyssen
 				vernBlock.SetCharacterAndDeliveryInfo(CorrelatedBlocks[i], bookNum, versification);
 
 				if (CorrelatedBlocks[i].UserConfirmed)
+				{
+					if (vernBlock.CharacterIsUnclear())
+						throw new InvalidOperationException("Character cannot be confirmed as ambigous or unknown.");
 					vernBlock.UserConfirmed = true;
+				}
 
 				//if (vernBlock.CharacterId != refBlock.CharacterId)
 				//{
@@ -217,6 +221,8 @@ namespace Glyssen
 					{
 						var refBlock = block.ReferenceBlocks.Single();
 						block.SetCharacterAndDeliveryInfo(refBlock, bookNum, versification);
+						if (block.CharacterIsUnclear())
+							throw new InvalidOperationException("Character cannot be confirmed as ambigous or unknown.");
 						block.UserConfirmed = true; // This does not affect original block until Apply is called
 					}
 				}

--- a/Glyssen/Character/CharacterVerseData.cs
+++ b/Glyssen/Character/CharacterVerseData.cs
@@ -56,6 +56,11 @@ namespace Glyssen.Character
 			return StandardCharacter.NonStandard;
 		}
 
+		public static bool IsCharacterUnclear(string characterId)
+		{
+			return characterId == CharacterVerseData.kAmbiguousCharacter || characterId == CharacterVerseData.kUnknownCharacter;
+		}
+
 		public static string GetStandardCharacterId(string bookId, StandardCharacter standardCharacterType)
 		{
 			return GetCharacterPrefix(standardCharacterType) + bookId;

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1181,9 +1181,16 @@ namespace Glyssen.Dialogs
 					}
 					m_viewModel.SetReferenceTextMatchupCharacter(e.RowIndex, selectedCharacter);
 
-					var block = matchup.GetCorrespondingOriginalBlock(matchup.CorrelatedBlocks[m_dataGridReferenceText.CurrentCellAddress.Y]);
+					var block = matchup.CorrelatedBlocks[m_dataGridReferenceText.CurrentCellAddress.Y];
 					if (m_viewModel.IsBlockAssignedToUnknownCharacterDeliveryPair(block))
-						// TODO: reset the selected delivery to be the appropriate one for this character.
+					{
+						// The first one should always be "normal" - we want a more specific one, if any.
+						var delivery = m_viewModel.GetDeliveriesForCharacter(selectedCharacter).LastOrDefault();
+						string deliveryAsString = delivery == null
+							? AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay
+							: delivery.LocalizedDisplay;
+						m_dataGridReferenceText.Rows[e.RowIndex].Cells[colDelivery.Index].Value = deliveryAsString;
+					}
 				}
 				UpdateInsertHeSaidButtonState();
 			}

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -742,7 +742,7 @@ namespace Glyssen.Dialogs
 			LoadDeliveryListBox(m_viewModel.GetDeliveriesForCharacter(selectedCharacter));
 			HideDeliveryFilter();
 			if (selectedCharacter != null && selectedCharacter.IsNarrator)
-				m_llMoreDel.Enabled = false;
+				m_llMoreDel.Enabled = false;			
 			UpdateAssignOrApplyAndResetButtonState();
 		}
 
@@ -1154,16 +1154,18 @@ namespace Glyssen.Dialogs
 			}
 			else
 			{
+				var matchup = m_viewModel.CurrentReferenceTextMatchup;
+
 				if ((colPrimary.Visible && e.ColumnIndex == colPrimary.Index) ||
 					(!colPrimary.Visible && e.ColumnIndex == colEnglish.Index))
 				{
 					var newValue = m_dataGridReferenceText.Rows[e.RowIndex].Cells[e.ColumnIndex].Value as string;
-					m_viewModel.CurrentReferenceTextMatchup.SetReferenceText(e.RowIndex, newValue, 0);
+					matchup.SetReferenceText(e.RowIndex, newValue, 0);
 				}
 				else if (e.ColumnIndex == colEnglish.Index)
 				{
 					var newValue = m_dataGridReferenceText.Rows[e.RowIndex].Cells[e.ColumnIndex].Value as string;
-					m_viewModel.CurrentReferenceTextMatchup.SetReferenceText(e.RowIndex, newValue, 1);
+					matchup.SetReferenceText(e.RowIndex, newValue, 1);
 				}
 				else
 				{
@@ -1178,6 +1180,10 @@ namespace Glyssen.Dialogs
 							colCharacter.Items.Cast<AssignCharacterViewModel.Character>().FirstOrDefault(c => c.LocalizedDisplay == newValue);
 					}
 					m_viewModel.SetReferenceTextMatchupCharacter(e.RowIndex, selectedCharacter);
+
+					var block = matchup.GetCorrespondingOriginalBlock(matchup.CorrelatedBlocks[m_dataGridReferenceText.CurrentCellAddress.Y]);
+					if (m_viewModel.IsBlockAssignedToUnknownCharacterDeliveryPair(block))
+						// TODO: reset the selected delivery to be the appropriate one for this character.
 				}
 				UpdateInsertHeSaidButtonState();
 			}

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -373,6 +373,8 @@ namespace Glyssen.Dialogs
 
 		private void SetCharacterAndDelivery(Block block, Character selectedCharacter, Delivery selectedDelivery)
 		{
+			if (CharacterVerseData.IsCharacterUnclear(selectedCharacter.CharacterId))
+				throw new ArgumentException("Character cannot be confirmed as ambigous or unknown.", "selectedCharacter");
 			// If the user sets a non-narrator to a block we marked as narrator, we want to track it
 			if (!selectedCharacter.IsNarrator && !block.IsQuote)
 				Analytics.Track("NarratorToQuote", new Dictionary<string, string>

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -614,7 +614,8 @@ namespace Glyssen.Dialogs
 				}
 
 				// Current block was navigated to ad-hoc and doesn't match the filter. See if there is a relevant block after it.
-				var indicesOfCurrentLocation = m_temporarilyIncludedBlock ?? m_navigator.GetIndicesOfSpecificBlock(m_currentRefBlockMatchups.OriginalBlocks.First());
+				var indicesOfCurrentLocation = m_currentRefBlockMatchups == null ? m_temporarilyIncludedBlock :
+					m_navigator.GetIndicesOfSpecificBlock(m_currentRefBlockMatchups.OriginalBlocks.Last());
 				return s_bookBlockComparer.Compare(m_relevantBlocks.Last(), indicesOfCurrentLocation) > 0;
 			}
 		}

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -182,31 +182,40 @@ namespace Glyssen
 				int bookNum = BCVRef.BookToNumber(book.BookId);
 
 				foreach (Block block in book.GetScriptBlocks().Where(block => block.CharacterId != null &&
-					block.CharacterId != CharacterVerseData.kAmbiguousCharacter &&
 					block.CharacterId != CharacterVerseData.kUnknownCharacter &&
 					!CharacterVerseData.IsCharacterStandard(block.CharacterId)))
 				{
-					var unknownCharacter = !characterDetailDictionary.ContainsKey(block.CharacterIdInScript);
-					if (unknownCharacter &&
-						project.ProjectCharacterVerseData.GetCharacters(bookNum, block.ChapterNumber, block.InitialStartVerseNumber, block.InitialEndVerseNumber).
-							Any(c => c.Character == block.CharacterId && c.Delivery == (block.Delivery ?? "")))
+					if (block.CharacterId == CharacterVerseData.kAmbiguousCharacter)
 					{
-						// PG-471: This is a known character who spoke in an unexpected location and was therefore added to the project CV file,
-						// but was subsequently removed or renamed from the master character detail list.
-						project.ProjectCharacterVerseData.Remove(bookNum, block.ChapterNumber, block.InitialStartVerseNumber,
-							block.InitialEndVerseNumber, block.CharacterId, block.Delivery ?? "");
-						block.CharacterId = CharacterVerseData.kUnknownCharacter;
-						block.CharacterIdInScript = null;
+						block.UserConfirmed = false;
 						numberOfChangesMade++;
 					}
 					else
 					{
-						var characters = cvInfo.GetCharacters(bookNum, block.ChapterNumber, block.InitialStartVerseNumber, block.InitialEndVerseNumber).ToList();
-						if (unknownCharacter ||
-							!characters.Any(c => c.Character == block.CharacterId && c.Delivery == (block.Delivery ?? "")))
+						var unknownCharacter = !characterDetailDictionary.ContainsKey(block.CharacterIdInScript);
+						if (unknownCharacter && project.ProjectCharacterVerseData.GetCharacters(bookNum, block.ChapterNumber, block.InitialStartVerseNumber,
+								block.InitialEndVerseNumber).
+								Any(c => c.Character == block.CharacterId && c.Delivery == (block.Delivery ?? "")))
 						{
-							block.SetCharacterAndDelivery(characters);
+							// PG-471: This is a known character who spoke in an unexpected location and was therefore added to the project CV file,
+							// but was subsequently removed or renamed from the master character detail list.
+							project.ProjectCharacterVerseData.Remove(bookNum, block.ChapterNumber, block.InitialStartVerseNumber,
+								block.InitialEndVerseNumber, block.CharacterId, block.Delivery ?? "");
+							block.CharacterId = CharacterVerseData.kUnknownCharacter;
+							block.CharacterIdInScript = null;
 							numberOfChangesMade++;
+						}
+						else
+						{
+							var characters = cvInfo.GetCharacters(bookNum, block.ChapterNumber, block.InitialStartVerseNumber, block.InitialEndVerseNumber).ToList();
+							if (unknownCharacter || !characters.Any(c => c.Character == block.CharacterId && c.Delivery == (block.Delivery ?? "")))
+							{
+								if (characters.Count(c => c.Character == block.CharacterId) == 1)
+									block.Delivery = characters.First(c => c.Character == block.CharacterId).Delivery;
+								else
+									block.SetCharacterAndDelivery(characters);
+								numberOfChangesMade++;
+							}
 						}
 					}
 				}

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -187,8 +187,11 @@ namespace Glyssen
 				{
 					if (block.CharacterId == CharacterVerseData.kAmbiguousCharacter)
 					{
-						block.UserConfirmed = false;
-						numberOfChangesMade++;
+						if (block.UserConfirmed)
+						{
+							block.UserConfirmed = false;
+							numberOfChangesMade++;
+						}
 					}
 					else
 					{

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -962,6 +962,19 @@ namespace GlyssenTests.Dialogs
 			m_model.LoadNextRelevantBlock();
 			Assert.AreEqual(origNextRelevantBlock, m_model.CurrentBlock);
 		}
+
+		[Test]
+		public void CanNavigateToNextRelevantBlock_CurrentBlockIsNonRelevantBlockInLastBlockMatchup_ReturnsFalse()
+		{
+			m_model.AttemptRefBlockMatchup = false;
+			m_model.Mode = BlocksToDisplay.NeedAssignments;
+			Assert.IsTrue(m_model.TryLoadBlock(new VerseRef(new BCVRef(BCVRef.BookToNumber("ACT"), 28, 27), m_testProject.Versification)));
+			m_model.LoadPreviousRelevantBlock();
+			m_model.CurrentBlockIndexInBook--;
+			m_model.AttemptRefBlockMatchup = true;
+			Assert.IsFalse(m_model.IsCurrentBlockRelevant);
+			Assert.IsFalse(m_model.CanNavigateToNextRelevantBlock);
+		}
 	}
 
 	[TestFixture]

--- a/GlyssenTests/ProjectDataMigratorTests.cs
+++ b/GlyssenTests/ProjectDataMigratorTests.cs
@@ -645,6 +645,19 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void MigrateDeprecatedCharacterIds_ExistingAmbiguousUserNotConfirmed_NoChanges()
+		{
+			var testProject = TestProject.CreateTestProject(TestProject.TestBook.LUK);
+			TestProject.SimulateDisambiguationForAllBooks(testProject);
+			var block = testProject.IncludedBooks.Single().GetBlocksForVerse(18, 39).Last();
+			block.CharacterId = CharacterVerseData.kAmbiguousCharacter;
+			block.UserConfirmed = false;
+
+			Assert.AreEqual(0, ProjectDataMigrator.MigrateDeprecatedCharacterIds(testProject));
+			Assert.AreEqual(false, block.UserConfirmed);
+		}
+
+		[Test]
 		public void MigrateDeprecatedCharacterIds_OneMemberOfMultiCharacterIdChanged_CharacterIdInScriptSetToReplacementId()
 		{
 			var testProject = TestProject.CreateTestProject(TestProject.TestBook.REV);


### PR DESCRIPTION
PG-805: Prevented problem caused when users apply a rainbow match that doesn't correspond to a character/delivery pair in the control file. Also made it less likely for the user to do this by accident.
PG-820: Fixed crash when clicking Apply when the current block is a non-relevant block in the last rainbow group.
Also fixed data migration bug reported by JimA regarding Ambiguous blocks getting set as user confirmed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/251)
<!-- Reviewable:end -->
