### PR TITLE
PG-1186: Made glyssenshare files for Paratext projects able to cope with missing project

### DIFF
--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -1166,11 +1166,13 @@ namespace Glyssen
 			{
 				m_tableLayoutPanel.Enabled = false;
 				Cursor.Current = Cursors.WaitCursor;
+				m_project.PrepareForExport();
 
 				var sourceDir = Path.GetDirectoryName(m_project.ProjectFilePath);
 
 				Debug.Assert(sourceDir != null);
 				Debug.Assert(sourceDir.StartsWith(GlyssenInfo.BaseDataFolder));
+
 				var nameInZip = sourceDir.Substring(GlyssenInfo.BaseDataFolder.Length);
 
 				var share = Path.Combine(GlyssenInfo.BaseDataFolder, "share");
@@ -1198,6 +1200,7 @@ namespace Glyssen
 			}
 			finally
 			{
+				m_project.ExportCompleted();
 				Cursor.Current = Cursors.Default;
 				m_tableLayoutPanel.Enabled = true;
 			}

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -102,10 +102,37 @@ namespace Glyssen
 			m_projectCharacterDetailData = ProjectCharacterDetailData.Load(ProjectCharacterDetailDataPath);
 			if (loadVersification)
 			{
-				if (RobustFile.Exists(VersificationFilePath))
+				if (HasVersificationFile)
 					m_vers = LoadVersification(VersificationFilePath);
 				else if (IsLiveParatextProject)
-					m_vers = GetSourceParatextProject().Settings.Versification;
+				{
+					try
+					{
+						m_vers = GetSourceParatextProject().Settings.Versification;
+					}
+					catch (ProjectNotFoundException e)
+					{
+						Logger.WriteError("Paratext project not found. Falling back to get usable versification file.", e);
+						if (RobustFile.Exists(FallbackVersificationFilePath))
+							m_vers = LoadVersification(FallbackVersificationFilePath);
+						else
+						{
+							MessageBox.Show(Format(LocalizationManager.GetString("Project.ParatextProjectMissingMsg",
+								"{0} project {1} is not available and project {2} does not have a fallback versification file; " +
+								"therefore, the {3} versification is being used by default. If this is not the correct versification " +
+								"for this project, some things will not work as expected.",
+								"Param 0: \"Paratext\" (product name); " +
+								"Param 1: Paratext project short name (unique project identifier); " +
+								"Param 2: Glyssen recording project name; " +
+								"Param 3: “English” (versification mame)"),
+								ParatextScrTextWrapper.kParatextProgramName,
+								ParatextProjectName,
+								Name,
+								"“English”"), GlyssenInfo.kProduct);
+							m_vers = ScrVers.English;
+						}
+					}
+				}
 			}
 			if (installFonts)
 				InstallFontsIfNecessary();
@@ -169,6 +196,8 @@ namespace Glyssen
 			RobustFile.WriteAllText(VersificationFilePath, Resources.EnglishVersification);
 			m_vers = LoadVersification(VersificationFilePath);
 		}
+
+		private bool HasVersificationFile => RobustFile.Exists(VersificationFilePath);
 
 		public static IEnumerable<string> AllPublicationFolders => Directory.GetDirectories(ProjectsBaseFolder).SelectMany(Directory.GetDirectories);
 
@@ -1225,6 +1254,8 @@ namespace Glyssen
 
 		private void RemoveAvailableBooksThatDoNotCorrespondToExistingBooks()
 		{
+			ScrText sourceParatextProject = null;
+
 			for (int i = 0; i < m_metadata.AvailableBooks.Count; i++)
 			{
 				if (!m_books.Any(b => b.BookId == m_metadata.AvailableBooks[i].Code))
@@ -1242,7 +1273,18 @@ namespace Glyssen
 						//    as no longer included.
 						if (m_metadata.AvailableBooks[i].IncludeInScript)
 						{
-							if (GetSourceParatextProject().BookPresent(Canon.BookIdToNumber(m_metadata.AvailableBooks[i].Code)))
+							if (sourceParatextProject == null)
+							{
+								try
+								{
+									sourceParatextProject = GetSourceParatextProject();
+								}
+								catch (ProjectNotFoundException e)
+								{
+									Logger.WriteError($"Paratext project not found. Removing {m_metadata.AvailableBooks[i].Code}.", e);
+								}
+							}
+							if (sourceParatextProject != null && sourceParatextProject.BookPresent(Canon.BookIdToNumber(m_metadata.AvailableBooks[i].Code)))
 								m_metadata.AvailableBooks[i].IncludeInScript = false;
 							else
 								m_metadata.AvailableBooks.RemoveAt(i--);
@@ -1650,6 +1692,26 @@ namespace Glyssen
 
 			if (AnalysisCompleted != null)
 				AnalysisCompleted(this, new EventArgs());
+		}
+
+		internal void PrepareForExport()
+		{
+			if (!HasVersificationFile)
+			{
+				try
+				{
+					m_vers.Save(FallbackVersificationFilePath);
+				}
+				catch (Exception e)
+				{
+					Logger.WriteError($"Failed to save fallback versification file to {FallbackVersificationFilePath}", e);
+				}
+			}
+		}
+
+		internal void ExportCompleted()
+		{
+			RobustFile.Delete(FallbackVersificationFilePath);
 		}
 
 		public void Save(bool saveCharacterGroups = false)

--- a/Glyssen/ProjectBase.cs
+++ b/Glyssen/ProjectBase.cs
@@ -14,6 +14,7 @@ namespace Glyssen
 	public abstract class ProjectBase
 	{
 		public const string kShareFileExtension = ".glyssenshare";
+		public const string kFallbackVersificationPrefix = "fallback_";
 
 		public static ScrVers LoadVersification(string vrsPath)
 		{
@@ -96,5 +97,6 @@ namespace Glyssen
 		}
 
 		protected string VersificationFilePath => Path.Combine(ProjectFolder, DblBundleFileUtils.kVersificationFileName);
+		protected string FallbackVersificationFilePath => Path.Combine(ProjectFolder, kFallbackVersificationPrefix + DblBundleFileUtils.kVersificationFileName);
 	}
 }


### PR DESCRIPTION


1) Improved the code that creates a glyssenshare to ensure the zip file includes a copy of the Paratext vrs file.
2) Improved the code that creates a project from a glyssenshare to use the live project's versification file if available, but fall back to the one from the glyssenshare file if not. As a final fallback (for compatibility with old glhyssenshare files), it defaults to English (notifying the user of a possible problem).
3) When removing books that don't correspond to an existing book, if the Paratext project is not available, changed the code to just remove it (rather than checking to see f it can just be excluded).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/487)
<!-- Reviewable:end -->
