### PR TITLE
Ensure valid state after a split by totally resetting state (PG-1075)

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -594,6 +594,10 @@ namespace Glyssen.Dialogs
 				// A split will always require the current matchup to be re-constructed.
 				SetBlockMatchupForCurrentVerse();
 			}
+
+			// This is basically a hack. All kinds of problems were occurring after splits causing our indices to get off.
+			// See https://jira.sil.org/browse/PG-1075. This ensures our state is valid every time.
+			SetModeInternal(Mode, true);
 		}
 		#endregion
 

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -311,19 +311,24 @@ namespace Glyssen.Dialogs
 
 		public virtual BlocksToDisplay Mode
 		{
-			get { return m_mode; }
+			get => m_mode;
 			set
 			{
 				if (m_mode == value)
 					return;
 
-				m_mode = value;
-				m_temporarilyIncludedBookBlockIndices = GetCurrentBlockIndices();
-				ResetFilter(BlockAccessor.CurrentBlock);
+				SetModeInternal(value);
 			}
 		}
 
-		protected void ResetFilter(Block selectedBlock)
+		protected void SetModeInternal(BlocksToDisplay mode, bool stayOnCurrentBlock = false)
+		{
+			m_mode = mode;
+			m_temporarilyIncludedBookBlockIndices = GetCurrentBlockIndices();
+			ResetFilter(BlockAccessor.CurrentBlock, stayOnCurrentBlock);
+		}
+
+		protected void ResetFilter(Block selectedBlock, bool stayOnCurrentBlock = false)
 		{
 			PopulateRelevantBlocks();
 
@@ -346,6 +351,11 @@ namespace Glyssen.Dialogs
 							if (SetAsCurrentLocationIfRelevant(indices))
 								return;
 						}
+					}
+					if (stayOnCurrentBlock)
+					{
+						SetBlock(m_temporarilyIncludedBookBlockIndices);
+						return;
 					}
 				}
 				LoadNextRelevantBlock();

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -266,6 +266,22 @@ namespace GlyssenTests.Dialogs
 		}
 
 		[Test]
+		public void SetMode_SwitchFromNotAlignedWithReferenceTextToNotAssignedAutomatically_MatchupIsTheSame()
+		{
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			FindRefInMark(8, 20);
+			var origBlock = m_model.CurrentBlock;
+			var origMatchup = m_model.CurrentReferenceTextMatchup;
+			m_model.Mode = BlocksToDisplay.NotAssignedAutomatically;
+			var newMatchup = m_model.CurrentReferenceTextMatchup;
+			Assert.AreEqual(origBlock.GetText(true), m_model.CurrentBlock.GetText(true));
+			Assert.AreEqual(origMatchup.IndexOfStartBlockInBook, newMatchup.IndexOfStartBlockInBook);
+			Assert.AreEqual(origMatchup.OriginalBlockCount, newMatchup.OriginalBlockCount);
+			Assert.AreEqual(origMatchup.CorrelatedAnchorBlock.GetText(true), newMatchup.CorrelatedAnchorBlock.GetText(true));
+		}
+
+		[Test]
 		public void BlockCountForCurrentBook_TestMrk_ReturnsTrue()
 		{
 			int expectedCount = m_testProject.IncludedBooks[0].Blocks.Count;


### PR DESCRIPTION
This is inefficient but better than crashing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/421)
<!-- Reviewable:end -->
