### PR TITLE
PG-900 The constructor saved m_defaultBlocksViewerText after it had ...

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -42,7 +42,7 @@ namespace Glyssen.Dialogs
 		private Font m_primaryReferenceTextFont;
 		private Font m_englishReferenceTextFont;
 		private bool m_userMadeChangesToReferenceTextMatchup;
-		private readonly string m_defaultBlocksViewerText;
+		private string m_defaultBlocksViewerText;
 		private int m_IndexOfFirstFilterItemRemoved;
 		private object[] m_filterItemsForRainbowModeOnly;
 
@@ -63,6 +63,7 @@ namespace Glyssen.Dialogs
 			L10N.LocalizeComboList(m_toolStripComboBoxFilter, "DialogBoxes.AssignCharacterDlg.FilterOptions");
 			UpdateFilterItems();
 
+			m_defaultBlocksViewerText = m_blocksViewer.Text;
 			m_xOfYFmt = m_labelXofY.Text;
 			m_singleVoiceCheckboxFmt = m_chkSingleVoice.Text;
 
@@ -73,8 +74,6 @@ namespace Glyssen.Dialogs
 		{
 			InitializeComponent();
 
-			m_defaultBlocksViewerText = m_blocksViewer.Text;
-
 			const int numberOfFilterItemsForRainbowModeOnly = 1;
 			m_IndexOfFirstFilterItemRemoved = m_toolStripComboBoxFilter.Items.Count - numberOfFilterItemsForRainbowModeOnly;
 			m_filterItemsForRainbowModeOnly = new object[numberOfFilterItemsForRainbowModeOnly];
@@ -82,6 +81,10 @@ namespace Glyssen.Dialogs
 				m_filterItemsForRainbowModeOnly[i] = m_toolStripComboBoxFilter.Items[m_IndexOfFirstFilterItemRemoved];
 
 			m_viewModel = viewModel;
+
+			HandleStringsLocalized();
+			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+
 			if (m_viewModel.CanDisplayReferenceTextForCurrentBlock)
 			{
 				// We want CheckChanged event to fire, so just setting Checked to true is not enough.
@@ -129,9 +132,6 @@ namespace Glyssen.Dialogs
 
 			m_dataGridReferenceText.DataError += HandleDataGridViewDataError;
 			colPrimary.HeaderText = m_viewModel.PrimaryReferenceTextName;
-
-			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
 
 			colCharacter.DisplayMember = m_listBoxCharacters.DisplayMember = "LocalizedDisplay";
 			colDelivery.DisplayMember = m_listBoxDeliveries.DisplayMember = "LocalizedDisplay";


### PR DESCRIPTION
already been changed when initializing m_blocksViewer.Text when initially in 'rainbow' mode. Moved the initialization of m_defaultBlocksViewerText to HandleStringsLocalized().  m_blocksViewer.Text is still not localized, but couldn't get it to work.  "Who speaks this part?" doesn't localize.

It now initializes correctly for both "Who speaks this part?" and "Match Reference Text" modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/323)
<!-- Reviewable:end -->
