### PR TITLE
PG-981: Prevented null object reference exception when opening a new project

### DIFF
--- a/Glyssen/Controls/ScriptBlocksViewer.cs
+++ b/Glyssen/Controls/ScriptBlocksViewer.cs
@@ -81,6 +81,11 @@ namespace Glyssen.Controls
 			m_dataGridViewBlocks.Dock = DockStyle.Fill;
 
 			Disposed += ScriptBlocksViewer_Disposed;
+		}
+
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
 
 			m_viewModel.CurrentBlockChanged += UpdateContextBlocksDisplay;
 			m_viewModel.CurrentBlockMatchupChanged += UpdateContextBlocksDisplay;

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -190,7 +190,7 @@ namespace Glyssen
 				m_imgCheckAssignCharacters.Visible = true;
 				m_imgCheckAssignCharacters.Image = Resources.Alert;
 			}
-			else
+			else if (m_btnIdentify.Enabled)
 				m_imgCheckAssignCharacters.Image = m_project.ProjectAnalysis.AlignmentPercent == 100 ? Resources.green_check : Resources.yellow_check;
 			m_btnExport.Enabled = !readOnly && m_btnIdentify.Enabled;
 


### PR DESCRIPTION
This was caused by trying to calculate alignment percentage on a project that hasn't yet been parsed)
Also fixed a crash caused by trying to invoke on the UI thread before the ScriptBlocksViewer handle is created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/388)
<!-- Reviewable:end -->
