### PR TITLE
Fix Split Dialog such that it always loads blocks corresponding to the selected quote

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1140,7 +1140,17 @@ namespace Glyssen.Dialogs
 				}
 
 				var matchup = m_viewModel.CurrentReferenceTextMatchup;
-				blockToSplit = matchup.GetCorrespondingOriginalBlock(matchup.CorrelatedBlocks[m_dataGridReferenceText.CurrentCellAddress.Y]);
+				var rowIndex = m_dataGridReferenceText.CurrentCellAddress.Y;
+				blockToSplit = matchup.GetCorrespondingOriginalBlock(matchup.CorrelatedBlocks[rowIndex]);
+				while (blockToSplit.IsContinuationOfPreviousBlockQuote)
+				{
+					if (rowIndex > 0)
+						blockToSplit = matchup.GetCorrespondingOriginalBlock(matchup.CorrelatedBlocks[--rowIndex]);
+					else
+					{
+						blockToSplit = m_viewModel.BlockAccessor.GetNthPreviousBlockWithinBook(1, blockToSplit);
+					}
+				}
 			}
 			else
 				blockToSplit = m_viewModel.CurrentBlock;

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -324,6 +324,7 @@
     <Compile Include="Dialogs\NarrationOptionsDlg.Designer.cs">
       <DependentUpon>NarrationOptionsDlg.cs</DependentUpon>
     </Compile>
+    <Compile Include="IBlockAccessor.cs" />
     <Compile Include="PortionScript.cs" />
     <Compile Include="ProjectBase.cs" />
     <Compile Include="ProjectDataMigrator.cs" />

--- a/Glyssen/IBlockAccessor.cs
+++ b/Glyssen/IBlockAccessor.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using SIL.Scripture;
+
+namespace Glyssen
+{
+	public interface IBlockAccessor
+	{
+		BookScript CurrentBook { get; }
+		Block CurrentBlock { get; }
+		Block CurrentEndBlock { get; }
+		BookBlockIndices GetIndices();
+		BookBlockIndices GetIndicesOfSpecificBlock(Block block);
+		BookBlockIndices GetIndicesOfFirstBlockAtReference(VerseRef verseRef, bool allowMidQuoteBlock = false);
+		BookScript GetBookScriptContainingBlock(Block block);
+		bool IsLastBook(BookScript book);
+		bool IsLastBlock();
+		bool IsLastBlockInBook(BookScript book, Block block);
+		bool IsFirstBook(BookScript book);
+		bool IsFirstBlock(Block block);
+		bool IsFirstBlockInBook(BookScript book, Block block);
+		Block GetNextBlock();
+		IEnumerable<Block> GetNextNBlocksWithinBook(int numberOfBlocks);
+		Block GetNthNextBlockWithinBook(int n);
+		Block GetNthNextBlockWithinBook(int n, Block baseLineBlock);
+		IEnumerable<Block> GetPreviousNBlocksWithinBook(int numberOfBlocks);
+		IEnumerable<Block> GetPreviousBlocksWithinBookWhile(Func<Block, bool> predicate);
+		IEnumerable<Block> GetNextBlocksWithinBookWhile(Func<Block, bool> predicate);
+		Block GetNthPreviousBlockWithinBook(int n);
+		Block GetNthPreviousBlockWithinBook(int n, Block baseLineBlock);
+		Block GetPreviousBlock();
+	}
+}

--- a/GlyssenTests/BlockNavigatorTests.cs
+++ b/GlyssenTests/BlockNavigatorTests.cs
@@ -177,7 +177,7 @@ namespace GlyssenTests
 			var firstBlock = firstBook[0];
 			var secondBlock = firstBook[1];
 			m_navigator.CurrentBlock = firstBlock;
-			Assert.AreEqual(secondBlock, m_navigator.NextBlock());
+			Assert.AreEqual(secondBlock, m_navigator.GoToNextBlock());
 		}
 
 		[Test]
@@ -188,7 +188,7 @@ namespace GlyssenTests
 			var secondBook = m_books[1];
 			var firstBlock = secondBook[0];
 			m_navigator.CurrentBlock = lastBlock;
