### PR TITLE
PG-969 (duplicates: PG-970, PG-991, PG-992): Fixed crash caused by leaving Apply button enabled…

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1236,7 +1236,10 @@ namespace Glyssen.Dialogs
 		private void m_btnApplyReferenceTextMatches_Click(object sender, EventArgs e)
 		{
 			if (CheckRefTextValuesAndApplyMatchup())
+			{
+				m_btnApplyReferenceTextMatches.Enabled = false;
 				MoveOn();
+			}
 		}
 
 		private bool CheckRefTextValuesAndApplyMatchup()

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -12997,8 +12997,8 @@ MRK	8	12	Jesus	exasperated		Normal
 MRK	8	15	Jesus	warning		Dialogue		
 MRK	8	16	disciples	defensive		Normal		
 MRK	8	17	Jesus	rebuking		Dialogue		
-MRK	8	18	Jesus			Normal		
-MRK	8	19	Jesus			Normal		
+MRK	8	18	Jesus	rebuking		Normal		
+MRK	8	19	Jesus	rebuking		Normal		
 MRK	8	19	disciples	hesitant		Dialogue		
 MRK	8	20	disciples			Dialogue		
 MRK	8	20	Jesus	questioning		Dialogue		


### PR DESCRIPTION
… when last group is aligned and user stays in ISP dialog box (or clicks twice).
Also, added some missing deliveries to prevent Glyssen having to add project-specific deliveries when "rebuking" delivery is applied to entire quote. (It was only present in control file for the first verse of the quote.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/390)
<!-- Reviewable:end -->
