### PR TITLE
PG-825: Fixed logic in BlockMatchup constructor to prevent trying to …

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -27,7 +27,7 @@ namespace Glyssen
 			var blocksForVersesCoveredByBlock =
 				vernacularBook.GetBlocksForVerse(originalAnchorBlock.ChapterNumber, originalAnchorBlock.InitialStartVerseNumber).ToList();
 			m_iStartBlock = iBlock - blocksForVersesCoveredByBlock.IndexOf(originalAnchorBlock);
-			while (!blocksForVersesCoveredByBlock.First().StartsAtVerseStart)
+			while (!blocksForVersesCoveredByBlock.First().StartsAtVerseStart && blocksForVersesCoveredByBlock.First().InitialStartVerseNumber < originalAnchorBlock.InitialStartVerseNumber)
 			{
 				var prepend = vernacularBook.GetBlocksForVerse(originalAnchorBlock.ChapterNumber, blocksForVersesCoveredByBlock.First().InitialStartVerseNumber).ToList();
 				prepend.RemoveAt(prepend.Count - 1);

--- a/Glyssen/Utilities/FormWithPersistedSettings.cs
+++ b/Glyssen/Utilities/FormWithPersistedSettings.cs
@@ -19,10 +19,23 @@ namespace Glyssen.Utilities
 
 		protected override void OnLoad(EventArgs e)
 		{
+			base.OnLoad(e);
+
 			RestoreFormSettings();
 			RestoreGridSettings(this);
 			m_finishedLoading = true;
-			base.OnLoad(e);
+
+			var workingArea = Screen.GetWorkingArea(this);
+			if (!workingArea.Contains(Bounds))
+			{
+				if (Bounds.Left < workingArea.Left || Bounds.Top < workingArea.Top)
+					Location = new Point(Math.Max(Bounds.Left, workingArea.Left), Math.Max(Bounds.Top, workingArea.Top));
+
+				if (Width > workingArea.Width)
+					Width = workingArea.Width;
+				if (Height > workingArea.Height)
+					Height = workingArea.Height;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
…back up into preceding verses when the first block for a verse is just an opening square bracket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/253)
<!-- Reviewable:end -->
