### PR TITLE
PG-982: Fix logic to prevent crash in BreakOutInterruptionsFromWorkingBlock

### DIFF
--- a/Glyssen/Quote/QuoteParser.cs
+++ b/Glyssen/Quote/QuoteParser.cs
@@ -733,7 +733,7 @@ namespace Glyssen.Quote
 			{
 				m_workingBlock = blocks.SplitBlock(blocks.GetScriptBlocks().Last(), nextInterruption.Item2, nextInterruption.Item1.Index, false);
 				var startCharIndex = nextInterruption.Item1.Length;
-				if (((ScriptText)m_workingBlock.BlockElements.Last()).Content.Substring(nextInterruption.Item1.Length).Any(IsLetter))
+				if (m_workingBlock.GetText(true).Substring(nextInterruption.Item1.Length).Any(IsLetter))
 				{
 					m_workingBlock = blocks.SplitBlock(blocks.GetScriptBlocks().Last(), nextInterruption.Item2, nextInterruption.Item1.Length, false);
 					startCharIndex = 0;


### PR DESCRIPTION
Crash was caused by incorrectly using length of previous interruption to get substring of last block element, whose length may be too short.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/389)
<!-- Reviewable:end -->
