### PR TITLE
PG-923 Resolved crash issues in BlockNavigatorViewModel using Identify Speaking ...

### DIFF
--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -664,6 +664,7 @@ namespace Glyssen.Dialogs
 			var indices = m_navigator.GetIndicesOfFirstBlockAtReference(verseRef, AttemptRefBlockMatchup);
 			if (indices == null)
 				return false;
+
 			m_currentRelevantIndex = m_relevantBookBlockIndices.IndexOf(indices);
 			if (m_currentRelevantIndex < 0)
 			{
@@ -797,7 +798,16 @@ namespace Glyssen.Dialogs
 
 			m_currentRefBlockMatchups = m_project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(CurrentBook,
 				CurrentBlockIndexInBook, m_project.Versification, m_navigator.GetIndices().MultiBlockCount);
-			m_currentRefBlockMatchups?.MatchAllBlocks(m_project.Versification);
+			if (m_currentRefBlockMatchups != null)
+			{
+				m_currentRefBlockMatchups.MatchAllBlocks(m_project.Versification);
+				if (IsCurrentBlockRelevant && !m_navigator.GetIndices().IsMultiBlock && m_temporarilyIncludedBookBlockIndices != null)
+				{
+					m_navigator.ExtendCurrentBlockGroup((uint)CurrentReferenceTextMatchup.OriginalBlockCount);
+					m_temporarilyIncludedBookBlockIndices = null;
+					m_currentRelevantIndex = m_relevantBookBlockIndices.IndexOf(m_navigator.GetIndices());
+				}
+			}
 			if (origValue != m_currentRefBlockMatchups)
 				CurrentBlockMatchupChanged?.Invoke(this, new EventArgs());
 		}

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -854,6 +854,35 @@ namespace GlyssenTests.Dialogs
 		}
 
 		[Test]
+		public void TryLoadBlock_FromRelevantBlockToRelevantBlockInMatchup_RelevantBlockLoaded()
+		{
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			m_model.LoadNextRelevantBlock();
+
+			m_model.TryLoadBlock(m_model.GetBlockVerseRef());
+			Assert.IsTrue(m_model.CurrentBlockDisplayIndex > 0);
+		}
+
+		[Test]
+		public void TryLoadBlock_FromIrrelevantBlockToRelevantBlockInMatchup_RelevantBlockLoaded()
+		{
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			m_model.LoadNextRelevantBlock();
+			var targetRef = m_model.GetBlockVerseRef();
+
+			int v = 1;
+			while (m_model.IsCurrentBlockRelevant)
+			{
+				m_model.TryLoadBlock(new VerseRef(41, 1, v++));
+			}
+
+			m_model.TryLoadBlock(targetRef);
+			Assert.IsTrue(m_model.CurrentBlockDisplayIndex > 0);
+		}
+
+		[Test]
 		public void LoadNextRelevantBlock_FollowingInsertionOfBlockByApplyingMatchupWithSplits_LoadsARelevantBlock()
 		{
 			BlockNavigatorViewModelTests.FindRefInMark(m_model, 9, 21);


### PR DESCRIPTION
Parts with 'Verses not aligned with Reference Text' filter.  Added additional unit tests for TryLoadBlock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/337)
<!-- Reviewable:end -->
