### PR TITLE
PG-1446: Fixed several bugs which combined to prevent proper parsing of verse number…

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -355,7 +355,8 @@ namespace Glyssen
 		{
 			if (referenceBlocksToJoin == null)
 				referenceBlocksToJoin = ReferenceBlocks;
-			var refBlock = new Block(StyleTag, ChapterNumber, InitialStartVerseNumber, InitialEndVerseNumber);
+			var baseBlock = (referenceBlocksToJoin?.FirstOrDefault() ?? this);
+			var refBlock = new Block(StyleTag, ChapterNumber, baseBlock.InitialStartVerseNumber, baseBlock.InitialEndVerseNumber);
 			refBlock.SetCharacterAndDeliveryInfo(this, bookNum, versification);
 			if (referenceBlocksToJoin.Any())
 				refBlock.AppendJoinedBlockElements(referenceBlocksToJoin, referenceLanguageInfo);
@@ -373,11 +374,15 @@ namespace Glyssen
 			var prevVerse = prevRefBlock == null ? (VerseNumberFromBlock)this : prevRefBlock.LastVerse;
 			var refBlock = GetEmptyReferenceBlock(prevVerse);
 			refBlock.ParsePlainText(text);
-			if (!refBlock.StartsAtVerseStart)
+			if (!refBlock.StartsAtVerseStart && prevRefBlock == null && refBlock.InitialEndVerseNumber > 0)
 			{
+				// If we don't have a preceding ref block that can be used to imply the starting verse number/bridge
+				// for this ref block, we at least want to prevent it from looking like it starts at or before the
+				// first verse number it actually contains, so we infer that it starts at the preceding verse. This
+				// is not a common scenario, and it is really somewhat of a guess as to what is actually happening.
 				var firstVerseInRefBlock = refBlock.BlockElements.OfType<Verse>().FirstOrDefault();
-				if (firstVerseInRefBlock != null && firstVerseInRefBlock.EndVerse <= refBlock.InitialEndVerseNumber)
-					refBlock.InitialEndVerseNumber = firstVerseInRefBlock.EndVerse - 1;
+				if (firstVerseInRefBlock != null && firstVerseInRefBlock.StartVerse <= refBlock.InitialEndVerseNumber)
+					refBlock.InitialEndVerseNumber = firstVerseInRefBlock.StartVerse - 1;
 			}
 			SetMatchedReferenceBlock(refBlock);
 
@@ -467,6 +472,7 @@ namespace Glyssen
 							if (!Int32.TryParse(match.Result("${endVerse}"), out endVerse))
 								endVerse = 0;
 							InitialEndVerseNumber = endVerse;
+							prependSpace = "";
 						}
 					}
 					else
@@ -556,7 +562,7 @@ namespace Glyssen
 		{
 			get
 			{
-				return BlockElements.First() is Verse || (StartsWithScriptTextElementContainingOnlyPunctuation && ContainsVerseNumber);
+				return !(BlockElements.First() is ScriptText) || (StartsWithScriptTextElementContainingOnlyPunctuation && ContainsVerseNumber);
 			}
 		}
 

--- a/Glyssen/BlockMatchup.cs
+++ b/Glyssen/BlockMatchup.cs
@@ -234,7 +234,10 @@ namespace Glyssen
 			block.CloneReferenceBlocks();
 			if (text == null)
 				text = string.Empty;
-			var newRefBlock = block.SetMatchedReferenceBlock(text, (blockIndex > 0) ? CorrelatedBlocks[blockIndex - 1].ReferenceBlocks.LastOrDefault() : null);
+			var prevRefBlock = (blockIndex > 0) ? CorrelatedBlocks[blockIndex - 1].ReferenceBlocks.LastOrDefault() : null;
+			for (int i = 0; i < level && prevRefBlock != null; i++)
+				prevRefBlock = prevRefBlock.ReferenceBlocks.LastOrDefault();
+			var newRefBlock = block.SetMatchedReferenceBlock(text, prevRefBlock);
 			bool foundFollowingPrimaryRefTextVerse = false;
 			bool foundFollowingSecondaryRefTextVerse = false;
 			while (++blockIndex < CorrelatedBlocks.Count)

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1814,12 +1814,12 @@ namespace Glyssen.Dialogs
 			if (!m_dataGridReferenceText.IsCurrentCellInEditMode)
 				m_dataGridReferenceText.BeginEdit(false);
 			var editingCtrl = (DataGridViewTextBoxEditingControl)m_dataGridReferenceText.EditingControl;
