### PR TITLE
PG-903 Bug allowed duplicate CharacterID entries in the CharacterDetail...

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -727,7 +727,7 @@ namespace Glyssen.Dialogs
 				if (dlg.ShowDialog() != DialogResult.OK)
 					return;
 
-				m_viewModel.AddCharacterDetailToProject(character, dlg.Gender, dlg.Age);
+				m_viewModel.StoreCharacterDetail(character, dlg.Gender, dlg.Age);
 			}
 
 			var newItem = new AssignCharacterViewModel.Character(character);

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -21,6 +21,7 @@ namespace Glyssen.Dialogs
 		private readonly DeliveryComparer m_deliveryComparer = new DeliveryComparer();
 		private readonly AliasComparer m_aliasComparer = new AliasComparer();
 		private int m_assignedBlocks;
+		private readonly Dictionary<String, CharacterDetail> m_pendingCharacterDetails = new Dictionary<string, CharacterDetail>();
 		private HashSet<CharacterVerse> m_currentCharacters;
 		private IEnumerable<Character> m_generatedCharacterList;
 		private List<Delivery> m_currentDeliveries = new List<Delivery>();
@@ -28,6 +29,7 @@ namespace Glyssen.Dialogs
 		public delegate void AsssignedBlockIncrementEventHandler(AssignCharacterViewModel sender, int increment, int newMaximum);
 		public event AsssignedBlockIncrementEventHandler AssignedBlocksIncremented;
 		public event EventHandler CurrentBookSaved;
+
 		#endregion
 
 		#region Constructors
@@ -111,11 +113,14 @@ namespace Glyssen.Dialogs
 			});
 		}
 
-		public void AddCharacterDetailToProject(string characterId, CharacterGender gender, CharacterAge age)
+		public void StoreCharacterDetail(string characterId, CharacterGender gender, CharacterAge age)
 		{
+			if (m_project.AllCharacterDetailDictionary.ContainsKey(characterId))
+			{
+				throw new ArgumentException("Project already contains a character with ID " + characterId);
+			}
 			var detail = new CharacterDetail { CharacterId = characterId, Gender = gender, Age = age, MaxSpeakers = 1 };
-			m_project.AddProjectCharacterDetail(detail);
-			m_project.SaveProjectCharacterDetailData();
+			m_pendingCharacterDetails[characterId] = detail;
 		}
 
 		private void OnSaveCurrentBook()
@@ -202,8 +207,18 @@ namespace Glyssen.Dialogs
 		{
 			m_currentCharacters = new HashSet<CharacterVerse>();
 			foreach (var block in CurrentReferenceTextMatchup.CorrelatedBlocks)
+			{
 				m_currentCharacters.UnionWith(GetUniqueCharacterVerseObjectsForBlock(block));
-			
+				if (m_pendingCharacterDetails.ContainsKey(block.CharacterId))
+				{
+					m_currentCharacters.Add(new CharacterVerse(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV,
+						block.CharacterId,
+						block.Delivery,
+						null,
+						true));
+				}
+			}
+
 			return GetUniqueCharacters(false);
 		}
 
