### PR TITLE
PG-872: Fixed bug that kept traditional views from highlighting entir…

### DIFF
--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -513,7 +513,7 @@ namespace Glyssen.Dialogs
 				if (BlockGroupingStyle == BlockGroupingType.Quote)
 				{
 					if (CurrentBlock.MultiBlockQuote == MultiBlockQuote.Start)
-						GetIndicesOfQuoteContinuationBlocks(CurrentBlock).Last();
+						return GetIndicesOfQuoteContinuationBlocks(CurrentBlock).Last();
 					return IndexOfFirstBlockInCurrentGroup;
 				}
 				return m_currentRefBlockMatchups.IndexOfStartBlockInBook + m_currentRefBlockMatchups.CorrelatedBlocks.Count - 1;


### PR DESCRIPTION
…e quote when a block was selected that was part of a multi-block quote.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/298)
<!-- Reviewable:end -->
