### PR TITLE
PG-1160, PG-1097, PG-1120: Fixed "Sequence contains no elements"

### DIFF
--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -35,7 +35,7 @@ namespace Glyssen
 				{
 					Logger.WriteEvent($"Anchor block not found in verse: {m_vernacularBook.BookId} {originalAnchorBlock.ChapterNumber}:" +
 						$"{originalAnchorBlock.InitialStartVerseNumber} Verse apparently occurs more than once in the Scripture text.");
-					// REVIEW: This logic assumes that the repeated verse is wholly contained in this onwe block.
+					// REVIEW: This logic assumes that the repeated verse is wholly contained in this one block.
 					blocksForVersesCoveredByBlock = new List<Block>() {originalAnchorBlock};
 					indexOfAnchorBlockInVerse = 0;
 				}

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -39,9 +39,9 @@ namespace Glyssen
 			{
 				if (fromControlFileVersion < 96)
 					MigrateInvalidMultiBlockQuoteData(project.Books);
-				if (fromControlFileVersion < 127)
+				if (fromControlFileVersion < 138)
 				{
-					// This method was originally called for the < 96 case above, but we found a new case
+					// This method was originally called for the < 96 case above, but we found new cases
 					// for which it is needed. Therefore, we call it here to keep it in the same order
 					// as it was before (though, technically, we aren't sure we care).
 					CleanUpOrphanedMultiBlockQuoteStati(project.Books);

--- a/Glyssen/Quote/QuoteParser.cs
+++ b/Glyssen/Quote/QuoteParser.cs
@@ -748,6 +748,8 @@ namespace Glyssen.Quote
 
 			var blocks = new PortionScript(bookId, new[] {m_workingBlock});
 			Block originalQuoteBlock = blocks.GetScriptBlocks().Last();
+			if (originalQuoteBlock.MultiBlockQuote != MultiBlockQuote.Continuation)
+				ProcessMultiBlock();
 			m_currentMultiBlockQuote.Add(originalQuoteBlock);
 
 			while (true)

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	137
+Control File Version	138
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5								
 # PSA will be handled as complete units, each psalm will be spoken by one voice								

--- a/GlyssenTests/BlockTests.cs
+++ b/GlyssenTests/BlockTests.cs
@@ -1683,17 +1683,17 @@ namespace GlyssenTests
 			Assert.True(block.ProbablyDoesNotContainInterruption);
 		}
 
-		[TestCase("a (bcd) e", "(bcd) ")]
-		[TestCase("a -b- c", "-b- ")]
-		[TestCase("a - b - c", "- b - ")]
-		[TestCase("a -- b -- c", "-- b -- ")]
-		[TestCase("a —b— c", "—b— ")]
-		[TestCase("a - b-c - d", "- b-c - ")]
-		[TestCase("a -- b-c -- d", "-- b-c -- ")]
-		public void GetNextInterruption_InterruptionFoundCorrectly(string text, string interruption)
+		[TestCase("a (bcd) e", ExpectedResult = "(bcd) ")]
+		[TestCase("a -b- c", ExpectedResult = "-b- ")]
+		[TestCase("a - b - c", ExpectedResult = "- b - ")]
+		[TestCase("a -- b -- c", ExpectedResult = "-- b -- ")]
+		[TestCase("a —b— c", ExpectedResult = "—b— ")]
+		[TestCase("a - b-c - d", ExpectedResult = "- b-c - ")]
+		[TestCase("a -- b-c -- d", ExpectedResult = "-- b-c -- ")]
+		public string GetNextInterruption_InterruptionFoundCorrectly(string text)
 		{
 			var block = GetBlockWithText(text);
-			Assert.AreEqual(interruption, block.GetNextInterruption().Item1.Value);
+			return block.GetNextInterruption().Item1.Value;
 		}
 
 		[TestCase("a b-c-d e")]


### PR DESCRIPTION
error caused by orphaned start quote block when breaking off an interruption.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/470)
<!-- Reviewable:end -->
