### PR TITLE
PG-925 Changed Project.ClearAssignCharacterStatus().  

### DIFF
--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -695,7 +695,7 @@ namespace Glyssen
 
 		internal void ClearAssignCharacterStatus()
 		{
-			Status.AssignCharacterMode = BlocksToDisplay.NotYetAssigned;
+			Status.AssignCharacterMode = BlocksToDisplay.NotAlignedToReferenceText;
 			Status.AssignCharacterBlock = new BookBlockIndices();
 		}
 


### PR DESCRIPTION
Initializes Status.AssignCharacterMode = BlocksToDisplay.NotAllignedToReferenceText instead of NotYetAssigned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/346)
<!-- Reviewable:end -->
