### PR TITLE
PG-822: Explain why Apply button is disabled and don't allow the user…

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -254,11 +254,8 @@ namespace Glyssen
 					{
 						var refBlock = block.ReferenceBlocks.Single();
 						block.SetCharacterAndDeliveryInfo(refBlock, bookNum, versification);
-						Debug.Assert(!block.CharacterIsUnclear(),
-							"Character in reference block not set: " + refBlock + ". This is probably the result of a bug in a " +
-							"previous version of Glyssen that allowed ref block assignment without specifying the character. It " +
-							"seems to be safe to ignore this.");
-						block.UserConfirmed = true; // This does not affect original block until Apply is called
+						if (!block.CharacterIsUnclear())
+							block.UserConfirmed = true; // This does not affect original block until Apply is called
 					}
 				}
 				else

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -644,14 +644,24 @@ namespace Glyssen.Dialogs
 							DialogResult.Yes;
 					}
 				}
-				else
+				else if (m_userMadeChangesToReferenceTextMatchup)
 				{
-					if (m_btnApplyReferenceTextMatches.Enabled && m_userMadeChangesToReferenceTextMatchup)
+					if (m_btnApplyReferenceTextMatches.Enabled)
 					{
 						string msg = LocalizationManager.GetString("DialogBoxes.AssignCharacterDlg.UnsavedReferenceTextChangesMessage",
 							"The alignment of the reference text to the vernacular script has not been applied. Do you want to save the alignment before navigating?");
 						if (MessageBox.Show(this, msg, UnsavedChangesMessageBoxTitle, MessageBoxButtons.YesNo) == DialogResult.Yes)
 							m_viewModel.ApplyCurrentReferenceTextMatchup();
+					}
+					else
+					{
+						// Technically, we shouyld have a separate message for the case where the Delivery column is showing, but in practice
+						// there is no way for the user to set the value for a cell in the Delivery column to null, so even though our code
+						// checks for this, it can't really happen.
+						string msg = LocalizationManager.GetString("DialogBoxes.AssignCharacterDlg.IncompleteCharacterAssignments",
+							"You have not finished specifying the character information for every block. Would you like to discard the changes you have made?");
+						result = MessageBox.Show(this, msg, UnsavedChangesMessageBoxTitle, MessageBoxButtons.YesNo,
+							MessageBoxIcon.None, MessageBoxDefaultButton.Button2) == DialogResult.Yes;
 					}
 				}
 


### PR DESCRIPTION
… to lose changes without warning when they click Next or Previous. Also, removed bogus debug assertion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/308)
<!-- Reviewable:end -->
