### PR TITLE
PG-1238: Fixed special row height adjustment logic

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
@@ -1155,6 +1155,8 @@ namespace Glyssen.Dialogs
 			this.m_dataGridReferenceText.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.m_dataGridReferenceText_CellValidating);
 			this.m_dataGridReferenceText.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.m_dataGridReferenceText_EditingControlShowing);
 			this.m_dataGridReferenceText.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.UpdateRowSpecificButtonStates);
+			this.m_dataGridReferenceText.RowHeightChanged += new System.Windows.Forms.DataGridViewRowEventHandler(this.m_dataGridReferenceText_RowHeightChanged);
+			this.m_dataGridReferenceText.Resize += new System.EventHandler(this.CheckRowHeights);
 			// 
 			// colCharacter
 			// 


### PR DESCRIPTION
This prevents crashes and general twitchiness when large amounts of data are on the clipboard or when cells contain huge amounts of text.
(DataGridView behaves very poorly when a single row gets taller than the entire control.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/522)
<!-- Reviewable:end -->
