### PR TITLE
PG-1166: Fixed off-by-one error, going off the end of a block matchup

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -143,6 +143,7 @@ namespace Glyssen.Dialogs
 
 		private void AddPendingProjectCharacterVerseData(Block block, string characterId, Delivery delivery = null)
 		{
+			Debug.Assert(!String.IsNullOrEmpty(characterId));
 			m_pendingCharacterVerseAdditions.Add(new CharacterVerse(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV,
 				characterId,
 				delivery == null ? Delivery.Normal.Text : delivery.Text,
@@ -484,18 +485,15 @@ namespace Glyssen.Dialogs
 			// PG-805: The block matchup UI does not prevent pairing a delivery with a character to which it does not correspond and
 			// also allows addition of new character/delivery pairs, so we need to check to see whether this has happened and, if
 			// so, add an appropriate entry to the project CV data.
-
-			//foreach (var block in CurrentReferenceTextMatchup.OriginalBlocks.Where(IsBlockAssignedToUnknownCharacterDeliveryPair))
-
 			int iLastBlockInMatchup = CurrentReferenceTextMatchup.IndexOfStartBlockInBook + CurrentReferenceTextMatchup.OriginalBlockCount;
 			var blocks = CurrentBook.GetScriptBlocks();
-			for (int i = CurrentReferenceTextMatchup.IndexOfStartBlockInBook; i <= iLastBlockInMatchup || (i < blocks.Count && blocks[i].IsContinuationOfPreviousBlockQuote); i++)
+			for (int i = CurrentReferenceTextMatchup.IndexOfStartBlockInBook; i < iLastBlockInMatchup || (i < blocks.Count && blocks[i].IsContinuationOfPreviousBlockQuote); i++)
 			{
 				var block = blocks[i];
 				if (IsBlockAssignedToUnknownCharacterDeliveryPair(block))
 				{
-				Debug.Assert(block.CharacterId != null);
-				Debug.Assert(block.CharacterId != "");
+					Debug.Assert(block.CharacterId != null);
+					Debug.Assert(block.CharacterId != "");
 					AddRecordToProjectCharacterVerseData(block,
 						GetCharactersForCurrentReferenceTextMatchup().First(c => c.CharacterId == block.CharacterId),
 						string.IsNullOrEmpty(block.Delivery) ? Delivery.Normal :
@@ -628,7 +626,8 @@ namespace Glyssen.Dialogs
 						var originalNextBlock = BlockAccessor.GetNthNextBlockWithinBook(1, blockSplitData.BlockToSplit);
 						var chipOffTheOldBlock = CurrentBook.SplitBlock(blockSplitData.BlockToSplit, blockSplitData.VerseToSplit,
 							blockSplitData.CharacterOffsetToSplit, true, characterId, m_project.Versification);
-						AddPendingProjectCharacterVerseDataIfNeeded(chipOffTheOldBlock, characterId);
+						if (!string.IsNullOrEmpty(firstCharacterId))
+							AddPendingProjectCharacterVerseDataIfNeeded(chipOffTheOldBlock, characterId);
 
 						var isNewBlock = originalNextBlock != chipOffTheOldBlock;
 						if (isNewBlock)

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -14050,8 +14050,8 @@ MRK	6	31	Jesus			Dialogue
 MRK	6	35	disciples	taking charge		Dialogue		MAT 14.15;MRK 6.35-36;LUK 9.12
 MRK	6	36	disciples	taking charge		Normal		
 MRK	6	37	Jesus			Dialogue		
-MRK	6	37	Philip the apostle	frustrated	disciples	Dialogue		MRK 6.37;JHN 6.7
-MRK	6	38	Andrew		disciples	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9
+MRK	6	37	Philip the apostle	frustrated	disciples (Philip, see John 6:7)	Dialogue		MRK 6.37;JHN 6.7
+MRK	6	38	Andrew		disciples (Andrew, see John 6:9)	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9
 MRK	6	38	Jesus	questioning		Dialogue		
 MRK	6	39	Jesus			Indirect		
 MRK	6	40	Jesus			Indirect		


### PR DESCRIPTION
Also prevent creating a pending blank character for an unassigned block from the split dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/477)
<!-- Reviewable:end -->