@@ -488,6 +503,14 @@ namespace Glyssen.Dialogs
 
 		private void AddRecordToProjectCharacterVerseData(Block block, Character character, Delivery delivery)
 		{
+			CharacterDetail detail;
+			if (m_pendingCharacterDetails.TryGetValue(character.CharacterId, out detail))
+			{
+				m_project.AddProjectCharacterDetail(detail);
+				m_project.SaveProjectCharacterDetailData();
+				m_pendingCharacterDetails.Remove(detail.CharacterId);
+			}
+
 			var cv = new CharacterVerse(
 				new BCVRef(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV),
 				character.IsNarrator

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using Glyssen.Character;
 using SIL.Extensions;
+using SIL.Reporting;
 using SIL.Scripture;
 
 namespace Glyssen
@@ -21,6 +22,8 @@ namespace Glyssen
 
 		public static void MigrateProjectData(Project project, int fromControlFileVersion)
 		{
+			Logger.WriteEvent("Migrating project " + project.ProjectFilePath);
+
 			if (s_lastProjectMigrated != project)
 				s_migrationsRun = 0;
 

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -1101,6 +1101,100 @@ namespace GlyssenTests.Dialogs
 			Assert.IsTrue(m_model.CurrentBlock.ChapterNumber > 9);
 		}
 
+		[Test]
+		public void StoreCharacterDetail_CallTwiceWithSameCharacter_NotSavedInProject()
+		{
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			var reloadedProject = Project.Load(m_testProject.ProjectFilePath);
+			Assert.IsFalse(reloadedProject.AllCharacterDetailDictionary.ContainsKey("Larry"));
+		}
+
+		[Test]
+		public void GetUniqueCharacters_AfterAddingProjectSpecificCharacter_ListIncludesCharacter()
+		{
+			m_fullProjectRefreshRequired = true;
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			m_model.SetCharacterAndDelivery(new AssignCharacterViewModel.Character("Larry"),
+				AssignCharacterViewModel.Delivery.Normal);
+			Assert.IsTrue(m_model.GetUniqueCharacters("Larry").Any(c => c.CharacterId == "Larry"));
+		}
+
+		[Test]
+		public void StoreCharacterDetail_CallWithExistingCharacter_Throws()
+		{
+			m_fullProjectRefreshRequired = true;
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			m_model.SetCharacterAndDelivery(new AssignCharacterViewModel.Character("Larry"),
+				AssignCharacterViewModel.Delivery.Normal);
+			Assert.Throws<ArgumentException>(() =>
+			{
+				m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			});
+		}
+
+		[Test]
+		public void StoreCharacterDetail_CallWithExistingFactoryCharacter_Throws()
+		{
+			Assert.Throws<ArgumentException>(() =>
+			{
+				m_model.StoreCharacterDetail("Jesus", CharacterGender.Male, CharacterAge.Adult);
+			});
+		}
+
+		[Test]
+		public void SetCharacterAndDelivery_ProjectSpecificCharacter_CharacterDetailSavedInProject()
+		{
+			m_fullProjectRefreshRequired = true;
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			m_model.SetCharacterAndDelivery(new AssignCharacterViewModel.Character("Larry"),
+				AssignCharacterViewModel.Delivery.Normal);
+			var reloadedProject = Project.Load(m_testProject.ProjectFilePath);
+			Assert.IsTrue(reloadedProject.AllCharacterDetailDictionary.ContainsKey("Larry"));
+		}
+
+		[Test]
+		public void StoreCharacterDetail_CharacterDetailChangedBeforeSavingInProject_ChangedDetailsSaved()
+		{
+			m_fullProjectRefreshRequired = true;
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.Adult);
+			m_model.StoreCharacterDetail("Larry", CharacterGender.Male, CharacterAge.YoungAdult);
+			m_model.SetCharacterAndDelivery(new AssignCharacterViewModel.Character("Larry"),
+				AssignCharacterViewModel.Delivery.Normal);
+			var reloadedProject = Project.Load(m_testProject.ProjectFilePath);
+			Assert.AreEqual(CharacterAge.YoungAdult, reloadedProject.AllCharacterDetailDictionary["Larry"].Age);
+		}
+
+		[Test]
+		public void ApplyCurrentReferenceTextMatchup_TwoAddedCharacters_AddsBothToProject()
+		{
+			Assert.IsFalse(m_testProject.AllCharacterDetailDictionary.ContainsKey("Christ"));
+			Assert.IsFalse(m_testProject.AllCharacterDetailDictionary.ContainsKey("Thaddeus' wife"));
+
+			m_fullProjectRefreshRequired = true;
+			m_model.Mode = BlocksToDisplay.NeedAssignments;
+
+			FindRefInMark(8, 5);
+			m_model.AttemptRefBlockMatchup = true;
+			Assert.IsNotNull(m_model.CurrentReferenceTextMatchup);
+			m_model.StoreCharacterDetail("Christ", CharacterGender.Male, CharacterAge.Adult);
+			m_model.StoreCharacterDetail("Thaddeus' wife", CharacterGender.Female, CharacterAge.YoungAdult);
+			m_model.SetReferenceTextMatchupCharacter(1, new AssignCharacterViewModel.Character("Christ"));
+			m_model.SetReferenceTextMatchupCharacter(3, new AssignCharacterViewModel.Character("Thaddeus' wife"));
+
+			m_model.ApplyCurrentReferenceTextMatchup();
+
+			var reloadedProject = Project.Load(m_testProject.ProjectFilePath);
+
+			var christ = reloadedProject.AllCharacterDetailDictionary["Christ"];
+			Assert.AreEqual(CharacterAge.Adult, christ.Age);
+			Assert.AreEqual(CharacterGender.Male, christ.Gender);
+
+			var wife = reloadedProject.AllCharacterDetailDictionary["Thaddeus' wife"];
+			Assert.AreEqual(CharacterAge.YoungAdult, wife.Age);
+			Assert.AreEqual(CharacterGender.Female, wife.Gender);
+		}
+
 		private void FindRefInMark(int chapter, int verse)
 		{
 			while (m_model.CurrentBlock.ChapterNumber != chapter || m_model.CurrentBlock.InitialStartVerseNumber != verse)

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="BlockElementTests.cs" />
     <Compile Include="BlockMatchupTests.cs" />
     <Compile Include="BlockNavigatorTests.cs" />
+    <Compile Include="ProjectCharacterDetailDataTests.cs" />
     <Compile Include="BlockTests.cs" />
     <Compile Include="BookMetadataTests.cs" />
     <Compile Include="BookSetUtilsTests.cs" />

--- a/GlyssenTests/ProjectCharacterDetailDataTests.cs
+++ b/GlyssenTests/ProjectCharacterDetailDataTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Glyssen.Character;
+using NUnit.Framework;
+using SIL.IO;
+
+namespace GlyssenTests
+{
+	[TestFixture]
+	class ProjectCharacterDetailDataTests
+	{
+		[Test]
+		public void Load_Normal_AllLinesLoaded()
+		{
+			var data = new HashSet<CharacterDetail>();
+			data.Add(new CharacterDetail { CharacterId = "Fred", Age = CharacterAge.Adult, Gender = CharacterGender.Male, MaxSpeakers = 5 });
+			data.Add(new CharacterDetail { CharacterId = "Marta", Age = CharacterAge.Child, Gender = CharacterGender.Female, MaxSpeakers = 1 });
+			data.Add(new CharacterDetail { CharacterId = "the whole gang of bums", Age = CharacterAge.YoungAdult, Gender = CharacterGender.Either, MaxSpeakers = -1 });
+			using (TempFile tempFile = new TempFile())
+			{
+				ProjectCharacterDetailData.WriteToFile(data, tempFile.Path);
+				var detailData = ProjectCharacterDetailData.Load(tempFile.Path);
+				Assert.AreEqual(3, detailData.Count);
+				foreach (var characterDetail in detailData)
+				{
+					Assert.AreEqual(1, data.Count(cd =>
+						cd.CharacterId == characterDetail.CharacterId &&
+						cd.Age == characterDetail.Age &&
+						cd.Gender == characterDetail.Gender &&
+						cd.MaxSpeakers == characterDetail.MaxSpeakers));
+				}
+			}
+		}
+
+		/// <summary>
+		/// PG-903
+		/// </summary>
+		[Test]
+		public void Load_DuplicateCharacterIds_DuplicatesEliminated()
+		{
+			var data = new HashSet<CharacterDetail>();
+			data.Add(new CharacterDetail { CharacterId = "Fred", Age = CharacterAge.Adult, Gender = CharacterGender.Male, MaxSpeakers = 5 });
+			data.Add(new CharacterDetail { CharacterId = "Fred", Age = CharacterAge.Child, Gender = CharacterGender.Either, MaxSpeakers = 1 });
+			data.Add(new CharacterDetail { CharacterId = "the whole gang of bums", Age = CharacterAge.YoungAdult, Gender = CharacterGender.Either, MaxSpeakers = -1 });
+			using (TempFile tempFile = new TempFile())
+			{
+				ProjectCharacterDetailData.WriteToFile(data, tempFile.Path);
+				var detailData = ProjectCharacterDetailData.Load(tempFile.Path);
+				Assert.AreEqual(2, detailData.Count);
+				Assert.IsTrue(detailData.Any(cd =>
+					cd.CharacterId == "Fred" &&
+					cd.Age == CharacterAge.Child &&
+					cd.Gender == CharacterGender.Either &&
+					cd.MaxSpeakers == 1));
+				Assert.IsTrue(detailData.Any(cd => cd.CharacterId == "the whole gang of bums"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
file which made Glyssen crash when opening the project.  This change fixes AssignCharacterDlg and AssignCharacterView Model so duplicate CharacterID entries cannot happen.  Tests were added to verify that duplicates are not possible.  ProjectDataMigrator was also modified to remove duplicate CharacterID entries from a project while opening so corrupt projects from earlier versions could be opened and repaired.  Tests were added to verify that erroneous duplicate CharacterID entries are eliminated and project can open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/324)
<!-- Reviewable:end -->
