### PR TITLE
PG-942 Successfully installs Glyssen when .NET Framework 4.6.1 is installed.

### DIFF
--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -45,10 +45,10 @@ users to install just the shortcut for your app, then demand-install the
 rest of the app the first time the icon is run.  If this is not behavior you
 are trying to support, you're better off using non-advertised shortcuts. "-->
 
-    <PropertyRef Id="NETFRAMEWORK45" />
-    <Condition Message="Before Glyssen can install on older computers, you need to install Microsoft's free .NET Framework 4.5.">
-      Installed OR NETFRAMEWORK45
-    </Condition>
+	<PropertyRef Id="NETFRAMEWORK45"/>
+	<Condition Message="Glyssen requires .NET Framework 4.6.1 or later.  You need to install Microsoft's free .NET Framework then run this installer again.">
+    <![CDATA[Installed OR (NETFRAMEWORK45 >= "#394254")]]>
+	</Condition>
 
     <!--because of bug, this needs to be 1 -->
     <Property Id ="ALLUSERS">1</Property>

--- a/build/TestInstallerBuild.bat
+++ b/build/TestInstallerBuild.bat
@@ -1,7 +1,7 @@
-call "c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat"
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"
 
 pushd .
-MSbuild /target:installer /property:teamcity_build_checkoutDir=..\ /property:Configuration="Release" /property:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /property:BUILD_NUMBER="*.*.0.001" /property:Minor="17"
+MSbuild /target:installer /property:teamcity_build_checkoutDir=..\ /property:Configuration="Release" /property:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /property:BUILD_NUMBER="*.*.0.001" /property:Minor="18"
 popd
 PAUSE
 


### PR DESCRIPTION
Pops up notice that it requires 4.6.1 in order to install Glyssen when 4.6 or earlier is installed or .NET Framework is not installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/349)
<!-- Reviewable:end -->