-			Assert.AreEqual(firstBlock, m_navigator.NextBlock());
+			Assert.AreEqual(firstBlock, m_navigator.GoToNextBlock());
 		}
 
 		[Test]
@@ -200,7 +200,7 @@ namespace GlyssenTests
 			m_navigator.CurrentBlock = firstBlock;
 			BookScript currentBook = m_navigator.CurrentBook;
 			Block currentBlock = m_navigator.CurrentBlock;
-			Assert.AreEqual(secondBlock, m_navigator.PeekNextBlock());
+			Assert.AreEqual(secondBlock, m_navigator.GetNextBlock());
 			Assert.AreEqual(currentBlock, m_navigator.CurrentBlock);
 			Assert.AreEqual(currentBook, m_navigator.CurrentBook);
 		}
@@ -215,7 +215,7 @@ namespace GlyssenTests
 			m_navigator.CurrentBlock = lastBlock;
 			BookScript currentBook = m_navigator.CurrentBook;
 			Block currentBlock = m_navigator.CurrentBlock;
-			Assert.AreEqual(firstBlock, m_navigator.PeekNextBlock());
+			Assert.AreEqual(firstBlock, m_navigator.GetNextBlock());
 			Assert.AreEqual(currentBlock, m_navigator.CurrentBlock);
 			Assert.AreEqual(currentBook, m_navigator.CurrentBook);
 		}
@@ -226,7 +226,7 @@ namespace GlyssenTests
 			var lastBook = m_books.Last();
 			var lastBlock = lastBook.GetScriptBlocks().Last();
 			m_navigator.CurrentBlock = lastBlock;
-			Assert.IsNull(m_navigator.NextBlock());
+			Assert.IsNull(m_navigator.GoToNextBlock());
 		}
 
 		[Test]
@@ -236,7 +236,7 @@ namespace GlyssenTests
 			var firstBlock = firstBook[0];
 			var secondBlock = firstBook[1];
 			m_navigator.CurrentBlock = secondBlock;
-			Assert.AreEqual(firstBlock, m_navigator.PreviousBlock());
+			Assert.AreEqual(firstBlock, m_navigator.GoToPreviousBlock());
 		}
 
 		[Test]
@@ -247,7 +247,7 @@ namespace GlyssenTests
 			var firstBook = m_books.First();
 			var lastBlock = firstBook.GetScriptBlocks().Last();
 			m_navigator.CurrentBlock = firstBlock;
-			Assert.AreEqual(lastBlock, m_navigator.PreviousBlock());
+			Assert.AreEqual(lastBlock, m_navigator.GoToPreviousBlock());
 		}
 
 		[Test]
@@ -259,7 +259,7 @@ namespace GlyssenTests
 			m_navigator.CurrentBlock = secondBlock;
 			BookScript currentBook = m_navigator.CurrentBook;
 			Block currentBlock = m_navigator.CurrentBlock;
-			Assert.AreEqual(firstBlock, m_navigator.PeekPreviousBlock());
+			Assert.AreEqual(firstBlock, m_navigator.GetPreviousBlock());
 			Assert.AreEqual(currentBlock, m_navigator.CurrentBlock);
 			Assert.AreEqual(currentBook, m_navigator.CurrentBook);
 		}
@@ -274,7 +274,7 @@ namespace GlyssenTests
 			m_navigator.CurrentBlock = firstBlock;
 			BookScript currentBook = m_navigator.CurrentBook;
 			Block currentBlock = m_navigator.CurrentBlock;
-			Assert.AreEqual(lastBlock, m_navigator.PeekPreviousBlock());
+			Assert.AreEqual(lastBlock, m_navigator.GetPreviousBlock());
 			Assert.AreEqual(currentBlock, m_navigator.CurrentBlock);
 			Assert.AreEqual(currentBook, m_navigator.CurrentBook);
 		}
