### PR TITLE
This AssemblyInfo file got missed by accident when upping version to 0.18

### DIFF
--- a/Glyssen/Properties/AssemblyInfo.cs
+++ b/Glyssen/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 // Only specify Major and Minor Build Numbers here. The others come from Team City
-[assembly: AssemblyVersion("0.17.0.0")]
-[assembly: AssemblyFileVersion("0.17.0.0")]
+[assembly: AssemblyVersion("0.18.0.0")]
+[assembly: AssemblyFileVersion("0.18.0.0")]
 [assembly: InternalsVisibleTo("GlyssenTests")]
 [assembly: InternalsVisibleTo("ControlDataIntegrityTests")]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/295)
<!-- Reviewable:end -->