-			editingCtrl.Click -= HandleClickToSplitText; // ensure we don't double-subscribe
-			editingCtrl.Click += HandleClickToSplitText;
-			editingCtrl.HandleDestroyed -= HandleClickToSplitText;
+			editingCtrl.Click -= HandleClickToSplitRefText; // ensure we don't double-subscribe
+			editingCtrl.Click += HandleClickToSplitRefText;
+			editingCtrl.HandleDestroyed -= HandleClickToSplitRefText;
 		}
 
-		private void HandleClickToSplitText(object sender, EventArgs eventArgs)
+		private void HandleClickToSplitRefText(object sender, EventArgs eventArgs)
 		{
 			var editingCtrl = (DataGridViewTextBoxEditingControl)sender;
 			if (editingCtrl.SelectionStart <= 0 || editingCtrl.SelectionStart >= editingCtrl.TextLength || editingCtrl.SelectionLength > 0)
@@ -1828,7 +1828,7 @@ namespace Glyssen.Dialogs
 					"To split the reference text, click the location where it is to be split. Do not attempt to make a text selection " +
 					"or click at the very start or end of the text. You will need to select the {0} command again to enable splitting now.");
 				MessageBox.Show(this, String.Format(msgFmt, m_ContextMenuItemSplitText.Text), ProductName, MessageBoxButtons.OK, MessageBoxIcon.Information);
-				editingCtrl.Click -= HandleClickToSplitText;
+				editingCtrl.Click -= HandleClickToSplitRefText;
 				return;
 			}
 			var currCell = m_dataGridReferenceText.CurrentCell;
@@ -1847,7 +1847,7 @@ namespace Glyssen.Dialogs
 			}
 			m_dataGridReferenceText.CurrentCell = destCell;
 			if (GetSplitTextDestination() == null)
-				editingCtrl.Click -= HandleClickToSplitText;
+				editingCtrl.Click -= HandleClickToSplitRefText;
 		}
 
 		private DataGridViewCell GetSplitTextDestination()

--- a/GlyssenShared/BlockElement.cs
+++ b/GlyssenShared/BlockElement.cs
@@ -216,7 +216,7 @@ namespace Glyssen.Shared
 		private const string kMusic = "Music";
 		private const string kSfx = "SFX";
 		public const int kNonSpecificStartOrStop = -999;
-		public const string kRegexForUserLocatedSounds = @"((\u00A0| )*\{F8 (?<musicOrSfx>(" + kSfx + ")|(" + kMusic + "))" + kDetailSeparatorDisplayString + @"(?<effectDetails>.*)\})";
+		public const string kRegexForUserLocatedSounds = @"((\u00A0| )*\{F8 (?<musicOrSfx>(" + kSfx + ")|(" + kMusic + "))" + kDetailSeparatorDisplayString + @"(?<effectDetails>[^\{\}]*)\})";
 
 		[XmlAttribute("soundType")]
 		[DefaultValue(SoundType.Music)]

--- a/GlyssenTests/BlockMatchupTests.cs
+++ b/GlyssenTests/BlockMatchupTests.cs
@@ -875,6 +875,11 @@ namespace GlyssenTests
 		[Test]
 		public void SetReferenceText_FirstBlock_RefBlockContainsBridge_ReferenceBlockHasStartVerseNumberImpliedByVerseNumberInRefBlock()
 		{
+			// The logic represented here is entirely "fuzzy", but the idea is that since the corresponding vernacular block is a verse
+			// bridge from 1-3, that the reference text is "probably" for that same range. But since it turns out that the reference
+			// text has a 3-4 verse bridge in the middle of it, logically the preceding text can't be for verse 1-3, so they must be
+			// for verses 1-2.
+			
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnknownCharacter, 1, "Entonces Jesus hablo, diciendo: ", true, 1, "p", 3));
 			vernacularBlocks.Last().SetMatchedReferenceBlock(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Then Jesus spoke unto them, ", true));

--- a/GlyssenTests/BlockMatchupTests.cs
+++ b/GlyssenTests/BlockMatchupTests.cs
@@ -843,7 +843,7 @@ namespace GlyssenTests
 		[TestCase("\u00A0")]
 		[TestCase(" ")]
 		[TestCase("")]
-		public void SetReferenceText_FirstBlock_VernBlockHasVerseBridgeThatCoversNumberInRefBlock_SpecifiedBlockMatchedWithReferenceBlockHavingStartVerseNumberFromVernBlock(string separator)
+		public void SetReferenceText_FirstBlock_VernBlockHasVerseBridgeThatCoversNumberInRefBlock_SpecifiedBlockMatchedWithReferenceBlockHavingStartVerseNumberImpliedByVerseNumberInRefBlock(string separator)
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnknownCharacter, 1, "Entonces Jesus hablo, diciendo: ", true, 1, "p", 3));
@@ -870,6 +870,60 @@ namespace GlyssenTests
 			Assert.AreEqual(1, newRefBlock.InitialStartVerseNumber);
 			Assert.AreEqual(0, newRefBlock.InitialEndVerseNumber);
 			Assert.AreEqual(2, newRefBlock.LastVerseNum);
