### PR TITLE
Prevent errant increment of indices when "split" occurs between blocks

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -556,22 +556,32 @@ namespace Glyssen.Dialogs
 
 			foreach (var groupOfSplits in blockSplits.GroupBy(s => new { s.BlockToSplit }))
 			{
-				foreach (var blockSplitData in groupOfSplits.OrderByDescending(s => s, BlockSplitData.BlockSplitDataVerseAndOffsetComparer))
+				foreach (var blockSplitData in groupOfSplits.OrderByDescending(s => s,
+					BlockSplitData.BlockSplitDataVerseAndOffsetComparer))
 				{
 					// get the character selected for this split
 					var characterId = characters.First(c => c.Key == blockSplitData.Id).Value;
 
-					var newBlock = CurrentBook.SplitBlock(blockSplitData.BlockToSplit, blockSplitData.VerseToSplit,
+					var originalNextBlock = BlockAccessor.GetNthNextBlockWithinBook(1, blockSplitData.BlockToSplit);
+					var chipOffTheOldBlock = CurrentBook.SplitBlock(blockSplitData.BlockToSplit, blockSplitData.VerseToSplit,
 						blockSplitData.CharacterOffsetToSplit, true, characterId, m_project.Versification);
 
-					var newBlockIndices = GetBlockIndices(newBlock);
-					var blocksIndicesNeedingUpdate = m_relevantBookBlockIndices.Where(
-						r => r.BookIndex == newBlockIndices.BookIndex &&
-							r.BlockIndex >= newBlockIndices.BlockIndex);
-					foreach (var block in blocksIndicesNeedingUpdate)
-						block.BlockIndex++;
-
-					AddToRelevantBlocksIfNeeded(newBlock);
+					var isNewBlock = originalNextBlock != chipOffTheOldBlock;
+					if (isNewBlock)
+					{
+						var newBlockIndices = GetBlockIndices(chipOffTheOldBlock);
+						var blocksIndicesNeedingUpdate = m_relevantBookBlockIndices.Where(
+							r => r.BookIndex == newBlockIndices.BookIndex &&
+								r.BlockIndex >= newBlockIndices.BlockIndex);
+						foreach (var bookBlockIndices in blocksIndicesNeedingUpdate)
+							bookBlockIndices.BlockIndex++;
+					}
+					else
+					{
+						// We "split" between existing blocks in a multiblock quote,
+						// so we don't need to do the same kind of cleanup above.
+					}
+					AddToRelevantBlocksIfNeeded(chipOffTheOldBlock, isNewBlock);
 				}
 			}
 			if (AttemptRefBlockMatchup)

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -1138,26 +1138,29 @@ namespace Glyssen.Dialogs
 			return false;
 		}
 
-		protected void AddToRelevantBlocksIfNeeded(Block newOrModifiedBlock)
+		protected void AddToRelevantBlocksIfNeeded(Block newOrModifiedBlock, bool blockIsNew)
 		{
 			if (m_currentRefBlockMatchups != null)
 			{
-				var indicesOfNewOrModifiedBlock = GetBlockIndices(newOrModifiedBlock);
-				var currentIndices = BlockAccessor.GetIndices();
-				if (currentIndices.BookIndex == indicesOfNewOrModifiedBlock.BookIndex &&
-					currentIndices.BlockIndex <= indicesOfNewOrModifiedBlock.BlockIndex &&
-					currentIndices.EffectiveFinalBlockIndex >= indicesOfNewOrModifiedBlock.BlockIndex - 1)
+				if (blockIsNew)
 				{
-					// We need to increment the count of blocks in both the navigator and the current
-					// relevant block (if the current matchup is relevant). These BookBlockIndices objects
-					// are (hopefully identical?) copies of each other.
-					m_navigator.ExtendCurrentBlockGroup(1);
-					if (m_currentRelevantIndex >= 0)
-						m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount++;
-				}
-				else
-				{
-					Debug.Fail("Look at this scenario. I don't think this should ever happen.");
+					var indicesOfNewOrModifiedBlock = GetBlockIndices(newOrModifiedBlock);
+					var currentIndices = BlockAccessor.GetIndices();
+					if (currentIndices.BookIndex == indicesOfNewOrModifiedBlock.BookIndex &&
+						currentIndices.BlockIndex <= indicesOfNewOrModifiedBlock.BlockIndex &&
+						currentIndices.EffectiveFinalBlockIndex >= indicesOfNewOrModifiedBlock.BlockIndex - 1)
+					{
+						// We need to increment the count of blocks in both the navigator and the current
+						// relevant block (if the current matchup is relevant). These BookBlockIndices objects
+						// are (hopefully identical?) copies of each other.
+						m_navigator.ExtendCurrentBlockGroup(1);
+						if (m_currentRelevantIndex >= 0)
+							m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount++;
+					}
+					else
+					{
+						Debug.Fail("Look at this scenario. I don't think this should ever happen.");
+					}
 				}
 			}
 			else if (IsRelevant(newOrModifiedBlock, true))


### PR DESCRIPTION
Tom and I worked on this together. No review necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/419)
<!-- Reviewable:end -->
