### PR TITLE
PG-909: Fixed crash caused by failing to find a block-block Indices…

### DIFF
--- a/Glyssen/BlockNavigator.cs
+++ b/Glyssen/BlockNavigator.cs
@@ -402,7 +402,7 @@ namespace Glyssen
 			}
 		}
 
-		public int EffectiveFinalBlockIndex => BlockIndex + (int)MultiBlockCount - 1;
+		public int EffectiveFinalBlockIndex => IsMultiBlock ? BlockIndex + (int)MultiBlockCount - 1 : BlockIndex;
 
 		public bool IsUndefined => BookIndex == -1 || BlockIndex == -1;
 

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -383,8 +383,13 @@ namespace Glyssen.Dialogs
 
 		private bool SetAsCurrentLocationIfRelevant(BookBlockIndices indices)
 		{
-			var i = m_relevantBookBlockIndices.IndexOf(indices);
-			if (i < 0)
+			int i;
+			for (i = 0; i < m_relevantBookBlockIndices.Count; i++)
+			{
+				if (m_relevantBookBlockIndices[i] == indices || m_relevantBookBlockIndices[i].Contains(indices))
+					break;
+			}
+			if (i == m_relevantBookBlockIndices.Count)
 				return false;
 			m_currentRelevantIndex = i;
 			m_temporarilyIncludedBookBlockIndices = null;

--- a/Glyssen/ProjectBase.cs
+++ b/Glyssen/ProjectBase.cs
@@ -18,7 +18,7 @@ namespace Glyssen
 		public static ScrVers LoadVersification(string vrsPath)
 		{
 			return Paratext.Versification.Table.Load(vrsPath, LocalizationManager.GetString("Project.DefaultCustomVersificationName",
-				"custom", "Used as the versification name when a the versification file does not contain a name."));
+				"custom", "Used as the versification name when the versification file does not contain a name."));
 		}
 
 		protected static string ProjectsBaseFolder

--- a/Glyssen/Resources/EnglishVersification.txt
+++ b/Glyssen/Resources/EnglishVersification.txt
@@ -1,4 +1,4 @@
-# Versification  "English"
+# Versification  "Sample"
 # Version=1.9
 #
 # modifications by Reinier de Blois 13/March/2012

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -249,6 +249,23 @@ namespace GlyssenTests.Dialogs
 			Assert.AreEqual(block1, m_model.CurrentBlock);
 		}
 
+		/// <summary>
+		/// PG-909
+		/// </summary>
+		[Test]
+		public void SetMode_SwitchFromNotAssignedAutomaticallyToNotAlignedWithReferenceText_CurrentMatchupIsRelevant_RelevantBlockIndicesSelected()
+		{
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAssignedAutomatically;
+			FindRefInMark(8, 5);
+			Assert.IsTrue(m_model.IsCurrentBlockRelevant);
+			var origMatchup = m_model.CurrentReferenceTextMatchup;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			Assert.IsTrue(m_model.IsCurrentBlockRelevant);
+			Assert.AreEqual(origMatchup.IndexOfStartBlockInBook, m_model.CurrentReferenceTextMatchup.IndexOfStartBlockInBook);
+			Assert.AreEqual(origMatchup.OriginalBlockCount, m_model.CurrentReferenceTextMatchup.OriginalBlockCount);
+		}
+
 		[Test]
 		public void BlockCountForCurrentBook_TestMrk_ReturnsTrue()
 		{


### PR DESCRIPTION
…object in the list of relevant blocks when it should have.

Also fixed some performance problems in unit tests by making the versification file used for the test projects (and sample) have a name other than English.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/328)
<!-- Reviewable:end -->
