### PR TITLE
Minor improvement to BlockContainsVerseEndInMiddleOfVerseBridge

### DIFF
--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -618,7 +618,7 @@ namespace Glyssen
 
 		private static bool BlockContainsVerseEndInMiddleOfVerseBridge(Block block, int verse)
 		{
-			return block.BlockElements.OfType<Verse>().Any(ve => ve.StartVerse <= verse && ve.EndVerse > verse);
+			return block.BlockElements.OfType<Verse>().Any(ve => ve.StartVerse <= verse && ve.EndVerse >= verse);
 		}
 
 		protected override string ProjectFolder { get { return m_projectFolder; } }


### PR DESCRIPTION
(used only in debug mode) to prevent needless alerts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/455)
<!-- Reviewable:end -->