@@ -282,45 +282,45 @@ namespace GlyssenTests
 		[Test]
 		public void PeekNthNextBlockWithinBook_NEquals1()
 		{
-			m_navigator.NavigateToFirstBlock();
-			Block result = m_navigator.PeekNthNextBlockWithinBook(1);
+			m_navigator.GoToFirstBlock();
+			Block result = m_navigator.GetNthNextBlockWithinBook(1);
 			Assert.AreEqual(m_books.First()[1], result);
 		}
 
 		[Test]
 		public void PeekNthNextBlockWithinBook_NGreaterThan1()
 		{
-			m_navigator.NavigateToFirstBlock();
-			Block result = m_navigator.PeekNthNextBlockWithinBook(2);
+			m_navigator.GoToFirstBlock();
+			Block result = m_navigator.GetNthNextBlockWithinBook(2);
 			Assert.AreEqual(m_books.First()[2], result);
 		}
 
 		[Test]
 		public void PeekNthNextBlockWithinBook_BeyondBook_ReturnsNull()
 		{
-			m_navigator.NavigateToFirstBlock();
-			Block result = m_navigator.PeekNthNextBlockWithinBook(3);
+			m_navigator.GoToFirstBlock();
+			Block result = m_navigator.GetNthNextBlockWithinBook(3);
 			Assert.IsNull(result);
 		}
 
 		[Test]
 		public void PeekNthNextBlockWithinBook_FromSpecificBook_NEquals1()
 		{
-			Block result = m_navigator.PeekNthNextBlockWithinBook(1, m_books[0].Blocks[0]);
+			Block result = m_navigator.GetNthNextBlockWithinBook(1, m_books[0].Blocks[0]);
 			Assert.AreEqual(m_books.First()[1], result);
 		}
 
 		[Test]
 		public void PeekNthNextBlockWithinBook_FromSpecificBook_NGreaterThan1()
 		{
-			Block result = m_navigator.PeekNthNextBlockWithinBook(1, m_books[0].Blocks[1]);
+			Block result = m_navigator.GetNthNextBlockWithinBook(1, m_books[0].Blocks[1]);
 			Assert.AreEqual(m_books.First()[2], result);
 		}
 
 		[Test]
 		public void PeekNthNextBlockWithinBook_FromSpecificBook_BeyondBook_ReturnsNull()
 		{
-			Block result = m_navigator.PeekNthNextBlockWithinBook(2, m_books[0].Blocks[1]);
+			Block result = m_navigator.GetNthNextBlockWithinBook(2, m_books[0].Blocks[1]);
 			Assert.IsNull(result);
 		}
 
@@ -328,7 +328,7 @@ namespace GlyssenTests
 		public void PeekNthPreviousBlockWithinBook_NEquals1()
 		{
 			m_navigator.CurrentBlock = m_books[1].Blocks[2];
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(1);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(1);
 			Assert.AreEqual(m_books[1].Blocks[1], result);
 		}
 
@@ -336,7 +336,7 @@ namespace GlyssenTests
 		public void PeekNthPreviousBlockWithinBook_NGreaterThan1()
 		{
 			m_navigator.CurrentBlock = m_books[1].Blocks[2];
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(2);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(2);
 			Assert.AreEqual(m_books[1].Blocks[0], result);
 		}
 
@@ -344,28 +344,28 @@ namespace GlyssenTests
 		public void PeekNthPreviousBlockWithinBook_BeyondBook_ReturnsNull()
 		{
 			m_navigator.CurrentBlock = m_books[1].Blocks[2];
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(3);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(3);
 			Assert.IsNull(result);
 		}
 
 		[Test]
 		public void PeekNthPreviousBlockWithinBook_FromSpecificBook_NEquals1()
 		{
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(1, m_books[1].Blocks[2]);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(1, m_books[1].Blocks[2]);
 			Assert.AreEqual(m_books[1].Blocks[1], result);
 		}
 
 		[Test]
 		public void PeekNthPreviousBlockWithinBook_FromSpecificBook_NGreaterThan1()
 		{
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(2, m_books[1].Blocks[2]);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(2, m_books[1].Blocks[2]);
 			Assert.AreEqual(m_books[1].Blocks[0], result);
 		}
 
 		[Test]
 		public void PeekNthPreviousBlockWithinBook_FromSpecificBook_BeyondBook_ReturnsNull()
 		{
-			Block result = m_navigator.PeekNthPreviousBlockWithinBook(3, m_books[1].Blocks[2]);
+			Block result = m_navigator.GetNthPreviousBlockWithinBook(3, m_books[1].Blocks[2]);
 			Assert.IsNull(result);
 		}
 
