### PR TITLE
PG-1187: Made Glyssen force the refreshing of Paratext project when updating…

### DIFF
--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -11705,6 +11705,15 @@
         <seg>El proyecto {0} {1} no incluye ningún libro compatible con {2}.</seg>
       </tuv>
     </tu>
+    <tu tuid="Project.NonEditingRole">
+      <note>Param: "Paratext" (product name)</note>
+      <tuv xml:lang="en">
+        <seg>(You do not seem to have editing privileges for this {0} project.)</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>(Parece que no tiene permiso de editar este proyecto {0}.)</seg>
+      </tuv>
+    </tu>
     <tu tuid="Project.NotWritableMsg">
       <tuv xml:lang="en">
         <seg>The project file is not writable. No changes will be saved.</seg>
@@ -11757,6 +11766,15 @@
         <seg>Para actualizar el proyecto {0}, el proyecto {2} debe estar disponible en {1}, pero no lo está.</seg>
       </tuv>
     </tu>
+    <tu tuid="Project.ParatextProjectMissingNoFallbackVersificationFile">
+      <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: Glyssen recording project name; Param 3: “English” (versification mame)</note>
+      <tuv xml:lang="en">
+        <seg>{0} project {1} is not available and project {2} does not have a fallback versification file; therefore, the {3} versification is being used by default. If this is not the correct versification for this project, some things will not work as expected.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>El proyecto {0} {1} no está disponible y el proyecto {2} no tiene un archivo de versificación de respaldo. Así que la versificación {3} se usará por defecto. Si ésta no es la correcta versificación para este proyecto, se esperan algunos problemas.</seg>
+      </tuv>
+    </tu>
     <tu tuid="Project.ParatextProjectNotFound">
       <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: "Glyssen" (product name); Param 3: Glyssen recording project name</note>
       <tuv xml:lang="en">
@@ -11764,6 +11782,15 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>No se puede acceder al proyecto {0} {1}, que es necesario para que {2} cargue el proyecto {3}.\n\nDetalles técnicos:</seg>
+      </tuv>
+    </tu>
+    <tu tuid="Project.ParatextProjectReloadFailure">
+      <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: Specific error message</note>
+      <tuv xml:lang="en">
+        <seg>An error occurred reloading the {0} project {1}:\n{2}\n\nIf you cannot fix the problem, you can cancel and continue to work with the existing project data.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Ocurrió un error al recargar el proyecto {0} {1}:\n{2}\n\nSi no se puede resolver el problema, se puede cancelar y así continuar utilizando los datos existentes del proyecto.</seg>
       </tuv>
     </tu>
     <tu tuid="Project.ParatextProjectUnavailable">

--- a/Glyssen/Dialogs/ProjectSettingsViewModel.cs
+++ b/Glyssen/Dialogs/ProjectSettingsViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Glyssen.Bundle;
 using Glyssen.Paratext;
 using Glyssen.Shared;
+using Paratext.Data;
 using SIL.Scripture;
 using SIL.Windows.Forms.WritingSystems;
 
@@ -179,7 +180,7 @@ namespace Glyssen.Dialogs
 
 		internal ParatextScrTextWrapper GetUpdatedParatextData()
 		{
-			return Project.GetLiveParatextDataIfCompatible();
+			return Project.GetLiveParatextDataIfCompatible(forceReload:true);
 		}
 	}
 }

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -117,7 +117,7 @@ namespace Glyssen
 							m_vers = LoadVersification(FallbackVersificationFilePath);
 						else
 						{
-							MessageBox.Show(Format(LocalizationManager.GetString("Project.ParatextProjectMissingMsg",
+							MessageBox.Show(Format(LocalizationManager.GetString("Project.ParatextProjectMissingNoFallbackVersificationFile",
 								"{0} project {1} is not available and project {2} does not have a fallback versification file; " +
 								"therefore, the {3} versification is being used by default. If this is not the correct versification " +
 								"for this project, some things will not work as expected.",
@@ -923,7 +923,7 @@ namespace Glyssen
 						{
 							string msg = contextMessage + Format(
 								LocalizationManager.GetString("Project.ParatextProjectReloadFailure",
-									"An error occurred reloading the {0} project {1}:\r{2}\r\r" +
+									"An error occurred reloading the {0} project {1}:\r\n{2}\r\n\r\n" +
 									"If you cannot fix the problem, you can cancel and continue to work with the existing project data.",
 									"Param 0: \"Paratext\" (product name); " +
 									"Param 1: Paratext project short name (unique project identifier); " +

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -909,14 +909,32 @@ namespace Glyssen
 
 			if (forceReload)
 			{
-				try
+				bool reloadSucceeded = false;
+				do
 				{
-					sourceScrText.Reload();
-				}
-				catch (Exception e)
-				{
-					Logger.WriteError(e);
-				}
+					try
+					{
+						sourceScrText.Reload();
+						reloadSucceeded = true;
+					}
+					catch (Exception e)
+					{
+						if (canInteractWithUser)
+						{
+							string msg = contextMessage + Format(
+								LocalizationManager.GetString("Project.ParatextProjectReloadFailure",
+									"An error occurred reloading the {0} project {1}:\r{2}\r\r" +
+									"If you cannot fix the problem, you can cancel and continue to work with the existing project data.",
+									"Param 0: \"Paratext\" (product name); " +
+									"Param 1: Paratext project short name (unique project identifier); " +
+									"Param 2: Specific error message"),
+								ParatextScrTextWrapper.kParatextProgramName, ParatextProjectName, e.Message);
+							if (DialogResult.Retry == MessageBox.Show(msg, GlyssenInfo.kProduct, MessageBoxButtons.RetryCancel))
+								continue;
+						}
+						return null;
+					}
+				} while (!reloadSucceeded);
 			}
 
 			try


### PR DESCRIPTION
…so it wouldn't get out-dated info from the cache and fixed bug in update code to re-get the quote info from Paratext if not overridden in the Glyssen project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/491)
<!-- Reviewable:end -->
