### PR TITLE
PG-824: Made changing anchor block work correctly when block breaks i…

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -205,8 +205,7 @@ namespace Glyssen
 
 		public bool IncludesBlock(Block block)
 		{
-			// TODO: Write tests for the second part of this
-			return OriginalBlocks.Contains(block); // || CorrelatedBlocks.Contains(block);
+			return OriginalBlocks.Contains(block) || CorrelatedBlocks.Contains(block);
 		}
 
 		public void MatchAllBlocks(Paratext.ScrVers versification)

--- a/GlyssenTests/BlockMatchupTests.cs
+++ b/GlyssenTests/BlockMatchupTests.cs
@@ -104,7 +104,7 @@ namespace GlyssenTests
 		}
 
 		[Test]
-		public void IncludesBlock_VernVersesSplitByReferenceText_ReturnValuesReflectOriginalBlocks()
+		public void IncludesBlock_VernVersesSplitByReferenceText_ReturnValuesReflectOriginalAndCorrelatedBlocks()
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Entonces Jesus abrio su boca y enseno.", true));
@@ -128,6 +128,8 @@ namespace GlyssenTests
 			Assert.IsTrue(matchup.IncludesBlock(vernacularBlocks[1]));
 			Assert.IsTrue(matchup.IncludesBlock(vernacularBlocks[2]));
 			Assert.IsFalse(matchup.IncludesBlock(vernacularBlocks[3]));
+
+			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => matchup.IncludesBlock(b)));
 
 			Assert.AreEqual(matchup.CorrelatedBlocks.First(), matchup.CorrelatedAnchorBlock);
 		}


### PR DESCRIPTION
…n reference text cause splits in matchup such that the blocks showing in the left pane are not the actual blocks in the book.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/256)
<!-- Reviewable:end -->
