### PR TITLE
Improved user experience when they have to try to find a bundle for a Glyssen project 

### DIFF
--- a/Glyssen/Dialogs/SelectBundleForProjectDlg.cs
+++ b/Glyssen/Dialogs/SelectBundleForProjectDlg.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+using Glyssen.Bundle;
+using Glyssen.Properties;
+using L10NSharp;
+using SIL.DblBundle;
+using static System.IO.Path;
+using static System.String;
+
+namespace Glyssen.Dialogs
+{
+	public class SelectBundleForProjectDlg : IDisposable
+	{
+		private OpenFileDialog m_fileDialog;
+		private readonly string m_projectNameAssociatedWithBundle;
+		private readonly string m_defaultFile;
+
+		private SelectBundleForProjectDlg(string projectNameAssociatedWithBundle, string defaultFile)
+		{
+			m_defaultFile = defaultFile;
+			m_projectNameAssociatedWithBundle = projectNameAssociatedWithBundle;
+		}
+
+		private string DefaultBundleDirectory
+		{
+			get => Settings.Default.DefaultBundleDirectory;
+			set => Settings.Default.DefaultBundleDirectory = value;
+		}
+
+		private string Title => Format(LocalizationManager.GetString("DialogBoxes.SelectProjectDlg.LocateTextReleaseBundleTitle", "Locate Text Release Bundle for project: {0}",
+			"Parameter is the project name for which the user is to try to locate the original or updated Text Release Bundle."),
+			m_projectNameAssociatedWithBundle);
+
+		public DialogResult ShowDialog()
+		{
+			if (m_fileDialog == null)
+				InitializeFileOpenDialog();
+			var result = m_fileDialog.ShowDialog();
+			if (result == DialogResult.OK)
+			{
+				FileName = m_fileDialog.FileName;
+				var dir = GetDirectoryName(FileName);
+				if (!IsNullOrEmpty(dir))
+					DefaultBundleDirectory = dir;
+			}
+			return result;
+		}
+
+		private void InitializeFileOpenDialog()
+		{
+			string defaultDir = DefaultBundleDirectory;
+			if (m_defaultFile != null)
+			{
+				try
+				{
+					FileName = GetFileName(m_defaultFile);
+					defaultDir = GetDirectoryName(m_defaultFile);
+					if (IsNullOrEmpty(defaultDir) || !Directory.Exists(defaultDir))
+						defaultDir = DefaultBundleDirectory;
+				}
+				catch
+				{
+				}
+			}
+			if (IsNullOrEmpty(defaultDir) || !Directory.Exists(defaultDir))
+				defaultDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			m_fileDialog = new OpenFileDialog
+			{
+				Title = Title,
+				InitialDirectory = defaultDir,
+				FileName = FileName,
+				Filter = Format("{0} ({1})|{1}|{2} ({3})|{3}",
+					LocalizationManager.GetString("DialogBoxes.SelectProjectDlg.ResourceBundleFileTypeLabel", "Text Resource Bundle files"),
+					"*" + DblBundleFileUtils.kDblBundleExtension,
+					LocalizationManager.GetString("DialogBoxes.FileDlg.AllFilesLabel", "All Files"),
+					"*.*"),
+				DefaultExt = DblBundleFileUtils.kDblBundleExtension
+			};
+		}
+
+		public string FileName { get; private set; }
+
+		public void Dispose()
+		{
+			m_fileDialog.Dispose();
+		}
+
+		public static bool TryGetBundleName(string projectName, string defaultFile, out string filename)
+		{
+			filename = null;
+			using (var dlg = new SelectBundleForProjectDlg(projectName, defaultFile))
+			{
+				if (dlg.ShowDialog() == DialogResult.OK)
+				{
+					filename = dlg.FileName;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public static bool GiveUserChanceToFindOriginalBundle(Project project)
+		{
+			if (TryGetBundleName(project.Name, project.OriginalBundlePath, out string bundlePath))
+			{
+				string invalidMessage = LocalizationManager.GetString("File.InvalidBundleMsg", "The selected file is not a valid text release bundle. Would you like to try again?");
+				string invalidCaption = LocalizationManager.GetString("File.InvalidBundleMsg", "Invalid Bundle");
+				if (GetExtension(bundlePath) == DblBundleFileUtils.kDblBundleExtension)
+				{
+					try
+					{
+						var bundle = new GlyssenBundle(bundlePath);
+						if (bundle.Id != project.Id)
+						{
+							string message = LocalizationManager.GetString("File.WrongBundleMsg", "The ID of the selected text release bundle does not match this project. Would you like to try again?");
+							string caption = LocalizationManager.GetString("File.WrongBundle", "Wrong Bundle");
+							return ErrorMessageWithRetry(message, caption, project);
+						}
+
+						project.OriginalBundlePath = bundlePath;
+						return true;
+					}
+					catch
+					{
+						return ErrorMessageWithRetry(invalidMessage, invalidCaption, project);
+					}
+				}
+				return ErrorMessageWithRetry(invalidMessage, invalidCaption, project);
+			}
+			return false;
+		}
+
+		private static bool ErrorMessageWithRetry(string message, string caption, Project project)
+		{
+			return MessageBox.Show(message, caption, MessageBoxButtons.YesNo) == DialogResult.Yes &&
+				GiveUserChanceToFindOriginalBundle(project);
+		}
+	}
+}

--- a/Glyssen/Dialogs/SelectProjectDlg.cs
+++ b/Glyssen/Dialogs/SelectProjectDlg.cs
@@ -1,79 +1,22 @@
-﻿using System.IO;
-using System.Windows.Forms;
-using Glyssen.Bundle;
-using Glyssen.Properties;
+﻿using Glyssen.Properties;
 using Glyssen.Shared;
 using L10NSharp;
-using SIL.DblBundle;
 using SIL.Windows.Forms.DblBundle;
 
 namespace Glyssen.Dialogs
 {
 	public class SelectProjectDlg : SelectProjectDlgBase
 	{
-		public SelectProjectDlg(bool allowProjectFiles = true, string defaultFile = null) : base(allowProjectFiles, defaultFile)
-		{
-		}
-
 		protected override string DefaultBundleDirectory
 		{
-			get { return Settings.Default.DefaultBundleDirectory; }
-			set { Settings.Default.DefaultBundleDirectory = value; }
+			get => Settings.Default.DefaultBundleDirectory;
+			set => Settings.Default.DefaultBundleDirectory = value;
 		}
 
-		protected override string ProjectFileExtension
-		{
-			get { return Constants.kProjectFileExtension; }
-		}
+		protected override string ProjectFileExtension => Constants.kProjectFileExtension;
 
-		protected override string Title
-		{
-			get { return LocalizationManager.GetString("DialogBoxes.SelectProjectDlg.Title", "Open Project"); }
-		}
+		protected override string Title => LocalizationManager.GetString("DialogBoxes.SelectProjectDlg.Title", "Open Project");
 
-		protected override string ProductName
-		{
-			get { return GlyssenInfo.kProduct; }
-		}
-
-		public static bool GiveUserChanceToFindOriginalBundle(Project project)
-		{
-			using (var dlg = new SelectProjectDlg(false))
-				if (dlg.ShowDialog() == DialogResult.OK)
-				{
-					string invalidMessage = LocalizationManager.GetString("File.InvalidBundleMsg", "The selected file is not a valid text release bundle. Would you like to try again?");
-					string invalidCaption = LocalizationManager.GetString("File.InvalidBundleMsg", "Invalid Bundle");
-					string bundlePath = dlg.FileName;
-					if (Path.GetExtension(bundlePath) == DblBundleFileUtils.kDblBundleExtension)
-					{
-						try
-						{
-							var bundle = new GlyssenBundle(bundlePath);
-							if (bundle.Id != project.Id)
-							{
-								string message = LocalizationManager.GetString("File.WrongBundleMsg", "The ID of the selected text release bundle does not match this project. Would you like to try again?");
-								string caption = LocalizationManager.GetString("File.WrongBundle", "Wrong Bundle");
-								return ErrorMessageWithRetry(message, caption, project);
-							}
-
-							project.OriginalBundlePath = bundlePath;
-							return true;
-						}
-						catch
-						{
-							return ErrorMessageWithRetry(invalidMessage, invalidCaption, project);
-						}
-					}
-					return ErrorMessageWithRetry(invalidMessage, invalidCaption, project);
-				}
-			return false;
-		}
-
-		private static bool ErrorMessageWithRetry(string message, string caption, Project project)
-		{
-			if (DialogResult.Yes == MessageBox.Show(message, caption, MessageBoxButtons.YesNo))
-				return GiveUserChanceToFindOriginalBundle(project);
-			return false;
-		}
+		protected override string ProductName => GlyssenInfo.kProduct;
 	}
 }

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -298,6 +298,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Dialogs\RolesForVoiceActorsSaveAsDialog.cs" />
+    <Compile Include="Dialogs\SelectBundleForProjectDlg.cs" />
     <Compile Include="Dialogs\UnappliedSplitsDlg.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -757,7 +757,7 @@ namespace Glyssen
 						LocalizationManager.GetString("Project.LocateBundleYourself", "Would you like to locate the text release bundle yourself?");
 					string caption = LocalizationManager.GetString("Project.UnableToLocateTextBundle", "Unable to Locate Text Bundle");
 					if (DialogResult.Yes == MessageBox.Show(msg, caption, MessageBoxButtons.YesNo))
-						upgradeProject = SelectProjectDlg.GiveUserChanceToFindOriginalBundle(existingProject);
+						upgradeProject = SelectBundleForProjectDlg.GiveUserChanceToFindOriginalBundle(existingProject);
 					if (!upgradeProject)
 						existingProject.m_projectMetadata.ParserUpgradeOptOutVersion = Settings.Default.ParserVersion;
 				}


### PR DESCRIPTION
…by showing the name of the project in the dialog box title and having the original bundle filename be the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/478)
<!-- Reviewable:end -->
