### PR TITLE
PG-1157?, PG-1158 (for sure): Prevent clearing of the list of pending character-verse additions…

### DIFF
--- a/Glyssen/Controls/ScriptBlocksGridView.cs
+++ b/Glyssen/Controls/ScriptBlocksGridView.cs
@@ -196,56 +196,57 @@ namespace Glyssen.Controls
 
 		public void UpdateContext()
 		{
+			int firstRow, lastRow;
 			m_updatingContext = true;
-			SuspendLayout();
-
-			ResetSelectionBackColors();
-
-			ClearSelection();
-			bool changingRowCount = RowCount != m_viewModel.BlockCountForCurrentBook;
-			var firstRow = m_viewModel.IndexOfFirstBlockInCurrentGroup;
-			var lastRow = m_viewModel.IndexOfLastBlockInCurrentGroup;
-			bool multiSelect = firstRow != lastRow;
-			if (changingRowCount || MultiSelect != multiSelect)
+			Cursor restoreCursor = Cursor.Current;
+			try
 			{
-				MultiSelect = multiSelect;
-				if (changingRowCount)
-				{
-					AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None;
-					RowCount = m_viewModel.BlockCountForCurrentBook;
-				}
-				// Need to clear the selection here again because some of the property setters on
-				// DataGridView have the side-effect of creating a selection. We want to avoid having
-				// HandleDataGridViewBlocksCellValueNeeded get called with an index that is out of
-				// range for the new book.
+				Cursor.Current = Cursors.WaitCursor;
+				SuspendLayout();
+
+				ResetSelectionBackColors();
+
 				ClearSelection();
-			}
-
-			for (var i = firstRow; i <= lastRow; i++)
-			{
-				Rows[i].Selected = true;
-				if (m_viewModel.BlockGroupingStyle == BlockGroupingType.BlockCorrelation)
+				bool changingRowCount = RowCount != m_viewModel.BlockCountForCurrentBook;
+				firstRow = m_viewModel.IndexOfFirstBlockInCurrentGroup;
+				lastRow = m_viewModel.IndexOfLastBlockInCurrentGroup;
+				bool multiSelect = firstRow != lastRow;
+				if (changingRowCount || MultiSelect != multiSelect)
 				{
-					Rows[i].DefaultCellStyle.SelectionBackColor = GlyssenColorPalette.ColorScheme.GetMatchColor(i - firstRow);
-					Rows[i].DefaultCellStyle.SelectionForeColor = Color.Black;
-
-					var characterId = (string)Rows[i].Cells["colCharacter"].Value;
-					Rows[i].Cells["colText"].Style.SelectionForeColor = GlyssenColorPalette.ColorScheme.GetForeColorByCharacterId(characterId);
+					MultiSelect = multiSelect;
+					if (changingRowCount)
+					{
+						AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.None;
+						RowCount = m_viewModel.BlockCountForCurrentBook;
+					}
+					// Need to clear the selection here again because some of the property setters on
+					// DataGridView have the side-effect of creating a selection. We want to avoid having
+					// HandleDataGridViewBlocksCellValueNeeded get called with an index that is out of
+					// range for the new book.
+					ClearSelection();
 				}
-			}
 
-			if (changingRowCount)
-				try
+				for (var i = firstRow; i <= lastRow; i++)
 				{
-					Cursor.Current = Cursors.WaitCursor;
+					Rows[i].Selected = true;
+					if (m_viewModel.BlockGroupingStyle == BlockGroupingType.BlockCorrelation)
+					{
+						Rows[i].DefaultCellStyle.SelectionBackColor = GlyssenColorPalette.ColorScheme.GetMatchColor(i - firstRow);
+						Rows[i].DefaultCellStyle.SelectionForeColor = Color.Black;
+
+						var characterId = (string)Rows[i].Cells["colCharacter"].Value;
+						Rows[i].Cells["colText"].Style.SelectionForeColor = GlyssenColorPalette.ColorScheme.GetForeColorByCharacterId(characterId);
+					}
+				}
+
+				if (changingRowCount)
 					AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells;
-				}
-				finally
-				{
-					Cursor.Current = Cursors.Default;
-				}
-
-			ResumeLayout();
+			}
+			finally
+			{
+				ResumeLayout();
+				Cursor.Current = restoreCursor;
+			}
 
 			m_updatingContext = false;
 

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1180,7 +1180,15 @@ namespace Glyssen.Dialogs
 				{
 					Logger.WriteMinorEvent("Split block in {0} into {1} parts.", m_scriptureReference.VerseControl.VerseRef.ToString(),
 						dlg.SplitLocations.Count + 1);
-					m_viewModel.SplitBlock(dlg.SplitLocations, dlg.SelectedCharacters);
+					try
+					{
+						Cursor.Current = Cursors.WaitCursor;
+						m_viewModel.SplitBlock(dlg.SplitLocations, dlg.SelectedCharacters);
+					}
+					finally
+					{
+						Cursor.Current = Cursors.Default;
+					}
 				}
 			}
 		}
