### PR TITLE
PG-919: Made applying a block matchup that causes blocks to be inserted adjust the ...

### DIFF
--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -880,12 +880,25 @@ namespace Glyssen.Dialogs
 			// Insertions before the anchor block can mess up m_currentBlockIndex, so we need to reset it to point to the newly inserted
 			// block that corresponds to the "anchor" block. Since the "OriginalBlocks" is not a cloned copy of the "CorrelatedBlocks",
 			// We can safely use the index of the anchor block in CorrelatedBlocks to find the correct block in OriginalBlocks.
-			var originalAnchorBlock = m_currentRefBlockMatchups.OriginalBlocks.ElementAt(m_currentRefBlockMatchups.CorrelatedBlocks.IndexOf(m_currentRefBlockMatchups.CorrelatedAnchorBlock));
-			SetBlock(m_navigator.GetIndicesOfSpecificBlock(originalAnchorBlock), false);
+			if (!m_navigator.GetIndices().IsMultiBlock)
+			{
+				var originalAnchorBlock = m_currentRefBlockMatchups.OriginalBlocks.ElementAt(
+						m_currentRefBlockMatchups.CorrelatedBlocks.IndexOf(m_currentRefBlockMatchups.CorrelatedAnchorBlock));
+				SetBlock(m_navigator.GetIndicesOfSpecificBlock(originalAnchorBlock), false);
+			}
 			if (insertions > 0)
 			{
 				var currentBookIndex = m_navigator.GetIndices().BookIndex;
-				for (int i = insertionIndex + RelevantBlockCount - origRelevantBlockCount; i < RelevantBlockCount && m_relevantBookBlockIndices[i].BookIndex == currentBookIndex; i++)
+				var startIndex = insertionIndex + RelevantBlockCount - origRelevantBlockCount;
+				if (m_currentRelevantIndex >= 0 && m_navigator.GetIndices().IsMultiBlock)
+				{
+					// Since this "relevant passage" is a multi-block matchup (as opposed to a single block), rather than incrementing the
+					// BlockIndex, we want to extend the count. Otherwise, this will cease to be relevant, and when the user clicks
+					// the Previous button, they will no longer get the same blocks selected.
+					m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount += (uint) insertions;
+					startIndex++;
+				}
+				for (int i = startIndex; i < RelevantBlockCount && m_relevantBookBlockIndices[i].BookIndex == currentBookIndex; i++)
 					m_relevantBookBlockIndices[i].BlockIndex += insertions;
 			}
 		}

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -1389,6 +1389,7 @@ namespace GlyssenTests.Dialogs
 		[Test]
 		public void ApplyCurrentReferenceTextMatchup_RelevantMatchup_RemainsRelevant()
 		{
+			m_assigned = 0;
 			m_fullProjectRefreshRequired = true;
 			m_model.AttemptRefBlockMatchup = true;
 			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -1386,6 +1386,28 @@ namespace GlyssenTests.Dialogs
 			}
 		}
 
+		[Test]
+		public void ApplyCurrentReferenceTextMatchup_RelevantMatchup_RemainsRelevant()
+		{
+			m_fullProjectRefreshRequired = true;
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			var origRelevantBlockCount = m_model.RelevantBlockCount;
+			while (m_model.CurrentReferenceTextMatchup == null || m_model.CurrentReferenceTextMatchup.CountOfBlocksAddedBySplitting == 0 ||
+				!m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.All(
+				b => m_model.GetCharactersForCurrentReferenceTextMatchup().Any(c => c.CharacterId == b.CharacterId)))
+			{
+				m_model.LoadNextRelevantBlock();
+			}
+
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CountOfBlocksAddedBySplitting > 0);
+			m_model.ApplyCurrentReferenceTextMatchup();
+
+			Assert.AreEqual(origRelevantBlockCount, m_model.RelevantBlockCount);
+			Assert.AreEqual(1, m_assigned);
+			Assert.IsTrue(m_model.IsCurrentBlockRelevant);
+		}
+
 		private void FindRefInMark(int chapter, int verse)
 		{
 			while (m_model.CurrentBlock.ChapterNumber != chapter || m_model.CurrentBlock.InitialStartVerseNumber != verse)


### PR DESCRIPTION
collection of relevant blocks appropriately so that the current matchup remains relevant.  Added     ApplyCurrentReferenceTextMatchup_RelevantMatchup_RemainsRelevant test to AssignCharacterViewModelTests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/336)
<!-- Reviewable:end -->
