### PR TITLE
PG-845: Prevent crash when parser changes make previously saved start index (for Identify Speaking Parts) invalid.

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -25,40 +25,40 @@ namespace Glyssen
 			m_referenceLanguageInfo = heSaidProvider;
 			var blocks = m_vernacularBook.GetScriptBlocks();
 			var originalAnchorBlock = blocks[iBlock];
-			var blocksForVersesCoveredByBlock =
+			var blocksForStartVerseOfAnchorBlock =
 				vernacularBook.GetBlocksForVerse(originalAnchorBlock.ChapterNumber, originalAnchorBlock.InitialStartVerseNumber).ToList();
-			m_iStartBlock = iBlock - blocksForVersesCoveredByBlock.IndexOf(originalAnchorBlock);
+			m_iStartBlock = iBlock - blocksForStartVerseOfAnchorBlock.IndexOf(originalAnchorBlock);
 			while (m_iStartBlock > 0)
 			{
-				if (blocksForVersesCoveredByBlock.First().InitialStartVerseNumber < originalAnchorBlock.InitialStartVerseNumber &&
-					!blocksForVersesCoveredByBlock.First().StartsAtVerseStart)
+				if (blocksForStartVerseOfAnchorBlock.First().InitialStartVerseNumber < originalAnchorBlock.InitialStartVerseNumber &&
+					!blocksForStartVerseOfAnchorBlock.First().StartsAtVerseStart)
 				{
 					var prepend = vernacularBook.GetBlocksForVerse(originalAnchorBlock.ChapterNumber,
-						blocksForVersesCoveredByBlock.First().InitialStartVerseNumber).ToList();
+						blocksForStartVerseOfAnchorBlock.First().InitialStartVerseNumber).ToList();
 					prepend.RemoveAt(prepend.Count - 1);
 					m_iStartBlock -= prepend.Count;
-					blocksForVersesCoveredByBlock.InsertRange(0, prepend);
+					blocksForStartVerseOfAnchorBlock.InsertRange(0, prepend);
 				}
 				if (m_iStartBlock == 0 || isOkayToBreakAtVerse(new VerseRef(bookNum, originalAnchorBlock.ChapterNumber,
-					blocksForVersesCoveredByBlock.First().InitialStartVerseNumber)))
+					blocksForStartVerseOfAnchorBlock.First().InitialStartVerseNumber)))
 				{
 					break;
 				}
 
 				m_iStartBlock--;
-				blocksForVersesCoveredByBlock.Insert(0, blocks[m_iStartBlock]);
+				blocksForStartVerseOfAnchorBlock.Insert(0, blocks[m_iStartBlock]);
 			}
-			int iLastBlock = m_iStartBlock + blocksForVersesCoveredByBlock.Count - 1;
+			int iLastBlock = m_iStartBlock + blocksForStartVerseOfAnchorBlock.Count - 1;
 			int i = iLastBlock;
 			AdvanceToCleanVerseBreak(blocks,
 				verseNum => isOkayToBreakAtVerse(new VerseRef(bookNum, originalAnchorBlock.ChapterNumber, verseNum)),
 				ref i);
 			if (i > iLastBlock)
-				blocksForVersesCoveredByBlock.AddRange(blocks.Skip(iLastBlock + 1).Take(i - iLastBlock));
-			while (CharacterVerseData.IsCharacterOfType(blocksForVersesCoveredByBlock.Last().CharacterId, CharacterVerseData.StandardCharacter.ExtraBiblical))
-				blocksForVersesCoveredByBlock.RemoveAt(blocksForVersesCoveredByBlock.Count - 1);
+				blocksForStartVerseOfAnchorBlock.AddRange(blocks.Skip(iLastBlock + 1).Take(i - iLastBlock));
+			while (CharacterVerseData.IsCharacterOfType(blocksForStartVerseOfAnchorBlock.Last().CharacterId, CharacterVerseData.StandardCharacter.ExtraBiblical))
+				blocksForStartVerseOfAnchorBlock.RemoveAt(blocksForStartVerseOfAnchorBlock.Count - 1);
 
