### PR TITLE
PG-1204: Prevent crash caused by bad matchup indexes following split

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1178,8 +1178,8 @@ namespace Glyssen.Dialogs
 				MainForm.LogDialogDisplay(dlg);
 				if (dlg.ShowDialog(this) == DialogResult.OK)
 				{
-					Logger.WriteMinorEvent("Split block in {0} into {1} parts.", m_scriptureReference.VerseControl.VerseRef.ToString(),
-						dlg.SplitLocations.Count + 1);
+					Logger.WriteMinorEvent($"Split block in {m_scriptureReference.VerseControl.VerseRef} into {dlg.SplitLocations.Count + 1} parts. " +
+						$"({dlg.SelectedCharacters.Count(kvp => !IsNullOrEmpty(kvp.Value))} characters assigned");
 					try
 					{
 						Cursor.Current = Cursors.WaitCursor;

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -1191,6 +1191,14 @@ namespace Glyssen.Dialogs
 						// We need to increment the count of blocks in both the navigator and the current
 						// relevant block (if the current matchup is relevant). These BookBlockIndices objects
 						// are (hopefully identical?) copies of each other.
+						// If the index actually represents a series of blocks (i.e., a block "matchup" in
+						// rainbow mode), then we just need to extend it by 1 more to account for the newly added block.
+						// However, if there is only one original* block represented by the matchup, then the
+						// multi-block count is 0 (not 1), so we need to increment it by 2 to reflext that there
+						// are now two blocks. (So basically, IIRC, 1 is not really a valid value for the multi-
+						// block count.)
+						// * We based the count of the number of original blocks, even if the process of matching
+						// them up causes them to be split into separate verses.
 						var extendBy = m_relevantBookBlockIndices[m_currentRelevantIndex].IsMultiBlock ? (uint)1 : 2;
 						m_navigator.ExtendCurrentBlockGroup(extendBy);
 						if (m_currentRelevantIndex >= 0)

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -1191,9 +1191,10 @@ namespace Glyssen.Dialogs
 						// We need to increment the count of blocks in both the navigator and the current
 						// relevant block (if the current matchup is relevant). These BookBlockIndices objects
 						// are (hopefully identical?) copies of each other.
-						m_navigator.ExtendCurrentBlockGroup(1);
+						var extendBy = m_relevantBookBlockIndices[m_currentRelevantIndex].IsMultiBlock ? (uint)1 : 2;
+						m_navigator.ExtendCurrentBlockGroup(extendBy);
 						if (m_currentRelevantIndex >= 0)
-							m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount++;
+							m_relevantBookBlockIndices[m_currentRelevantIndex].MultiBlockCount += extendBy;
 						return;
 					}
 					// else - This can happen when using a filter (e.g., All Scripture) that does not make use

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -1016,7 +1016,7 @@ namespace GlyssenTests.Dialogs
 			var origRelevantBlockCount = model.RelevantBlockCount;
 			var origBlock = model.CurrentReferenceTextMatchup.OriginalBlocks.Single();
 			var origBlockText = origBlock.GetText(true);
-			var blockToSplit = model.CurrentReferenceTextMatchup.OriginalBlocks.First();
+			var blockToSplit = origBlock;
 
 			model.LoadNextRelevantBlock();
 			var origNextRelevantBlockText = model.CurrentBlock.GetText(true);
@@ -1039,6 +1039,45 @@ namespace GlyssenTests.Dialogs
 
 			model.LoadNextRelevantBlock();
 			Assert.AreEqual(origNextRelevantBlockText, model.CurrentBlock.GetText(true));
+		}
+
+		// PG-1204
+		[Test]
+		public void SplitBlock_TextBlockIsOnlyOriginalBlockInIndex_BlockMatchupExtendedToContainBothBlocksAndStillBeRelevant()
+		{
+			var project = TestProject.CreateTestProject(TestProject.TestBook.MAT);
+			var model = new AssignCharacterViewModel(project);
+
+			model.Mode = BlocksToDisplay.MissingExpectedQuote;
+			model.AttemptRefBlockMatchup = true;
+			Assert.IsTrue(model.IsCurrentBlockRelevant);
+			while (model.CurrentReferenceTextMatchup.OriginalBlockCount != 1 && model.CanNavigateToNextRelevantBlock)
+			{
+				model.LoadNextRelevantBlock();
+			}
+			Assert.IsTrue(model.IsCurrentBlockRelevant, $"Setup problem: no block in {project.IncludedBooks.Single().BookId} " +
+				$"matches the filter for {model.Mode} and results in a matchup with a single original block.");
+
+			var origBlock = model.CurrentReferenceTextMatchup.OriginalBlocks.Single();
+			var origBlockText = origBlock.GetText(true);
+			var blockToSplit = origBlock;
+
+			var indexOfFirstVerseElement = blockToSplit.BlockElements.IndexOf(be => be is Verse);
+			var verseToSplit = ((Verse)blockToSplit.BlockElements[indexOfFirstVerseElement]).Number;
+			var splitPosInVerse = ((ScriptText)blockToSplit.BlockElements[indexOfFirstVerseElement + 1]).Content.IndexOf(" ");
+
+			model.SplitBlock(new[] { new BlockSplitData(1, blockToSplit, verseToSplit, splitPosInVerse) },
+				GetListOfCharacters(2, new[] { "", "" }));
+
+			Assert.AreEqual(2, model.CurrentReferenceTextMatchup.OriginalBlockCount);
+			Assert.AreEqual(origBlock, model.CurrentReferenceTextMatchup.OriginalBlocks.First());
+			Assert.AreEqual(String.Join("", model.CurrentReferenceTextMatchup.OriginalBlocks.Select(b => b.GetText(true))), origBlockText);
+
+			var indexOfBlockThatWasSplitOff = model.IndexOfLastBlockInCurrentGroup;
+			model.Mode = BlocksToDisplay.AllScripture;
+			model.LoadNextRelevantBlock();
+
+			Assert.True(model.IndexOfFirstBlockInCurrentGroup > indexOfBlockThatWasSplitOff);
 		}
 
 		// PG-1075


### PR DESCRIPTION
When an existing matchup has a single original block, splitting it turns it into a proper multi-block matchup.
Also made small improvement to logging for better future diagnostics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/503)
<!-- Reviewable:end -->
