### PR TITLE
PG-1017: Prevent over-agressive detection of interruptions

### DIFF
--- a/Glyssen/Quote/QuoteParser.cs
+++ b/Glyssen/Quote/QuoteParser.cs
@@ -48,6 +48,7 @@ namespace Glyssen.Quote
 		public static void SetQuoteSystem(QuoteSystem quoteSystem)
 		{
 			s_quoteSystem = quoteSystem;
+			Block.InitializeInterruptionRegEx(quoteSystem.QuotationDashMarker != null && quoteSystem.QuotationDashMarker.Any(c => c == '\u2014' || c == '\u2015'));
 		}
 
 		private readonly ICharacterVerseInfo m_cvInfo;
@@ -735,7 +736,7 @@ namespace Glyssen.Quote
 				if (m_workingBlock.GetText(true).Substring(nextInterruption.Item1.Length).Any(IsLetter))
 				{
 					m_workingBlock = blocks.SplitBlock(blocks.GetScriptBlocks().Last(), nextInterruption.Item2, nextInterruption.Item1.Length, false);
-					startCharIndex = 0;
+					startCharIndex = 1;
 				}
 				nextInterruption = m_workingBlock.GetNextInterruption(startCharIndex);
 			}

--- a/GlyssenTests/Resources/TestCharacterVerse.txt
+++ b/GlyssenTests/Resources/TestCharacterVerse.txt
@@ -9216,8 +9216,9 @@ JHN	1	38	Jesus	questioning		Dialogue
 JHN	1	38	narrator-JHN			Quotation		
 JHN	1	38	narrator-JHN			Interruption		
 JHN	1	39	Jesus			Dialogue
-JHN	1	41	Andrew	excited		Dialogue
-JHN	1	41	narrator-JHN			Dialogue
+JHN	1	41	Andrew	excited		Dialogue		
+JHN	1	41	narrator-JHN			Quotation		
+JHN	1	41	narrator-JHN			Interruption	
 JHN	1	42	Jesus			Dialogue		
 JHN	1	42	narrator-JHN			Quotation		
 JHN	1	42	narrator-JHN			Interruption		


### PR DESCRIPTION
 (particularly when using dialogue quotes) that cause cause a crash from trying to split a block at the very beginning).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/394)
<!-- Reviewable:end -->