+		}
+
+		[Test]
+		public void SetReferenceText_FirstBlock_RefBlockContainsBridge_ReferenceBlockHasStartVerseNumberImpliedByVerseNumberInRefBlock()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnknownCharacter, 1, "Entonces Jesus hablo, diciendo: ", true, 1, "p", 3));
+			vernacularBlocks.Last().SetMatchedReferenceBlock(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Then Jesus spoke unto them, ", true));
+
+			var block2 = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, "Jesus", "“Este es versiculo dos y tres.”", "p");
+			block2.SetMatchedReferenceBlock(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“This is verse two.”", false, 1, "p", 3));
+
+			var vernBook = new BookScript("MAT", vernacularBlocks);
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, null);
+			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => b.MatchesReferenceText));
+
+			var newRefBlock = matchup.SetReferenceText(0, "Then Jesus told them {3-4}that it was actually a verse bridge starting with three.");
+			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => b.MatchesReferenceText));
+			// Ensure block 1 not changed
+			Assert.AreEqual("Jesus", matchup.CorrelatedBlocks[1].CharacterId);
+			Assert.AreEqual("{2-3}\u00A0“This is verse two.”", matchup.CorrelatedBlocks[1].GetPrimaryReferenceText());
+
+			Assert.AreEqual("Then Jesus told them {3-4}\u00A0that it was actually a verse bridge starting with three.", matchup.CorrelatedBlocks[0].GetPrimaryReferenceText());
+			Assert.AreEqual(matchup.CorrelatedBlocks[0].ReferenceBlocks.Single(), newRefBlock);
+			Assert.AreEqual(1, newRefBlock.InitialStartVerseNumber);
+			Assert.AreEqual(2, newRefBlock.InitialEndVerseNumber);
+			Assert.AreEqual(4, newRefBlock.LastVerseNum);
+		}
+
+		[Test]
+		public void SetReferenceText_FirstBlock_RefBlockContainsAnnotationAndThenBridge_ReferenceBlockHasStartVerseNumberImpliedByVerseNumberInRefBlock()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnknownCharacter, 1, "Entonces Jesus hablo, diciendo: ", true, 1, "p", 3));
+			vernacularBlocks.Last().SetMatchedReferenceBlock(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Then Jesus spoke unto them, ", true));
+
+			var block2 = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, "Jesus", "“Este es versiculo dos y tres.”", "p");
+			block2.SetMatchedReferenceBlock(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“This is verse two.”", false, 1, "p", 3));
+
+			var vernBook = new BookScript("MAT", vernacularBlocks);
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, null);
+			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => b.MatchesReferenceText));
+
+			var newRefBlock = matchup.SetReferenceText(0, "{F8 Music--Ends} {3-4}This is actually a verse bridge starting with three.");
+			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => b.MatchesReferenceText));
+			// Ensure block 1 not changed
+			Assert.AreEqual("Jesus", matchup.CorrelatedBlocks[1].CharacterId);
+			Assert.AreEqual("{2-3}\u00A0“This is verse two.”", matchup.CorrelatedBlocks[1].GetPrimaryReferenceText());
+
+			Assert.AreEqual("{F8 Music--Ends} {3-4}\u00A0This is actually a verse bridge starting with three.", matchup.CorrelatedBlocks[0].GetPrimaryReferenceText());
+			Assert.AreEqual(matchup.CorrelatedBlocks[0].ReferenceBlocks.Single(), newRefBlock);
+			Assert.AreEqual(3, newRefBlock.InitialStartVerseNumber);
+			Assert.AreEqual(4, newRefBlock.InitialEndVerseNumber);
+			Assert.AreEqual(4, newRefBlock.LastVerseNum);
 		}
 
 		[Test]
