### PR TITLE
PG-1017: Prevent over-aggressive detection of interruptions

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -32,7 +32,7 @@ namespace Glyssen
 						".scripttext {{display:inline}}";
 
 		private static readonly Regex s_regexFollowOnParagraphStyles;
-		internal static readonly Regex s_regexInterruption;
+		internal static Regex s_regexInterruption;
 
 		public static Func<string /* Book ID */, int /*Chapter Number*/, string> FormatChapterAnnouncement;
 
@@ -61,9 +61,21 @@ namespace Glyssen
 			s_emptyVerseText = new Regex("^ *(?<verseWithWhitespace>" + kRegexForVerseNumber + kRegexForWhitespaceFollowingVerseNumber + @")? *$",
 				RegexOptions.Compiled);
 			s_regexFollowOnParagraphStyles = new Regex("^((q.{0,2})|m|mi|(pi.?))$", RegexOptions.Compiled);
+			InitializeInterruptionRegEx(false);
+		}
+
+		internal static void InitializeInterruptionRegEx(bool excludeLongDashes)
+		{
 			var dashStyleInterruptionFmt = @"|({0}[^{0}]*\w+[^{0}]*{0})";
-			s_regexInterruption = new Regex(@"((\([^)\]]\w+[^)\]]+\))|(\[[^)\]]\w+[^)\]]+\])" + Format(dashStyleInterruptionFmt, "-") +
-				Format(dashStyleInterruptionFmt, "\u2014") + Format(dashStyleInterruptionFmt + @")[^\w]*", "\u2015"), RegexOptions.Compiled);
+			StringBuilder pattern = new StringBuilder(@"((\([^)\]]\w+[^)\]]+\))|(\[[^)\]]\w+[^)\]]+\])");
+			pattern.AppendFormat(dashStyleInterruptionFmt, "-");
+			if (!excludeLongDashes)
+			{
+				pattern.AppendFormat(dashStyleInterruptionFmt, "\u2014");
+				pattern.AppendFormat(dashStyleInterruptionFmt, "\u2015");
+			}
+			pattern.Append(@")[^\w]*");
+			s_regexInterruption = new Regex(pattern.ToString(), RegexOptions.Compiled);
 		}
 
 		internal Block()
@@ -1193,7 +1205,7 @@ namespace Glyssen
 			return true;
 		}
 
-		public Tuple<Match, string> GetNextInterruption(int startCharIndex = 0)
+		public Tuple<Match, string> GetNextInterruption(int startCharIndex = 1)
 		{
 			var verse = InitialVerseNumberOrBridge;
 			foreach (var element in BlockElements)
@@ -1204,7 +1216,7 @@ namespace Glyssen
 					var match = Block.s_regexInterruption.Match(text.Content, startCharIndex);
 					if (match.Success)
 						return new Tuple<Match, string>(match, verse);
-					startCharIndex = 0;
+					startCharIndex = 1;
 				}
 				else
 				{

--- a/Glyssen/Quote/QuoteParser.cs
+++ b/Glyssen/Quote/QuoteParser.cs
@@ -49,6 +49,7 @@ namespace Glyssen.Quote
 		public static void SetQuoteSystem(QuoteSystem quoteSystem)
 		{
 			s_quoteSystem = quoteSystem;
+			Block.InitializeInterruptionRegEx(quoteSystem.QuotationDashMarker != null && quoteSystem.QuotationDashMarker.Any(c => c == '\u2014' || c == '\u2015'));
 		}
 
 		private readonly ICharacterVerseInfo m_cvInfo;
@@ -736,7 +737,7 @@ namespace Glyssen.Quote
 				if (m_workingBlock.GetText(true).Substring(nextInterruption.Item1.Length).Any(IsLetter))
 				{
 					m_workingBlock = blocks.SplitBlock(blocks.GetScriptBlocks().Last(), nextInterruption.Item2, nextInterruption.Item1.Length, false);
-					startCharIndex = 0;
+					startCharIndex = 1;
 				}
 				nextInterruption = m_workingBlock.GetNextInterruption(startCharIndex);
 			}

--- a/GlyssenTests/Resources/TestCharacterVerse.txt
+++ b/GlyssenTests/Resources/TestCharacterVerse.txt
@@ -9216,8 +9216,9 @@ JHN	1	38	Jesus	questioning		Dialogue
 JHN	1	38	narrator-JHN			Quotation		
 JHN	1	38	narrator-JHN			Interruption		
 JHN	1	39	Jesus			Dialogue
-JHN	1	41	Andrew	excited		Dialogue
-JHN	1	41	narrator-JHN			Dialogue
+JHN	1	41	Andrew	excited		Dialogue		
+JHN	1	41	narrator-JHN			Quotation		
+JHN	1	41	narrator-JHN			Interruption	
 JHN	1	42	Jesus			Dialogue		
 JHN	1	42	narrator-JHN			Quotation		
 JHN	1	42	narrator-JHN			Interruption		


### PR DESCRIPTION
(particularly when using dialogue quotes) that cause cause a crash from trying to split a block at the very beginning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/395)
<!-- Reviewable:end -->
