### PR TITLE
PG-962: Made single-voice books export nicely, aligned to the reference text.

### DIFF
--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -204,7 +204,7 @@ namespace Glyssen
 			if (MakesSplits(referenceBook, bookNum, Versification, verseSplitLocationsBasedOnVern, LanguageName, "vernacular"))
 				m_modifiedBooks.Add(referenceBook.BookId);
 
-			MatchVernBlocksToReferenceTextBlocks(vernacularBook.GetScriptBlocks(), vernacularBook.BookId, vernacularVersification);
+			MatchVernBlocksToReferenceTextBlocks(vernacularBook.GetScriptBlocks(), vernacularBook.BookId, vernacularVersification, vernacularBook.SingleVoice);
 		}
 
 		public bool CanDisplayReferenceTextForBook(BookScript vernacularBook)
@@ -243,7 +243,7 @@ namespace Glyssen
 			return matchup;
 		}
 
-		private void MatchVernBlocksToReferenceTextBlocks(IReadOnlyList<Block> vernBlockList, string bookId, ScrVers vernacularVersification)
+		private void MatchVernBlocksToReferenceTextBlocks(IReadOnlyList<Block> vernBlockList, string bookId, ScrVers vernacularVersification, bool forceMatch = false)
 		{
 			int bookNum = BCVRef.BookToNumber(bookId);
 			var refBook = Books.Single(b => b.BookId == bookId);
@@ -400,11 +400,21 @@ namespace Glyssen
 						}
 						else
 						{
-							vernBlockList[iVernBlock].MatchesReferenceText = false;
-							vernBlockList[iVernBlock].ReferenceBlocks = remainingRefBlocks.ToList();
+							var remainingRefBlocksList = remainingRefBlocks.ToList();
+							if (forceMatch)
+							{
+								var refBlock = remainingRefBlocksList[0];
+								for (int rb = 1; rb < remainingRefBlocksList.Count; rb++)
+									refBlock.CombineWith(remainingRefBlocksList[rb]);
+								vernBlockList[iVernBlock].SetMatchedReferenceBlock(refBlock);
+							}
+							else
+							{
+								vernBlockList[iVernBlock].MatchesReferenceText = false;
+								vernBlockList[iVernBlock].ReferenceBlocks = remainingRefBlocksList;
+							}
 							iRefBlock = indexOfRefVerseStart + numberOfRefBlocksInVerseChunk - 1;
 						}
-
 						break;
 					}
 				}

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -2595,6 +2595,28 @@ namespace GlyssenTests
 			Assert.AreEqual(0, matchup.CorrelatedBlocks[1].ReferenceBlocks.Count);
 		}
 
+		[Test]
+		public void GetBlocksForVerseMatchedToReferenceText_VernBlockHasLeadingSquareBracket_BlockIsNotSplitBetweenBracketAndVerseNumber()
+		{
+			var vernacularBlocks = new List<Block> {
+				CreateNarratorBlockForVerse(8, "Ci mon gukatti woko ki i lyel, gucako ŋwec ki myelkom pi lworo ma omakogi matek twatwal; lworo ogeŋogi tito lokke ki ŋatti mo. ", true, 16, "MRK"),
+				CreateNarratorBlockForVerse(9, "Ka en doŋ ocer odiko con i nino mukwoŋo me cabit, okwoŋo nyutte bot Maliam Lamagdala, ma yam en oryemo cen abiro i kome-ni. ", true, 16, "MRK")
+				.AddVerse(10, "En otugi tero lok bot jo ma yam gibedo kwede, i kare ma gitye ki cola ki kumu-gu. ").AddVerse(11, "Ka guwinyo ni en tye gire makwo, dok ni otyeko nyutte, kome onen bot Maliam, pe guye lokke. "),
+			};
+			vernacularBlocks.Last().BlockElements.Insert(0, new ScriptText("["));
+			var vernBook = new BookScript("MRK", vernacularBlocks);
+
+			var refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 1, m_vernVersification);
+			Assert.AreEqual(3, matchup.CorrelatedBlocks.Count);
+			var firstCorrelatedBlock = matchup.CorrelatedBlocks.First();
+			Assert.AreEqual(3, firstCorrelatedBlock.BlockElements.Count);
+			Assert.AreEqual("[", ((ScriptText)firstCorrelatedBlock.BlockElements[0]).Content);
+			Assert.AreEqual("9", ((Verse)firstCorrelatedBlock.BlockElements[1]).Number);
+			Assert.IsTrue(((ScriptText)firstCorrelatedBlock.BlockElements[2]).Content.StartsWith("Ka en doŋ"));
+		}
+
 		#region private helper methods
 		internal static Block CreateBlockForVerse(string characterId, int initialStartVerseNumber, string text, bool paraStart = false,
 			int chapter = 1, string styleTag = "p", int initialEndVerseNumber = 0)


### PR DESCRIPTION
Also included a little fix that was causing an incorrect block break between a leading open bracket and the actual verse number for disputed passages (e.g., MRK 16:9)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/380)
<!-- Reviewable:end -->
