### PR TITLE
PG-1230: Relax logic to disallow ChapterAnnouncement options based on IncludedBooks

### DIFF
--- a/Glyssen/Dialogs/ProjectSettingsDlg.cs
+++ b/Glyssen/Dialogs/ProjectSettingsDlg.cs
@@ -51,9 +51,11 @@ namespace Glyssen.Dialogs
 					"DialogBoxes.ProjectSettingsDlg.ChapterAnnouncementTab.BookMarkerComboBox.Items." + chapterAnnouncement,
 					m_cboBookMarker.Items[i].ToString()), chapterAnnouncement);
 			}
-			if (model.Project.IncludedBooks.All(book => string.IsNullOrEmpty(book.PageHeader)))
+
+			IReadOnlyList<BookScript> books = model.Project.IncludedBooks.Any() ? model.Project.IncludedBooks : model.Project.Books;
+			if (books.All(book => string.IsNullOrEmpty(book.PageHeader)))
 				RemoveItemFromBookMarkerCombo(ChapterAnnouncement.PageHeader);
-			if (model.Project.IncludedBooks.All(book => string.IsNullOrEmpty(book.MainTitle)))
+			if (books.All(book => string.IsNullOrEmpty(book.MainTitle)))
 				RemoveItemFromBookMarkerCombo(ChapterAnnouncement.MainTitle1);
 
 			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;


### PR DESCRIPTION
When disallowing ChapterAnnouncement options that depend on IncludedBooks, if there are no included books, use all Books instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/518)
<!-- Reviewable:end -->