@@ -373,7 +373,7 @@ namespace GlyssenTests
 		public void PeekForwardWithinBook_OneBlock_WithinBook()
 		{
 			var secondBlock = m_books.First()[1];
-			IEnumerable<Block> result = m_navigator.PeekForwardWithinBook(1);
+			IEnumerable<Block> result = m_navigator.GetNextNBlocksWithinBook(1);
 			Assert.AreEqual(1, result.Count());
 			Assert.AreEqual(secondBlock, result.First());
 		}
@@ -382,7 +382,7 @@ namespace GlyssenTests
 		public void PeekForwardWithinBook_OneBlock_StartAtBookEnd_ReturnsEmpty()
 		{
 			m_navigator.CurrentBlock = m_books.First().Blocks.Last();
-			IEnumerable<Block> result = m_navigator.PeekForwardWithinBook(1);
+			IEnumerable<Block> result = m_navigator.GetNextNBlocksWithinBook(1);
 			Assert.AreEqual(0, result.Count());
 		}
 
@@ -391,7 +391,7 @@ namespace GlyssenTests
 		{
 			var secondBlock = m_books.First()[1];
 			var thirdBlock = m_books.First()[2];
-			IEnumerable<Block> result = m_navigator.PeekForwardWithinBook(2);
+			IEnumerable<Block> result = m_navigator.GetNextNBlocksWithinBook(2);
 			Assert.AreEqual(2, result.Count());
 			Assert.AreEqual(secondBlock, result.First());
 			Assert.AreEqual(thirdBlock, result.Last());
@@ -402,7 +402,7 @@ namespace GlyssenTests
 		{
 			var secondBlock = m_books.First()[1];
 			var thirdBlock = m_books.First()[2];
-			IEnumerable<Block> result = m_navigator.PeekForwardWithinBook(3);
+			IEnumerable<Block> result = m_navigator.GetNextNBlocksWithinBook(3);
 			Assert.AreEqual(2, result.Count());
 			Assert.AreEqual(secondBlock, result.First());
 			Assert.AreEqual(thirdBlock, result.Last());
@@ -414,7 +414,7 @@ namespace GlyssenTests
 			var firstBlock = m_books.First()[0];
 			var secondBlock = m_books.First()[1];
 			m_navigator.CurrentBlock = secondBlock;
-			IEnumerable<Block> result = m_navigator.PeekBackwardWithinBook(1);
+			IEnumerable<Block> result = m_navigator.GetPreviousNBlocksWithinBook(1);
 			Assert.AreEqual(1, result.Count());
 			Assert.AreEqual(firstBlock, result.First());
 		}
@@ -422,7 +422,7 @@ namespace GlyssenTests
 		[Test]
 		public void PeekBackwardWithinBook_OneBlock_StartAtBookBegin_ReturnsEmpty()
 		{
-			IEnumerable<Block> result = m_navigator.PeekBackwardWithinBook(1);
+			IEnumerable<Block> result = m_navigator.GetPreviousNBlocksWithinBook(1);
 			Assert.AreEqual(0, result.Count());
 		}
 
@@ -433,7 +433,7 @@ namespace GlyssenTests
 			var secondBlock = m_books.First()[1];
 			var thirdBlock = m_books.First()[2];
 			m_navigator.CurrentBlock = thirdBlock;
-			IEnumerable<Block> result = m_navigator.PeekBackwardWithinBook(2);
+			IEnumerable<Block> result = m_navigator.GetPreviousNBlocksWithinBook(2);
 			Assert.AreEqual(2, result.Count());
 			Assert.AreEqual(firstBlock, result.First());
 			Assert.AreEqual(secondBlock, result.Last());
@@ -446,7 +446,7 @@ namespace GlyssenTests
 			var secondBlock = m_books.First()[1];
 			var thirdBlock = m_books.First()[2];
 			m_navigator.CurrentBlock = thirdBlock;
-			IEnumerable<Block> result = m_navigator.PeekBackwardWithinBook(3);
+			IEnumerable<Block> result = m_navigator.GetPreviousNBlocksWithinBook(3);
 			Assert.AreEqual(2, result.Count());
 			Assert.AreEqual(firstBlock, result.First());
 			Assert.AreEqual(secondBlock, result.Last());
@@ -458,7 +458,7 @@ namespace GlyssenTests
 			var firstBook = m_books.First();
 			var firstBlock = firstBook[0];
 			m_navigator.CurrentBlock = firstBlock;
-			Assert.IsNull(m_navigator.PreviousBlock());
+			Assert.IsNull(m_navigator.GoToPreviousBlock());
 		}
 
 		[Test]
