### PR TITLE
Prevented crash when empty ScriptText Content is deserialized as a null.

### DIFF
--- a/Glyssen/BlockElement.cs
+++ b/Glyssen/BlockElement.cs
@@ -57,6 +57,8 @@ namespace Glyssen
 	public class ScriptText : BlockElement
 	{
 		private static readonly Regex s_startsWithEllipsis = new Regex(@"^(\u2026|(\.\.\.))", RegexOptions.Compiled);
+		private string m_content;
+
 		public ScriptText()
 		{
 			// Needed for deserialization
@@ -68,7 +70,11 @@ namespace Glyssen
 		}
 
 		[XmlText]
-		public string Content { get; set; }
+		public string Content
+		{
+			get { return m_content ?? String.Empty; }
+			set { m_content = value; }
+		}
 
 		public bool StartsWithEllipsis => s_startsWithEllipsis.IsMatch(Content);
 

--- a/Glyssen/ProjectExporter.cs
+++ b/Glyssen/ProjectExporter.cs
@@ -762,6 +762,7 @@ namespace Glyssen
 				Empty : " ";
 			return annotationInfo + separator + text;
 		}
+
 		private bool HasReferenceText(List<object> dataRow)
 		{
 			return !IsNullOrEmpty((string)dataRow[GetColumnIndex(ExportColumn.PrimaryReferenceText)]);


### PR DESCRIPTION
This ended up not having anything to do with PG-955, which was a duplicate of the already-fixed PG-905, but I also added another test for that, and I decided to keep it because it seems to be testing an additional useful case (primary reftext has only a verse number and secondary reftext is an empty string.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/357)
<!-- Reviewable:end -->
