### PR TITLE
Fixed crash in UpdateBookDisplay caused by using formatted message instead of directory name

### DIFF
--- a/Glyssen/Dialogs/ExportDlg.cs
+++ b/Glyssen/Dialogs/ExportDlg.cs
@@ -107,7 +107,7 @@ namespace Glyssen.Dialogs
 			{
 				m_lblBookDirectory.Visible = true;
 				m_lblBookDirectory.Text = string.Format(m_bookDirectoryFmt, m_viewModel.BookDirectory);
-				m_lblBookDirectoryExists.Visible = Directory.Exists(m_lblBookDirectory.Text);
+				m_lblBookDirectoryExists.Visible = Directory.Exists(m_viewModel.BookDirectory);
 			}
 			else
 			{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/286)
<!-- Reviewable:end -->
