### PR TITLE
Fixed splitting problem caused by characters in data that get encoded (e.g., &nbsp;) in HTML.

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -579,13 +579,11 @@ namespace Glyssen
 							var offsetToInsertExtra = blockSplit.CharacterOffsetToSplit;
 							if (blockSplit.VerseToSplit == currVerse)
 							{
-								if (offsetToInsertExtra == BookScript.kSplitAtEndOfVerse)
+								if (offsetToInsertExtra == PortionScript.kSplitAtEndOfVerse)
 									offsetToInsertExtra = preEncodedContent.Length;
 								if (offsetToInsertExtra < 0 || offsetToInsertExtra > preEncodedContent.Length)
 								{
-									// ReSharper disable once NotResolvedInText
-									throw new ArgumentOutOfRangeException("offsetToInsertExtra", offsetToInsertExtra,
-										@"Value must be greater than or equal to 0 and less than or equal to the length (" + preEncodedContent.Length +
+									throw new IndexOutOfRangeException(@"Value of offsetToInsertExtra must be greater than or equal to 0 and less than or equal to the length (" + preEncodedContent.Length +
 										@") of the encoded content of verse " + currVerse);
 								}
 								allContentToInsert.Insert(0, BuildSplitLineHtml(blockSplit.Id) + (showCharacters ? CharacterSelect(blockSplit.Id) : ""));

--- a/Glyssen/Dialogs/SplitBlockDlg.cs
+++ b/Glyssen/Dialogs/SplitBlockDlg.cs
@@ -10,6 +10,7 @@ using Gecko;
 using Gecko.DOM;
 using Glyssen.Properties;
 using Glyssen.Utilities;
+using SIL.Reporting;
 
 namespace Glyssen.Dialogs
 {
@@ -122,9 +123,19 @@ namespace Glyssen.Dialogs
 				}
 				else if (DetermineSplitLocation(geckoElement))
 				{
-					SetHtml();
-					m_btnOk.Enabled = true;
-					m_lblInvalidSplitLocation.Visible = false;
+					try
+					{
+						SetHtml();
+						m_btnOk.Enabled = true;
+						m_lblInvalidSplitLocation.Visible = false;
+					}
+					catch (Exception exception)
+					{
+						m_lblInvalidSplitLocation.Visible = true;
+						Logger.WriteError(exception);
+						m_splitLocations.Remove(m_splitLocations.Last());
+					}
+
 				}
 				else
 					m_lblInvalidSplitLocation.Visible = true;
@@ -288,7 +299,9 @@ namespace Glyssen.Dialogs
 					if (previousElement.GetAttribute("data-verse") != verseToSplit)
 						break;
 
-					sb.Append(m_verseNumberRegex.Replace(previousElement.InnerHtml, ""));
+					var textWithoutVerseNumbers = m_verseNumberRegex.Replace(previousElement.InnerHtml, "");
+					var unencodedText = System.Web.HttpUtility.HtmlDecode(textWithoutVerseNumbers);
+					sb.Append(unencodedText);
 				}
 				previousElement = previousElement.PreviousSibling as GeckoHtmlElement;
 			}

--- a/GlyssenTests/BlockTests.cs
+++ b/GlyssenTests/BlockTests.cs
@@ -552,11 +552,11 @@ namespace GlyssenTests
 		}
 
 		[Test]
-		public void GetSplitTextAsHtml_OffsetTooHigh_ThrowsArgumentOutOfRangeException()
+		public void GetSplitTextAsHtml_OffsetTooHigh_ThrowsIndexOutOfRangeException()
 		{
 			var block = new Block("p", 4, 3);
 			block.BlockElements.Add(new ScriptText("Text"));
-			Assert.Throws<ArgumentOutOfRangeException>(
+			Assert.Throws<IndexOutOfRangeException>(
 				() => block.GetSplitTextAsHtml(0, false, new[] {new BlockSplitData(1, block, "3", 5)}, false));
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/403)
<!-- Reviewable:end -->
