### PR TITLE
PG-811: Changed exception to debug assertion for scenario where a previous

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -220,8 +220,10 @@ namespace Glyssen
 					{
 						var refBlock = block.ReferenceBlocks.Single();
 						block.SetCharacterAndDeliveryInfo(refBlock, bookNum, versification);
-						if (block.CharacterIsUnclear())
-							throw new InvalidOperationException("Character cannot be confirmed as ambigous or unknown.");
+						Debug.Assert(!block.CharacterIsUnclear(),
+							"Character in reference block not set: " + refBlock + ". This is probably the result of a bug in a " +
+							"previous version of Glyssen that allowed ref block assignment without specifying the character. It " +
+							"seems to be safe to ignore this.");
 						block.UserConfirmed = true; // This does not affect original block until Apply is called
 					}
 				}


### PR DESCRIPTION
version of Glyssen allowed ref block assignment without specifying the character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/267)
<!-- Reviewable:end -->