@@ -476,16 +476,16 @@ namespace GlyssenTests
 		[Test]
 		public void GetNextBlock_GetPreviousBlock_BackToFirst()
 		{
-			m_navigator.NextBlock();
-			Assert.AreEqual(m_books.First()[0], m_navigator.PreviousBlock());
+			m_navigator.GoToNextBlock();
+			Assert.AreEqual(m_books.First()[0], m_navigator.GoToPreviousBlock());
 		}
 
 		[Test]
 		public void GetPreviousBlock_GetNextBlock_BackToLast()
 		{
 			m_navigator.CurrentBlock = m_books.Last().GetScriptBlocks().Last();
-			m_navigator.PreviousBlock();
-			Assert.AreEqual(m_books.Last().GetScriptBlocks().Last(), m_navigator.NextBlock());
+			m_navigator.GoToPreviousBlock();
+			Assert.AreEqual(m_books.Last().GetScriptBlocks().Last(), m_navigator.GoToNextBlock());
 		}
 
 		[Test]

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -639,10 +639,10 @@ namespace GlyssenTests.Dialogs
 
 			//Create bad data
 			BlockNavigator navigator = (BlockNavigator)ReflectionHelper.GetField(m_model, "m_navigator");
-			Block nextBlock = navigator.NextBlock();
+			Block nextBlock = navigator.GoToNextBlock();
 			var originalStatus = nextBlock.MultiBlockQuote;
 			nextBlock.MultiBlockQuote = followingStatus;
-			navigator.PreviousBlock();
+			navigator.GoToPreviousBlock();
 
 			Assert.AreEqual(MultiBlockQuote.Start, m_model.CurrentBlock.MultiBlockQuote);
 
@@ -650,7 +650,7 @@ namespace GlyssenTests.Dialogs
 			Assert.AreEqual(m_model.CurrentBlock, lastBlock);
 
 			//Reset data for other tests
-			nextBlock = navigator.NextBlock();
+			nextBlock = navigator.GoToNextBlock();
 			nextBlock.MultiBlockQuote = originalStatus;
 		}
 
@@ -675,11 +675,11 @@ namespace GlyssenTests.Dialogs
 
 			var model = new BlockNavigatorViewModel(bookList, ScrVers.English);
 			var navigator = (BlockNavigator)ReflectionHelper.GetField(model, "m_navigator");
-			navigator.NavigateToFirstBlock();
-			navigator.NextBlock();
-			navigator.NextBlock();
-			navigator.NextBlock();
-			navigator.NextBlock();
+			navigator.GoToFirstBlock();
+			navigator.GoToNextBlock();
+			navigator.GoToNextBlock();
+			navigator.GoToNextBlock();
+			navigator.GoToNextBlock();
 
 			var found = model.CurrentBlockHasMissingExpectedQuote(versesWithPotentialMissingQuote);
 
@@ -703,13 +703,13 @@ namespace GlyssenTests.Dialogs
 
 			var model = new BlockNavigatorViewModel(bookList, ScrVers.English);
 			var navigator = (BlockNavigator) ReflectionHelper.GetField(model, "m_navigator");
-			navigator.NavigateToFirstBlock();
-			navigator.NextBlock();
+			navigator.GoToFirstBlock();
+			navigator.GoToNextBlock();
 
 			var found = model.CurrentBlockHasMissingExpectedQuote(versesWithPotentialMissingQuote);
 			Assert.False(found);
 
-			navigator.NextBlock();
+			navigator.GoToNextBlock();
 			found = model.CurrentBlockHasMissingExpectedQuote(versesWithPotentialMissingQuote);
 			Assert.False(found);
 		}


### PR DESCRIPTION
Tom and I worked on this together. No code review necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/418)
<!-- Reviewable:end -->