@@ -1138,6 +1192,36 @@ namespace GlyssenTests
 			Assert.AreEqual(3, newRefBlock.InitialStartVerseNumber);
 			Assert.AreEqual(0, newRefBlock.InitialEndVerseNumber);
 			Assert.AreEqual(4, newRefBlock.LastVerseNum);
+		}
+
+		[TestCase("")]
+		[TestCase("{F8 Music--Ends} ")]
+		public void SetReferenceText_Secondary_AnnotationAndVerseNumberAtStart_VerseNumberNotLost(string annotationText)
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(2, "Esigit diluk nen ane yogiseke:", false, 18, "REV", "p", 3));
+			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, "angel, another, coming down from heaven",
+				"“O nggok Babel kagarogo ’bigi o! It kota Babel kagarigogo mende ma, en oba dagasinem,");
+			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, "angel, another, coming down from heaven",
+				"Kagat nabini, yiluk, akoni, kugi obabut weyak mende inom,");
+			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, "angel, another, coming down from heaven",
+				"Sewe nausak dek yiluk mende ta’bokogona inom, kagat laga o,” ");
+			ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks, "yiluk yogiseke.");
+			var vernBook = new BookScript("REV", vernacularBlocks);
+			var russianRefText = ReferenceText.GetStandardReferenceText(ReferenceTextType.Russian);
+			var matchup = russianRefText.GetBlocksForVerseMatchedToReferenceText(vernBook, 0, russianRefText.Versification);
+			matchup.MatchAllBlocks(null);
+			matchup.SetReferenceText(0, "{2} He cried with a mighty voice, saying,", 1);
+			matchup.SetReferenceText(1, "“Fallen is Babylon! She is a home of demons, spirits and unclean birds!", 1);
+			matchup.SetReferenceText(2, "spirits and unclean birds!", 1);
+			matchup.SetReferenceText(3, annotationText + "{3} All nations had sex and got rich with her.”", 1);
+			var englishRefBlockForVernBlock3 = matchup.CorrelatedBlocks[3].ReferenceBlocks.Single().ReferenceBlocks.Single();
+			if (annotationText.Length > 0)
+				Assert.IsTrue(englishRefBlockForVernBlock3.BlockElements.OfType<Sound>().Single().SoundType == SoundType.Music);
+			Assert.AreEqual("3", englishRefBlockForVernBlock3.BlockElements.OfType<Verse>().Single().Number);
+			Assert.AreEqual("3", englishRefBlockForVernBlock3.InitialVerseNumberOrBridge);
+			Assert.AreEqual("All nations had sex and got rich with her.”",
+				((ScriptText)englishRefBlockForVernBlock3.BlockElements.Last()).Content);
 		}
 
 		[Test]

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -3302,10 +3302,11 @@ namespace GlyssenTests
 			return AddBlockForVerseInProgress(list, CharacterVerseData.GetStandardCharacterId(book, CharacterVerseData.StandardCharacter.Narrator), text);
 		}
 
-		internal static Block CreateNarratorBlockForVerse(int verseNumber, string text, bool paraStart = false, int chapter = 1, string book = "MAT", string styleTag = "p")
+		internal static Block CreateNarratorBlockForVerse(int verseNumber, string text, bool paraStart = false, int chapter = 1,
+			string book = "MAT", string styleTag = "p", int initialEndVerseNumber = 0)
 		{
 			return CreateBlockForVerse(CharacterVerseData.GetStandardCharacterId(book, CharacterVerseData.StandardCharacter.Narrator),
-				verseNumber, text, paraStart, chapter, styleTag);
+				verseNumber, text, paraStart, chapter, styleTag, initialEndVerseNumber);
 		}
 		#endregion
 	}


### PR DESCRIPTION
…in a reference text being SplitBlock

Also improved implementation and clarity in logic designed to prevent a screwy InitialEndVerseNumber when parsing a verse number in a reference text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/526)
<!-- Reviewable:end -->