@@ -1453,7 +1461,6 @@ namespace Glyssen.Dialogs
 				else
 				{
 					Debug.Assert(e.ColumnIndex == colCharacter.Index);
-					Debug.Assert(!colCharacter.ReadOnly);
 					var selectedCharacter = m_dataGridReferenceText.Rows[e.RowIndex].Cells[e.ColumnIndex]
 						.Value as AssignCharacterViewModel.Character;
 					if (selectedCharacter == null)
@@ -1734,6 +1741,7 @@ namespace Glyssen.Dialogs
 			if (!m_dataGridReferenceText.IsCurrentCellInEditMode)
 				m_dataGridReferenceText.BeginEdit(false);
 			var editingCtrl = (DataGridViewTextBoxEditingControl)m_dataGridReferenceText.EditingControl;
+			editingCtrl.Click -= HandleClickToSplitText; // ensure we don't double-subscribe
 			editingCtrl.Click += HandleClickToSplitText;
 			editingCtrl.HandleDestroyed -= HandleClickToSplitText;
 		}

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -148,7 +148,8 @@ namespace Glyssen.Dialogs
 				delivery == null ? Delivery.Normal.Text : delivery.Text,
 				null,
 				true));
-			GetCharactersForCurrentReferenceTextMatchup(); // This forces the model's internal list to refresh to just the relevant ones
+			if (CurrentReferenceTextMatchup != null)
+				PopulateCurrentCharactersForCurrentReferenceTextMatchup(); // This forces the model's internal list to refresh to just the relevant ones
 		}
 
 		private void OnSaveCurrentBook()
@@ -218,12 +219,16 @@ namespace Glyssen.Dialogs
 
 		public IEnumerable<Character> GetCharactersForCurrentReferenceTextMatchup()
 		{
+			PopulateCurrentCharactersForCurrentReferenceTextMatchup();
+			return GetUniqueCharacters(false);
+		}
+
+		public void PopulateCurrentCharactersForCurrentReferenceTextMatchup()
+		{
 			m_currentCharacters = new HashSet<CharacterVerse>();
 			foreach (var block in CurrentReferenceTextMatchup.CorrelatedBlocks)
 				m_currentCharacters.UnionWith(GetUniqueCharacterVerseObjectsForBlock(block));
 			m_currentCharacters.UnionWith(m_pendingCharacterVerseAdditions);
-
-			return GetUniqueCharacters(false);
 		}
 
 		public IEnumerable<Character> GetUniqueCharactersForCurrentReference(bool expandIfNone = true)


### PR DESCRIPTION
… when a block is split during the process of aligning to the reference text.

This both prevents a crash and also ensures that the project c-v file gets written correctly.
Also, made a minor UI improvement to show wait cursor while splitting logic happens (takes a long time because we re-calc the filter and grid column widths)
Also fixed an unrelated bug whereby the Split reference text instructions message could sometimes be displayed when it shouldn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/473)
<!-- Reviewable:end -->
