### PR TITLE
PG-1246: Prevented duplicate reference text blocks at end of book

### DIFF
--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -279,25 +279,40 @@ namespace Glyssen
 
 			for (int iVernBlock = 0; iVernBlock < vernBlockList.Count; iVernBlock++, iRefBlock++)
 			{
-				if (iRefBlock >= refBlockList.Count && iRefBlockMemory < 0)
-				{
-					// We still have more vernacular verses to consider. Most likely, this is an
-					// additional alternate ending (in Mark). It's not very efficient, but we'll just
-					// start back at the beginning of the reference text block collection.
-					iRefBlock = 0;
-				}
-
 				var currentVernBlock = vernBlockList[iVernBlock];
 
-				// TODO: This handles the only case I know of (and for which there is a test) where a versification pulls in verses
-				// from the end of the book to an earlier spot, namely Romans 14:24-26 <- Romans 16:25-27. If we ever have this same
-				// kind of behavior that is pulling from somewhere other than the *end* of the book, the logic to reset iRefBlock
-				// based on iRefBlockMemory will need to be moved/added elsewhere.
-				if (iRefBlockMemory >= 0 && iRefBlock >= refBlockList.Count)
+				if (iRefBlock >= refBlockList.Count)
 				{
-					iRefBlock = iRefBlockMemory;
-					iRefBlockMemory = -1;
+					if (iRefBlockMemory < 0)
+					{
+						Debug.Assert(iVernBlock > 0);
+						if (currentVernBlock.LastVerseNum == vernBlockList[iVernBlock - 1].LastVerseNum)
+						{
+							// Either this is a section head, in which case we don't care until we get to the
+							// next actual Scripture block; or the vernacular happens to have more blocks in the
+							// last verse at the end of the book, in which case they will just go unmatched.
+							continue;
+						}
+
+						// We still have more vernacular verses to consider. Most likely, this is an
+						// additional alternate ending (in Mark).
+						if (bookId != "MRK")
+							Logger.WriteMinorEvent("Reference text matching went off end of ref block list for " +
+								$"vern block {currentVernBlock}");
+						iRefBlock = refBook.GetIndexOfFirstBlockForVerse(currentVernBlock.ChapterNumber, currentVernBlock.InitialStartVerseNumber);
+					}
+					else
+					{
+						// This handles the only case I know of (and for which there is a test) where a versification pulls in verses
+						// from the end of the book to an earlier spot, namely Romans 14:24-26 <- Romans 16:25-27. If we ever have this same
+						// kind of behavior that is pulling from somewhere other than the *end* of the book, the logic to reset iRefBlock
+						// based on iRefBlockMemory will need to be moved/added elsewhere.
+						iRefBlock = iRefBlockMemory;
+						iRefBlockMemory = -1;
+					}
 				}
+
+
 				var currentRefBlock = refBlockList[iRefBlock];
 				var vernInitStartVerse = new VerseRef(bookNum, currentVernBlock.ChapterNumber, currentVernBlock.InitialStartVerseNumber, vernacularVersification);
 				var refInitStartVerse = new VerseRef(bookNum, currentRefBlock.ChapterNumber, currentRefBlock.InitialStartVerseNumber, Versification);
@@ -346,7 +361,7 @@ namespace Glyssen
 							if (currentRefBlock.IsChapterAnnouncement)
 								continue;
 						}
-						goto case CharacterVerseData.StandardCharacter.ExtraBiblical;
+						goto case CharacterVerseData.StandardCharacter.ExtraBiblical; // Book title
 					case CharacterVerseData.StandardCharacter.ExtraBiblical:
 						if (type == CharacterVerseData.GetStandardCharacterType(currentRefBlock.CharacterId))
 						{

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -2663,6 +2663,25 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void GetBooksWithBlocksConnectedToReferenceText_ExtraBlockAtEndOfBook_ExtraBlocksNotAlignedtoreferenceText()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(CreateBlockForVerse("Jesus", 19,
+				"“Tell everybody everywhere about me and get them to follow me,” ", true, 28, "p", 21));
+			AddNarratorBlockForVerseInProgress(vernacularBlocks, "said Jesus.");
+			var testProject = TestProject.CreateTestProject(TestProject.TestBook.MAT);
+			testProject.Books[0].Blocks = vernacularBlocks;
+
+			var primaryReferenceText = ReferenceText.GetReferenceText(ReferenceTextProxy.GetOrCreate(ReferenceTextType.English));
+
+			var result = primaryReferenceText.GetBooksWithBlocksConnectedToReferenceText(testProject).Single().GetScriptBlocks();
+
+			Assert.AreEqual(2, result[0].ReferenceBlocks.Count);
+			Assert.IsFalse(result[1].MatchesReferenceText);
+			Assert.IsFalse(result[1].ReferenceBlocks.Any());
+		}
+
+		[Test]
 		public void GetBlocksForVerseMatchedToReferenceText_BadIndex_ThrowsArgumentOutOfRangeException()
 		{
 			var vernBook = new BookScript("MAT", new List<Block>(0));


### PR DESCRIPTION
 when vern has more blocks than the ref text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/525)
<!-- Reviewable:end -->
