### PR TITLE
Only try to reset narrator's delivery to normal if it isn't already normal

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1309,8 +1309,9 @@ namespace Glyssen.Dialogs
 						// the line that sets the character in the reference text matchup will have already reset
 						// the delivery. This leaves the UI out of synch with the data in the block, so we need
 						// to fix that first.
-						m_dataGridReferenceText.Rows[e.RowIndex].Cells[colDelivery.Index].Value =
-							AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay;
+						var deliveryCell = m_dataGridReferenceText.Rows[e.RowIndex].Cells[colDelivery.Index];
+						if (deliveryCell.Value as string != AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay)
+							deliveryCell.Value = AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay;
 					}
 					m_viewModel.SetReferenceTextMatchupCharacter(e.RowIndex, selectedCharacter);
 


### PR DESCRIPTION
I'm making this change mostly because I got a debug assertion failure (which I can't understand or reproduce) as a result of setting the delivery to normal, and I'm thinking I might at least reduce the likelihood of it happening again by not setting the delivery unless necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/290)
<!-- Reviewable:end -->
