### PR TITLE
PG-897 A different approach to m_dataGridReferenceText_CellEnter() 

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1465,9 +1465,18 @@ namespace Glyssen.Dialogs
 		{
 			if (e.ColumnIndex != colEnglish.Index && e.ColumnIndex != colPrimary.Index)
 				return;
+
 			if (m_dataGridReferenceText.CurrentCellAddress.Y < 0 || (!Focused && (m_dataGridReferenceText.EditingControl == null || !m_dataGridReferenceText.EditingControl.Focused)))
 			{
-				var minHeight = m_dataGridReferenceText.RowTemplate.Height * 3;
+				// Leave Height unchanged for cell with existing text
+				if (!m_dataGridReferenceText.CurrentCell.Value.Equals(""))
+					return;
+
+				// PG-897 For empty reference text cell, adjust Height based on contents of the clipboard
+				m_dataGridReferenceText.CurrentCell.Value = Clipboard.GetText();
+				var minHeight = m_dataGridReferenceText.Rows[e.RowIndex].Height;
+				m_dataGridReferenceText.CurrentCell.Value = "";
+				
 				if (m_dataGridReferenceText.CurrentRow != null && m_dataGridReferenceText.CurrentRow.Height < minHeight)
 					m_dataGridReferenceText.CurrentRow.MinimumHeight = minHeight;
 			}


### PR DESCRIPTION
to use DataGridViewCell.MeasureTextHeight() recommended by Tom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/347)
<!-- Reviewable:end -->
