### PR TITLE
PG-924: Fixed crash caused by incorrectly setting indices for a block…

### DIFF
--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -801,9 +801,14 @@ namespace Glyssen.Dialogs
 			if (m_currentRefBlockMatchups != null)
 			{
 				m_currentRefBlockMatchups.MatchAllBlocks(m_project.Versification);
-				if (IsCurrentBlockRelevant && !m_navigator.GetIndices().IsMultiBlock && m_temporarilyIncludedBookBlockIndices != null)
+				// We might have gotten here by ad-hoc navigation (clicking or using the Verse Reference control). If we're using a filter
+				// that holds *groups* of relevant blocks (rather than individual ones) and the new current block is in one of those groups
+				// (i.e., it is relevant), we need to set indices based on the group rather than the individual block. Otherwise, we'll lose
+				// track of our place in the list (which not only affects the display index but also can lead to crashes, such as PG-924)
+				// later when we try to go to the previous or next relevant passage).
+				if (IsCurrentBlockRelevant && m_temporarilyIncludedBookBlockIndices != null && !m_navigator.GetIndices().IsMultiBlock && m_relevantBookBlockIndices.Any(i => i.IsMultiBlock))
 				{
-					m_navigator.ExtendCurrentBlockGroup((uint)CurrentReferenceTextMatchup.OriginalBlockCount);
+					m_navigator.SetIndices(new BookBlockIndices(m_navigator.GetIndices().BookIndex, m_currentRefBlockMatchups.IndexOfStartBlockInBook, (uint)m_currentRefBlockMatchups.OriginalBlockCount));
 					m_temporarilyIncludedBookBlockIndices = null;
 					m_currentRelevantIndex = m_relevantBookBlockIndices.IndexOf(m_navigator.GetIndices());
 				}

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -521,6 +521,34 @@ namespace GlyssenTests.Dialogs
 			Assert.AreEqual(expectedBlock, m_model.CurrentBlock);
 		}
 
+
+		/// <summary>
+		/// PG-924
+		/// </summary>
+		[Test]
+		public void SetCurrentBlockIndexInBook_CurrentBlockIsNotTheFirstBlockOfRelevantMatchup_CurrentBlockRelevantAndDisplayIndexIsCorrect()
+		{
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.LoadNextRelevantBlock();
+			var followingMatchup = m_model.CurrentReferenceTextMatchup;
+			Assert.IsNotNull(followingMatchup);
+			Assert.IsTrue(m_model.IsCurrentBlockRelevant);
+			var origDisplayIndex = m_model.CurrentBlockDisplayIndex;
+			m_model.CurrentBlockIndexInBook = followingMatchup.IndexOfStartBlockInBook + followingMatchup.OriginalBlockCount + followingMatchup.CountOfBlocksAddedBySplitting;
+			Assert.AreNotEqual(followingMatchup, m_model.CurrentReferenceTextMatchup);
+
+			var precedingMatchup = m_model.CurrentReferenceTextMatchup;
+			Assert.IsNotNull(precedingMatchup);
+
+			m_model.CurrentBlockIndexInBook = m_model.CurrentReferenceTextMatchup.IndexOfStartBlockInBook - 1;
+
+			Assert.IsTrue(m_model.IsCurrentBlockRelevant);
+			Assert.AreEqual(origDisplayIndex, m_model.CurrentBlockDisplayIndex);
+			m_model.LoadNextRelevantBlock();
+			Assert.AreEqual(origDisplayIndex + 1, m_model.CurrentBlockDisplayIndex);
+		}
+
 		[Test]
 		public void SetCurrentBlockIndexInBook_BlockFollowsCurrentMatchup_StateReflectsCorrectBlock()
 		{


### PR DESCRIPTION
… that is not the first block in a matchup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/344)
<!-- Reviewable:end -->