-			m_portion = new PortionScript(vernacularBook.BookId, blocksForVersesCoveredByBlock.Select(b => b.Clone()));
+			m_portion = new PortionScript(vernacularBook.BookId, blocksForStartVerseOfAnchorBlock.Select(b => b.Clone()));
 			CorrelatedAnchorBlock = m_portion.GetScriptBlocks()[iBlock - m_iStartBlock];
 			if (splitBlocks != null)
 			{

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -137,7 +137,8 @@ namespace Glyssen.Dialogs
 			if (m_inHandleCurrentBlockChanged)
 				return;
 			m_inHandleCurrentBlockChanged = true;
-			Debug.Assert(!CharacterVerseData.IsCharacterExtraBiblical(CurrentBlock.CharacterId));
+			if (CharacterVerseData.IsCharacterExtraBiblical(CurrentBlock.CharacterId))
+				throw new InvalidOperationException("Cannot attempt to match an extra-biblical block to a reference text.");
 			if (AttemptRefBlockMatchup)
 			{
 				if (CurrentReferenceTextMatchup == null || !CurrentReferenceTextMatchup.IncludesBlock(CurrentBlock))

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -96,12 +96,17 @@ namespace Glyssen.Dialogs
 
 			Mode = mode;
 
-			if (startingIndices != null && !startingIndices.IsUndefined)
+			if (startingIndices != null && !startingIndices.IsUndefined && startingIndices.BookIndex < m_project.IncludedBooks.Count)
 			{
-				SetBlock(startingIndices);
-				m_currentBlockIndex = m_relevantBlocks.IndexOf(startingIndices);
-				if (m_currentBlockIndex < 0)
-					m_temporarilyIncludedBlock = startingIndices;
+				var startingBook = m_project.IncludedBooks[startingIndices.BookIndex];
+				var blocks = startingBook.GetScriptBlocks();
+				if (blocks.Count > startingIndices.BlockIndex && !CharacterVerseData.IsCharacterExtraBiblical(blocks[startingIndices.BlockIndex].CharacterId))
+				{
+					SetBlock(startingIndices);
+					m_currentBlockIndex = m_relevantBlocks.IndexOf(startingIndices);
+					if (m_currentBlockIndex < 0)
+						m_temporarilyIncludedBlock = startingIndices;
+				}
 			}
 		}
 

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Glyssen;
+using Glyssen.Bundle;
 using Glyssen.Character;
 using Glyssen.Dialogs;
 using NUnit.Framework;
@@ -1120,6 +1121,65 @@ namespace GlyssenTests.Dialogs
 			}
 
 			return returnVal;
+		}
+	}
+
+	[TestFixture]
+	internal class AssignCharacterViewModelConstructorTests
+	{
+		private Project m_testProject;
+
+		[TestFixtureSetUp]
+		public void TestFixtureSetUp()
+		{
+			m_testProject = TestProject.CreateTestProject(TestProject.TestBook.MRK);
+		}
+
+		[TestFixtureTearDown]
+		public void TestFixtureTearDown()
+		{
+			TestProject.DeleteTestProjectFolder();
+		}
+
+		/// <summary>
+		/// PG-845
+		/// </summary>
+		[Test]
+		public void Constructor_StartingIndexIsExtraBiblicalBlock_StartingIndexIgnored()
+		{
+			var model = new AssignCharacterViewModel(m_testProject, BlocksToDisplay.NeedAssignments, new BookBlockIndices(0,
+				m_testProject.IncludedBooks[0].GetScriptBlocks().IndexOf(b => b.CharacterIs("MRK", CharacterVerseData.StandardCharacter.ExtraBiblical) &&
+				b.InitialStartVerseNumber > 0)));
+			model.AttemptRefBlockMatchup = true;
+			Assert.IsFalse(model.CurrentBlock.CharacterIs("MRK", CharacterVerseData.StandardCharacter.ExtraBiblical));
+			Assert.IsFalse(model.CanNavigateToPreviousRelevantBlock);
+		}
+
+		[Test]
+		public void Constructor_StartingIndexIsChapterBlock_StartingIndexIgnored()
+		{
+			var model = new AssignCharacterViewModel(m_testProject, BlocksToDisplay.NeedAssignments, new BookBlockIndices(0,
+				m_testProject.IncludedBooks[0].GetScriptBlocks().IndexOf(b => b.CharacterIs("MRK", CharacterVerseData.StandardCharacter.BookOrChapter) &&
+				b.ChapterNumber > 0)));
+			model.AttemptRefBlockMatchup = true;
+			Assert.IsFalse(model.CurrentBlock.CharacterIs("MRK", CharacterVerseData.StandardCharacter.BookOrChapter));
+			Assert.IsFalse(model.CanNavigateToPreviousRelevantBlock);
+		}
+
+		[Test]
+		public void Constructor_StartingIndexIsOutOfRangeBook_StartingIndexIgnored()
+		{
+			var model = new AssignCharacterViewModel(m_testProject, BlocksToDisplay.NeedAssignments, new BookBlockIndices(1, 3));
+			model.AttemptRefBlockMatchup = true;
+			Assert.IsFalse(model.CanNavigateToPreviousRelevantBlock);
+		}
+
+		[Test]
+		public void Constructor_StartingIndexIsOutOfRangeBlock_StartingIndexIgnored()
+		{
+			var model = new AssignCharacterViewModel(m_testProject, BlocksToDisplay.NeedAssignments, new BookBlockIndices(0, Int32.MaxValue));
+			model.AttemptRefBlockMatchup = true;
+			Assert.IsFalse(model.CanNavigateToPreviousRelevantBlock);
 		}
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/283)
<!-- Reviewable:end -->
