### PR TITLE
PG-843: Fixed crash and made it so blocks for books that do not have a corresponding reference text are not considered misalignments.

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -83,8 +83,9 @@ namespace Glyssen.Dialogs
 			{
 				// We want CheckChanged event to fire, so just setting Checked to true is not enough.
 				m_toolStripButtonMatchReferenceText.CheckState = (Settings.Default.AssignCharactersMatchReferenceText ||
-					(m_viewModel.Mode & BlocksToDisplay.NotAlignedToReferenceText) != 0)
-					? CheckState.Checked : CheckState.Unchecked;
+																(m_viewModel.Mode & BlocksToDisplay.NotAlignedToReferenceText) != 0)
+					? CheckState.Checked
+					: CheckState.Unchecked;
 				HandleCharacterSelectionTabIndexChanged(m_tabControlCharacterSelection, new EventArgs());
 			}
 			else
@@ -950,38 +951,47 @@ namespace Glyssen.Dialogs
 			if (!IsHandleCreated)
 				return;
 
-			BlocksToDisplay mode;
+			Cursor = Cursors.WaitCursor;
 
-			switch (m_toolStripComboBoxFilter.SelectedIndex)
+			try
 			{
-				case 0: mode = BlocksToDisplay.NeedAssignments; break;
-				case 1: mode = BlocksToDisplay.MissingExpectedQuote; break;
-				case 2: mode = BlocksToDisplay.MoreQuotesThanExpectedSpeakers; break;
-				case 3: mode = BlocksToDisplay.AllExpectedQuotes; break;
-				case 4: mode = BlocksToDisplay.AllQuotes; break;
-				case 6: mode = BlocksToDisplay.NotAlignedToReferenceText; break;
-				default: mode = BlocksToDisplay.AllScripture; break;
+				BlocksToDisplay mode;
+
+				switch (m_toolStripComboBoxFilter.SelectedIndex)
+				{
+					case 0: mode = BlocksToDisplay.NeedAssignments; break;
+					case 1: mode = BlocksToDisplay.MissingExpectedQuote; break;
+					case 2: mode = BlocksToDisplay.MoreQuotesThanExpectedSpeakers; break;
+					case 3: mode = BlocksToDisplay.AllExpectedQuotes; break;
+					case 4: mode = BlocksToDisplay.AllQuotes; break;
+					case 6: mode = BlocksToDisplay.NotAlignedToReferenceText; break;
+					default: mode = BlocksToDisplay.AllScripture; break;
+				}
+
+				if (m_toolStripButtonExcludeUserConfirmed.Checked)
+					mode |= BlocksToDisplay.ExcludeUserConfirmed;
+
+				m_viewModel.Mode = mode;
+
+				if (m_viewModel.RelevantBlockCount > 0)
+				{
+					LoadBlock(sender, e);
+					//m_viewModel.AttemptRefBlockMatchup = m_toolStripButtonGridView.Checked;
+					LoadBlockMatchup(sender, e);
+				}
+				else
+				{
+					m_labelXofY.Visible = false;
+					UpdateNavigationButtonState();
+					m_blocksViewer.ShowNothingMatchesFilterMessage();
+				}
+
+				UpdateProgressBarForMode();
 			}
-
-			if (m_toolStripButtonExcludeUserConfirmed.Checked)
-				mode |= BlocksToDisplay.ExcludeUserConfirmed;
-
-			m_viewModel.Mode = mode;
-
-			if (m_viewModel.RelevantBlockCount > 0)
+			finally
 			{
-				LoadBlock(sender, e);
-				//m_viewModel.AttemptRefBlockMatchup = m_toolStripButtonGridView.Checked;
-				LoadBlockMatchup(sender, e);
+				Cursor = Cursors.Default;
 			}
-			else
-			{
-				m_labelXofY.Visible = false;
-				UpdateNavigationButtonState();
-				m_blocksViewer.ShowNothingMatchesFilterMessage();
-			}
-
-			UpdateProgressBarForMode();
 		}
 
 		private void HandleMatchReferenceTextCheckChanged(object sender, EventArgs e)

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -883,6 +883,8 @@ namespace Glyssen.Dialogs
 				return BlockNeedsAssignment(block);
 			if ((Mode & BlocksToDisplay.NotAlignedToReferenceText) > 0)
 			{
+				// Note that the logic here is absolutely dependent on block being in CurrentBook!!!
+
 				if (!block.IsScripture || !m_project.ReferenceText.CanDisplayReferenceTextForBook(CurrentBook))
 					return false;
 

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -883,7 +883,7 @@ namespace Glyssen.Dialogs
 				return BlockNeedsAssignment(block);
 			if ((Mode & BlocksToDisplay.NotAlignedToReferenceText) > 0)
 			{
-				if (!block.IsScripture)
+				if (!block.IsScripture || !m_project.ReferenceText.CanDisplayReferenceTextForBook(CurrentBook))
 					return false;
 
 				if (s_lastMatchup == null || !s_lastMatchup.OriginalBlocks.Contains(block))


### PR DESCRIPTION
Also, added wait cursor changing the filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/280)
<!-- Reviewable:end -->
