### PR TITLE
PG-1203: Distinguished between \qa and other "normal" poetry styles in IsFollowOnParagraphStyle

### DIFF
--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -70,7 +70,7 @@
     <applicationSettings>
         <Glyssen.Properties.Settings>
             <setting name="ParserVersion" serializeAs="String">
-                <value>45</value>
+                <value>46</value>
             </setting>
             <setting name="DataFormatVersion" serializeAs="String">
                 <value>4</value>

--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -62,7 +62,7 @@ namespace Glyssen
 				RegexOptions.Compiled);
 			s_emptyVerseText = new Regex("^ *(?<verseWithWhitespace>" + kRegexForVerseNumber + kRegexForWhitespaceFollowingVerseNumber + @")? *$",
 				RegexOptions.Compiled);
-			s_regexFollowOnParagraphStyles = new Regex("^((q.{0,2})|m|mi|(pi.?))$", RegexOptions.Compiled);
+			s_regexFollowOnParagraphStyles = new Regex("^((q((m?\\d?)|[rc])?)|m|mi|(pi.?))$", RegexOptions.Compiled);
 			InitializeInterruptionRegEx(false);
 		}
 

--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -62,6 +62,10 @@ namespace Glyssen
 				RegexOptions.Compiled);
 			s_emptyVerseText = new Regex("^ *(?<verseWithWhitespace>" + kRegexForVerseNumber + kRegexForWhitespaceFollowingVerseNumber + @")? *$",
 				RegexOptions.Compiled);
+			// Rather than a very permissive regex that attempts to include all \q* markers in hopes of catching any future markers that
+			// might be added to the USFM standard, this regex matches only the known allowed poetry markers. It specifically prevents matching
+			// "qa", which is an acrostic header and should not be treated like other poetry markers. As the standard is changed in the future,
+			// any new markers that should be treated as "follow on" paragraphs will need to be added here.
 			s_regexFollowOnParagraphStyles = new Regex("^((q((m?\\d?)|[rc])?)|m|mi|(pi.?))$", RegexOptions.Compiled);
 			InitializeInterruptionRegEx(false);
 		}

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -799,6 +799,12 @@ namespace Glyssen
 							return true;
 						m_projectMetadata.ParserVersion = Settings.Default.ParserVersion;
 						return false;
+					case 46:
+						// This change only affects the way the \qa marker is handled, and that marker is most likely only used in Psalm 119
+						if (m_projectMetadata.ParserVersion < 45 || AvailableBooks.Any(b => b.Code == "PSA"))
+							return true;
+						m_projectMetadata.ParserVersion = Settings.Default.ParserVersion;
+						return false;
 					default:
 						return true;
 				}

--- a/Glyssen/Properties/Settings.Designer.cs
+++ b/Glyssen/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Glyssen.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -73,7 +73,7 @@ namespace Glyssen.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("45")]
+        [global::System.Configuration.DefaultSettingValueAttribute("46")]
         public int ParserVersion {
             get {
                 return ((int)(this["ParserVersion"]));

--- a/Glyssen/Properties/Settings.settings
+++ b/Glyssen/Properties/Settings.settings
@@ -15,7 +15,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ParserVersion" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">45</Value>
+      <Value Profile="(Default)">46</Value>
     </Setting>
     <Setting Name="DefaultSfmDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/GlyssenTests/Quote/QuoteParserTests.cs
+++ b/GlyssenTests/Quote/QuoteParserTests.cs
@@ -5439,7 +5439,7 @@ namespace GlyssenTests.Quote
 				new Block(q1, 119, 8) {IsParagraphStart = true}.AddVerse(8, "I will keep thy statutes;"),
 				new Block(q2, 119, 8) {IsParagraphStart = true}.AddText("This language doesn't use periods in poetry"),
 				new Block("qa", 119, 8) {IsParagraphStart = true}.AddText("Beth"),
-				new Block(q1, 119, 3) {IsParagraphStart = true}.AddVerse(9, "How shall a pipsqueak cleanse his way?"),
+				new Block(q1, 119, 9) {IsParagraphStart = true}.AddVerse(9, "How shall a pipsqueak cleanse his way?"),
 			};
 
 			QuoteParser.SetQuoteSystem(QuoteSystem.Default);

--- a/GlyssenTests/Quote/QuoteParserTests.cs
+++ b/GlyssenTests/Quote/QuoteParserTests.cs
@@ -5424,6 +5424,34 @@ namespace GlyssenTests.Quote
 			Assert.AreEqual("Jesus", output[3].CharacterId);
 		}
 
+		// Test for PG-1203
+		[TestCase("q", "q")]
+		[TestCase("q", "qr")]
+		[TestCase("q", "qc")]
+		[TestCase("qm1", "qm2")]
+		[TestCase("q1", "q2")]
+		[TestCase("q", "qm")]
+		[TestCase("qc", "qr")]
+		public void Parse_AcrosticHeading_NotCombined(string q1, string q2)
+		{
+			var input = new List<Block>
+			{
+				new Block(q1, 119, 8) {IsParagraphStart = true}.AddVerse(8, "I will keep thy statutes;"),
+				new Block(q2, 119, 8) {IsParagraphStart = true}.AddText("This language doesn't use periods in poetry"),
+				new Block("qa", 119, 8) {IsParagraphStart = true}.AddText("Beth"),
+				new Block(q1, 119, 3) {IsParagraphStart = true}.AddVerse(9, "How shall a pipsqueak cleanse his way?"),
+			};
+
+			QuoteParser.SetQuoteSystem(QuoteSystem.Default);
+			IList<Block> output = new QuoteParser(ControlCharacterVerseData.Singleton, "PSA", input).Parse().ToList();
+			Assert.AreEqual(3, output.Count);
+			Assert.AreEqual(q1, output[0].StyleTag);
+			Assert.AreEqual("{8}\u00A0I will keep thy statutes; This language doesn't use periods in poetry", output[0].GetText(true));
+			Assert.AreEqual("Beth", output[1].GetText(true));
+			Assert.AreEqual("{9}\u00A0How shall a pipsqueak cleanse his way?", output[2].GetText(true));
+			Assert.IsTrue(output.All(b => b.CharacterIs("PSA", CharacterVerseData.StandardCharacter.Narrator)));
+		}
+
 		// Test for PG-1121
 		[Test]
 		public void Parse_ColonFollowedByNormalInlineQuoteAndSubsequentVerses_ColonNotTreatedAsStartOfDialogue()


### PR DESCRIPTION
This prevents combining the acrostic headings in Psalm 119 with adjoining poetry paragraphs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/501)
<!-- Reviewable:end -->
