### PR TITLE
Added trace listener to channel trace info from ParatextData into our log file.

### DIFF
--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -380,6 +380,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Utilities\L10N.cs" />
+    <Compile Include="Utilities\LogFileTraceListener.cs" />
     <Compile Include="Utilities\MessageBoxStrings.cs" />
     <Compile Include="Utilities\UndoActionSequence.cs" />
     <Compile Include="Dialogs\VoiceActorAssignmentUndoAction.cs" />

--- a/Glyssen/Program.cs
+++ b/Glyssen/Program.cs
@@ -67,7 +67,10 @@ namespace Glyssen
 			UserInfo userInfo = new UserInfo { UILanguageCode = Settings.Default.UserInterfaceLanguage };
 			bool sldrIsInitialized = false;
 
-			Alert.Implementation = new AlertImpl(); // Do this before calling Initialize, just in case Initilize tries to display an alert.
+			Logger.Init();
+			Trace.Listeners.Add(new LogFileTraceListener());
+
+			Alert.Implementation = new AlertImpl(); // Do this before calling Initialize, just in case Initialize tries to display an alert.
 			if (ParatextInfo.IsParatextInstalled)
 			{
 				string userName = null;
@@ -139,8 +142,6 @@ namespace Glyssen
 			using (new Analytics("WEyYj2BOnZAP9kplKmo2BDPvfyofbMZy", userInfo, allowTracking))
 #endif
 			{
-				Logger.Init();
-
 				foreach (var exception in _pendingExceptionsToReportToAnalytics)
 					Analytics.ReportException(exception);
 				_pendingExceptionsToReportToAnalytics.Clear();

--- a/Glyssen/Utilities/LogFileTraceListener.cs
+++ b/Glyssen/Utilities/LogFileTraceListener.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using SIL.Reporting;
+
+namespace Glyssen.Utilities
+{
+	class LogFileTraceListener : TraceListener
+	{
+		public override void Write(string message)
+		{
+			WriteLine(message);
+		}
+
+		public override void WriteLine(string message)
+		{
+			Logger.WriteEvent(message);
+		}
+
+		public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id,
+			string format, params object[] args)
+		{
+			// Write timestamp and calling method
+			WriteLine($"[{DateTime.Now:yyyy-MM-dd'T'HH:mm:sszz}, Thread={ThreadId}] - {eventType}: ");
+			WriteLine(string.Format(format, args));
+		}
+
+		/// <summary>
+		/// Calculate a unique thread description.
+		/// </summary>
+		/// <returns>unique thread description</returns>
+		private static string ThreadId =>
+			Thread.CurrentThread.Name == null ? "Unnamed thread" : Thread.CurrentThread.Name +
+				$"({Thread.CurrentThread.ManagedThreadId})";
+	}
+}


### PR DESCRIPTION
I implemented this in hopes of getting some useful info to track down ICU load error reported in PG-1234. However, the trace info from ICU do not make it out, so all we get is the trace inf from ParatextData. Still that seems like a useful improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/523)
<!-- Reviewable:end -->
