### PR TITLE
PG-1123, PG-1131: Fixed "Sequence contains no matching element"

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1459,26 +1459,35 @@ namespace Glyssen.Dialogs
 					if (selectedCharacter == null)
 					{
 						var newValue = m_dataGridReferenceText.Rows[e.RowIndex].Cells[e.ColumnIndex].Value as string;
-						selectedCharacter = colCharacter.Items.Cast<AssignCharacterViewModel.Character>()
-							.First(c => c.LocalizedDisplay == newValue);
+						if (newValue != null)
+							selectedCharacter = colCharacter.Items.Cast<AssignCharacterViewModel.Character>()
+								.First(c => c.LocalizedDisplay == newValue);
 					}
 
-					var characterIdForLog = selectedCharacter.IsNarrator ? selectedCharacter.ToString() : selectedCharacter.CharacterId;
-					Logger.WriteMinorEvent($"Setting character to {characterIdForLog} for " +
-						$"block {block.ChapterNumber}:{block.InitialStartVerseNumber} {block.GetText(true)}");
-
-					if (selectedCharacter == AssignCharacterViewModel.Character.Narrator && colDelivery.Visible)
+					if (selectedCharacter == null)
 					{
-						// Narrators are never allowed to have a delivery other than normal.
-						// Unfortunately, by the time we call IsBlockAssignedToUnknownCharacterDeliveryPair below,
-						// the line that sets the character in the reference text matchup will have already reset
-						// the delivery. This leaves the UI out of synch with the data in the block, so we need
-						// to fix that first.
-						var deliveryCell = m_dataGridReferenceText.Rows[e.RowIndex].Cells[colDelivery.Index];
-						if (deliveryCell.Value as string != AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay)
+						Logger.WriteMinorEvent($"No character selected; setting to Ambiguous for " +
+							$"block {block.ChapterNumber}:{block.InitialStartVerseNumber} {block.GetText(true)}");
+					}
+					else
+					{
+						var characterIdForLog = selectedCharacter.IsNarrator ? selectedCharacter.ToString() : selectedCharacter.CharacterId;
+						Logger.WriteMinorEvent($"Setting character to {characterIdForLog} for " +
+							$"block {block.ChapterNumber}:{block.InitialStartVerseNumber} {block.GetText(true)}");
+
+						if (selectedCharacter == AssignCharacterViewModel.Character.Narrator && colDelivery.Visible)
 						{
-							Logger.WriteMinorEvent("Character is Narrator. Forcing delivery to normal.");
-							deliveryCell.Value = AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay;
+							// Narrators are never allowed to have a delivery other than normal.
+							// Unfortunately, by the time we call IsBlockAssignedToUnknownCharacterDeliveryPair below,
+							// the line that sets the character in the reference text matchup will have already reset
+							// the delivery. This leaves the UI out of synch with the data in the block, so we need
+							// to fix that first.
+							var deliveryCell = m_dataGridReferenceText.Rows[e.RowIndex].Cells[colDelivery.Index];
+							if (deliveryCell.Value as string != AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay)
+							{
+								Logger.WriteMinorEvent("Character is Narrator. Forcing delivery to normal.");
+								deliveryCell.Value = AssignCharacterViewModel.Delivery.Normal.LocalizedDisplay;
+							}
 						}
 					}
 					m_viewModel.SetReferenceTextMatchupCharacter(e.RowIndex, selectedCharacter);

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	136
+Control File Version	137
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5								
 # PSA will be handled as complete units, each psalm will be spoken by one voice								
@@ -15669,6 +15669,8 @@ JHN	9	17	Pharisees			Dialogue
 JHN	9	19	Jews, the	challenging		Dialogue		
 JHN	9	20	parents of cured man, blind from birth	cautious		Dialogue	father of cured man, blind from birth	
 JHN	9	21	parents of cured man, blind from birth			Normal	mother of cured man, blind from birth	
+JHN	9	22	parents of cured man, blind from birth			Indirect	father of cured man, blind from birth	
+JHN	9	22	Jews, the			Indirect		
 JHN	9	23	parents of cured man, blind from birth			Quotation	mother of cured man, blind from birth	
 JHN	9	24	Jews, the	challenging		Dialogue		
 JHN	9	25	cured man, blind from birth			Dialogue		


### PR DESCRIPTION
 This is the case of this crash that happens when moving a ref block whose character is not set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/469)
<!-- Reviewable:end -->
