### PR TITLE
PG-1166 & PG-1090: Fixed logic errors

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -626,7 +626,7 @@ namespace Glyssen.Dialogs
 						var originalNextBlock = BlockAccessor.GetNthNextBlockWithinBook(1, blockSplitData.BlockToSplit);
 						var chipOffTheOldBlock = CurrentBook.SplitBlock(blockSplitData.BlockToSplit, blockSplitData.VerseToSplit,
 							blockSplitData.CharacterOffsetToSplit, true, characterId, m_project.Versification);
-						if (!string.IsNullOrEmpty(firstCharacterId))
+						if (!string.IsNullOrEmpty(characterId))
 							AddPendingProjectCharacterVerseDataIfNeeded(chipOffTheOldBlock, characterId);
 
 						var isNewBlock = originalNextBlock != chipOffTheOldBlock;

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -1194,17 +1194,16 @@ namespace Glyssen.Dialogs
 						m_navigator.ExtendCurrentBlockGroup(1);
 						if (m_currentRelevantIndex >= 0)
 							m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount++;
+						return;
 					}
-					else
-					{
-						Logger.WriteEvent("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-						Logger.WriteEvent("In AddToRelevantBlocksIfNeeded, we created a scenario which we don't think should ever happen! currentIndices ({0}), indicesOfNewOrModifiedBlock ({1})", currentIndices, indicesOfNewOrModifiedBlock);
-						Logger.WriteEvent("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-						Debug.Fail("Look at this scenario. I don't think this should ever happen.");
-					}
+					// else - This can happen when using a filter (e.g., All Scripture) that does not make use
+					// of MultiBlockCount to track with the block matchups. In that case, we want to fall through
+					// in order do the simple addition of this block to relevant blocks if appropriate.
 				}
+				else
+					return;
 			}
-			else if (IsRelevant(newOrModifiedBlock, true))
+			if (IsRelevant(newOrModifiedBlock, true))
 			{
 				var indicesOfNewOrModifiedBlock = GetBlockIndices(newOrModifiedBlock);
 				m_relevantBookBlockIndices.Add(indicesOfNewOrModifiedBlock);


### PR DESCRIPTION
PG-1166: Error that could allow a blank character ID to go into pending list (and show up as blank entry in combo box)
PG-1090: Removed debug assertion that alerted developer to condition that was though to be impossible. In light of this scenario, made minor correction to logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/479)
<!-- Reviewable:end -->
