### PR TITLE
Updated Glyssen to use latest ParatextData, libpalaso and L10nSharp

### DIFF
--- a/ControlDataIntegrityTests/App.config
+++ b/ControlDataIntegrityTests/App.config
@@ -7,15 +7,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
+++ b/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
@@ -39,43 +39,49 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.5.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.5.4\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Paratext.LexicalContracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9a5af29a0e638a7b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Paratext.LexicalContracts.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\dotnet\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Spart.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Spart.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -111,7 +117,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\ParatextData.8.1.7\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" />
+  <Import Project="..\packages\ParatextData.9.0.3\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.9.0.3\build\ParatextData.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ControlDataIntegrityTests/packages.config
+++ b/ControlDataIntegrityTests/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
+  <package id="icu.net" version="2.5.4" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="ParatextData" version="8.1.7" targetFramework="net461" />
+  <package id="ParatextData" version="9.0.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/DevTools/App.config
+++ b/DevTools/App.config
@@ -7,15 +7,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DevTools/DevTools.csproj
+++ b/DevTools/DevTools.csproj
@@ -37,29 +37,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.5.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.5.4\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Paratext.LexicalContracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9a5af29a0e638a7b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Paratext.LexicalContracts.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -74,10 +74,16 @@
       <HintPath>..\lib\dotnet\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Spart.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Spart.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -158,7 +164,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\ParatextData.8.1.7\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" />
+  <Import Project="..\packages\ParatextData.9.0.3\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.9.0.3\build\ParatextData.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DevTools/packages.config
+++ b/DevTools/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
   <package id="EPPlus" version="4.0.5" targetFramework="net45" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="ParatextData" version="8.1.7" targetFramework="net461" />
+  <package id="icu.net" version="2.5.4" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="ParatextData" version="9.0.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
-  <header srclang="es" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="3.0.43.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
+  <header srclang="es" adminlang="en" creationtool="Palaso Localization Manager" creationtoolversion="4.0.0.0" segtype="block" datatype="unknown" o-tmf="PalasoTMXUtils">
     <prop type="x-appversion">1.1.0.0</prop>
     <prop type="x-hardlinebreakreplacement">\n</prop>
   </header>
@@ -9369,6 +9369,14 @@
       </tuv>
       <tuv xml:lang="es">
         <seg>Faltante: {0}</seg>
+      </tuv>
+    </tu>
+    <tu tuid="DialogBoxes.ProjectSettingsDlg.OverwriteProjectFailed">
+      <tuv xml:lang="en">
+        <seg>{0} was unable to delete all of the files in {1}. You can try to clean this up manually and then re-attempt saving these changes.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>{0} no pudo eliminar todos los archivos en {1}. Puede intentar limpiar esto manualmente y luego volver a intentar guardar estos cambios.</seg>
       </tuv>
     </tu>
     <tu tuid="DialogBoxes.ProjectSettingsDlg.OverwriteProjectPrompt">

--- a/Glyssen.sln.DotSettings
+++ b/Glyssen.sln.DotSettings
@@ -8,4 +8,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=StaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="s_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb_AaBb"&gt;&lt;ExtraRule Prefix="m_" Suffix="" Style="aaBb_AaBb" /&gt;&lt;/Policy&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="k" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="k" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Glyssen/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -55,15 +55,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Glyssen/Character/ControlCharacterVerseData.cs
+++ b/Glyssen/Character/ControlCharacterVerseData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Glyssen.Properties;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.Scripture;
 
@@ -23,7 +24,7 @@ namespace Glyssen.Character
 				if (Program.IsRunning)
 					throw new InvalidOperationException();
 				s_readHypotheticalAsNarrator = value;
-				s_singleton = null;
+				s_singleton?.Dispose();
 			}
 		}
 
@@ -39,7 +40,7 @@ namespace Glyssen.Character
 			set
 			{
 				s_tabDelimitedCharacterVerseData = value;
-				s_singleton = null;
+				s_singleton?.Dispose();
 			}
 		}
 
@@ -49,7 +50,13 @@ namespace Glyssen.Character
 			if (TabDelimitedCharacterVerseData == null)
 				TabDelimitedCharacterVerseData = Resources.CharacterVerseData;
 			LoadAll();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized; // Don't need to unsubscribe since this object will be around as long as the program is running.
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized; // Don't need to unsubscribe since this object will be around as long as the program is running.
+		}
+
+		private void Dispose()
+		{
+			LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+			s_singleton = null;
 		}
 
 		public static ControlCharacterVerseData Singleton

--- a/Glyssen/Controls/ExistingProjectsList.Designer.cs
+++ b/Glyssen/Controls/ExistingProjectsList.Designer.cs
@@ -1,5 +1,5 @@
-﻿using System.Security.AccessControl;
-using Gecko;
+﻿using L10NSharp.TMXUtils;
+using L10NSharp.UI;
 
 namespace Glyssen.Controls
 {
@@ -16,9 +16,12 @@ namespace Glyssen.Controls
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Controls/ExistingProjectsList.cs
+++ b/Glyssen/Controls/ExistingProjectsList.cs
@@ -9,6 +9,7 @@ using Glyssen.Shared;
 using Glyssen.Shared.Bundle;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using Paratext.Data;
 using SIL.DblBundle;
@@ -40,7 +41,7 @@ namespace Glyssen.Controls
 		public ExistingProjectsList()
 		{
 			InitializeComponent();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 			HandleStringsLocalized();
 		}
 

--- a/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using L10NSharp.UI;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Controls
 {
@@ -17,7 +18,7 @@ namespace Glyssen.Controls
 		{
 			if (disposing && (components != null))
 			{
-				LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 				if (ParentForm != null)
 					ParentForm.Closing -= ParentForm_Closing;
 				components.Dispose();

--- a/Glyssen/Controls/VoiceActorInformationGrid.cs
+++ b/Glyssen/Controls/VoiceActorInformationGrid.cs
@@ -8,6 +8,7 @@ using DesktopAnalytics;
 using Glyssen.Utilities;
 using Glyssen.VoiceActor;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.Reporting;
 
@@ -68,7 +69,7 @@ namespace Glyssen.Controls
 			Cameo.ToolTipText = LocalizationManager.GetString("DialogBoxes.VoiceActorInformation.CameoTooltip",
 				"Distinguished actor to play minor character role.");
 
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		private void HandleStringsLocalized()

--- a/Glyssen/Dialogs/AddCharacterToGroupDlg.Designer.cs
+++ b/Glyssen/Dialogs/AddCharacterToGroupDlg.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace Glyssen.Dialogs
+﻿using L10NSharp.UI;
+using L10NSharp.TMXUtils;
+
+namespace Glyssen.Dialogs
 {
 	partial class AddCharacterToGroupDlg
 	{
@@ -13,9 +16,12 @@
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/AddCharacterToGroupDlg.cs
+++ b/Glyssen/Dialogs/AddCharacterToGroupDlg.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using Glyssen.Utilities;
 using L10NSharp;
 using L10NSharp.UI;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -17,7 +17,7 @@ namespace Glyssen.Dialogs
 
 			m_viewModel = model;
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg< TMXDocument>.StringsLocalized += HandleStringsLocalized;
 			m_characterDetailsGrid.RowCount = m_viewModel.FilteredCharactersCount;
 		}
 

--- a/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Glyssen.Controls;
+﻿using Glyssen.Controls;
 using Glyssen.Utilities;
 using L10NSharp.UI;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -23,7 +23,7 @@ namespace Glyssen.Dialogs
 				m_dataGridReferenceText.DataError -= HandleDataGridViewDataError;
 
 				m_viewModel.CurrentBlockChanged -= LoadBlock;
-				LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 				m_viewModel.AssignedBlocksIncremented -= m_viewModel_AssignedBlocksIncremented;
 				m_viewModel.CurrentBlockMatchupChanged -= LoadBlockMatchup;
 				m_viewModel.UiFontSizeChanged -= SetFontsFromViewModel;

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -20,6 +20,7 @@ using Glyssen.Controls;
 using Glyssen.Properties;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.Extensions;
 using SIL.Reporting;
@@ -99,7 +100,7 @@ namespace Glyssen.Dialogs
 			m_scriptureReference.VerseControl.GetLocalizedBookName = L10N.GetLocalizedBookNameFunc(m_scriptureReference.VerseControl.GetLocalizedBookName);
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			if (m_viewModel.CanDisplayReferenceTextForCurrentBlock)
 			{

--- a/Glyssen/Dialogs/CastSizePlanningDlg.Designer.cs
+++ b/Glyssen/Dialogs/CastSizePlanningDlg.Designer.cs
@@ -1,4 +1,4 @@
-﻿using Glyssen.Bundle;
+﻿using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -18,7 +18,8 @@ namespace Glyssen.Dialogs
 		{
 			if (disposing)
 			{
-				LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+
 				if (m_viewModel != null)
 				{
 					m_viewModel.MaleNarratorsValueChanged -= m_viewModel_MaleNarratorsValueChanged;

--- a/Glyssen/Dialogs/CastSizePlanningDlg.Designer.cs
+++ b/Glyssen/Dialogs/CastSizePlanningDlg.Designer.cs
@@ -18,7 +18,7 @@ namespace Glyssen.Dialogs
 		{
 			if (disposing)
 			{
-				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 
 				if (m_viewModel != null)
 				{

--- a/Glyssen/Dialogs/CastSizePlanningDlg.cs
+++ b/Glyssen/Dialogs/CastSizePlanningDlg.cs
@@ -7,6 +7,7 @@ using Glyssen.Controls;
 using Glyssen.Shared;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -27,7 +28,7 @@ namespace Glyssen.Dialogs
 			m_castSizePlanningOptions.SetViewModel(m_viewModel);
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			m_tableLayoutStartingOver.Visible = m_viewModel.Project.CharacterGroupListPreviouslyGenerated;
 			m_maleNarrators.Maximum = m_viewModel.MaximumNarratorsValue;

--- a/Glyssen/Dialogs/ExportDlg.Designer.cs
+++ b/Glyssen/Dialogs/ExportDlg.Designer.cs
@@ -1,4 +1,6 @@
 ﻿using Glyssen.Utilities;
+using L10NSharp.TMXUtils;
+using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
 {
@@ -15,9 +17,12 @@ namespace Glyssen.Dialogs
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/ExportDlg.Designer.cs
+++ b/Glyssen/Dialogs/ExportDlg.Designer.cs
@@ -19,7 +19,7 @@ namespace Glyssen.Dialogs
 		{
 			if (disposing)
 			{
-				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 
 				if (components != null)
 					components.Dispose();

--- a/Glyssen/Dialogs/ExportDlg.cs
+++ b/Glyssen/Dialogs/ExportDlg.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using Glyssen.Shared;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -30,7 +31,7 @@ namespace Glyssen.Dialogs
 				HideControlsThatRequireVoiceActors();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			m_lblFileName.Text = m_viewModel.FullFileName;
 

--- a/Glyssen/Dialogs/ExportToRecordingToolDlg.Designer.cs
+++ b/Glyssen/Dialogs/ExportToRecordingToolDlg.Designer.cs
@@ -1,4 +1,6 @@
 ﻿using Glyssen.Utilities;
+using L10NSharp.TMXUtils;
+using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
 {
@@ -15,9 +17,12 @@ namespace Glyssen.Dialogs
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/ExportToRecordingToolDlg.Designer.cs
+++ b/Glyssen/Dialogs/ExportToRecordingToolDlg.Designer.cs
@@ -19,7 +19,7 @@ namespace Glyssen.Dialogs
 		{
 			if (disposing)
 			{
-				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 
 				if (components != null)
 					components.Dispose();

--- a/Glyssen/Dialogs/ExportToRecordingToolDlg.cs
+++ b/Glyssen/Dialogs/ExportToRecordingToolDlg.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 using Glyssen.Shared;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -17,7 +18,7 @@ namespace Glyssen.Dialogs
 			InitializeComponent();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		private void ExportToRecordingToolDlg_Load(object sender, EventArgs e)

--- a/Glyssen/Dialogs/NewCharacterDlg.Designer.cs
+++ b/Glyssen/Dialogs/NewCharacterDlg.Designer.cs
@@ -18,7 +18,7 @@ namespace Glyssen.Dialogs
 		{
 			if (disposing)
 			{
-				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 
 				if (components != null)
 					components.Dispose();

--- a/Glyssen/Dialogs/NewCharacterDlg.Designer.cs
+++ b/Glyssen/Dialogs/NewCharacterDlg.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace Glyssen.Dialogs
+﻿using L10NSharp.UI;
+using L10NSharp.TMXUtils;
+
+namespace Glyssen.Dialogs
 {
 	partial class NewCharacterDlg
 	{
@@ -13,9 +16,12 @@
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/NewCharacterDlg.cs
+++ b/Glyssen/Dialogs/NewCharacterDlg.cs
@@ -2,6 +2,7 @@
 using System.Windows.Forms;
 using Glyssen.Character;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -17,7 +18,7 @@ namespace Glyssen.Dialogs
 			InitializeComponent();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			PopulateComboBoxes();
 		}

--- a/Glyssen/Dialogs/ProjectSettingsDlg.Designer.cs
+++ b/Glyssen/Dialogs/ProjectSettingsDlg.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace Glyssen.Dialogs
+﻿using L10NSharp.UI;
+using L10NSharp.TMXUtils;
+
+namespace Glyssen.Dialogs
 {
 	partial class ProjectSettingsDlg
 	{
@@ -13,14 +16,17 @@
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
 				if (UpdatedBundle != null)
 				{
 					UpdatedBundle.Dispose();
 					UpdatedBundle = null;
 				}
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/QuotationMarksDlg.Designer.cs
+++ b/Glyssen/Dialogs/QuotationMarksDlg.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using L10NSharp.UI;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -20,7 +21,7 @@ namespace Glyssen.Dialogs
 				if (components != null)
 					components.Dispose();
 				m_project.AnalysisCompleted -= HandleAnalysisCompleted;
-				LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
 				if (m_navigatorViewModel != null)
 					m_navigatorViewModel.CurrentBlockChanged -= HandleCurrentBlockChanged;
 			}

--- a/Glyssen/Dialogs/QuotationMarksDlg.cs
+++ b/Glyssen/Dialogs/QuotationMarksDlg.cs
@@ -14,6 +14,7 @@ using Glyssen.Quote;
 using Glyssen.Shared;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.ObjectModel;
 using SIL.Scripture;
@@ -85,7 +86,7 @@ namespace Glyssen.Dialogs
 			try
 			{
 				HandleStringsLocalized();
-				LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+				LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 				SetFilterControlsFromMode();
 

--- a/Glyssen/Dialogs/RolesForVoiceActorsSaveAsDialog.cs
+++ b/Glyssen/Dialogs/RolesForVoiceActorsSaveAsDialog.cs
@@ -5,6 +5,7 @@ using DesktopAnalytics;
 using Glyssen.Properties;
 using Glyssen.Shared;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.IO;
 using SIL.Reporting;
@@ -21,7 +22,7 @@ namespace Glyssen.Dialogs
 		public RolesForVoiceActorsSaveAsDialog(ProjectExporter projectExporter)
 		{
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			m_projectExporter = projectExporter;
 

--- a/Glyssen/Dialogs/ScriptureRangeSelectionDlg.Designer.cs
+++ b/Glyssen/Dialogs/ScriptureRangeSelectionDlg.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+﻿using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -15,10 +15,12 @@ namespace Glyssen.Dialogs
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			L10NSharp.UI.LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				L10NSharp.UI.LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
+++ b/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
@@ -12,6 +12,7 @@ using Glyssen.Paratext;
 using Glyssen.Shared;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.DblBundle.Text;
 using SIL.Reporting;
@@ -50,7 +51,7 @@ namespace Glyssen.Dialogs
 			Initialize();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		private void HandleStringsLocalized()

--- a/Glyssen/Dialogs/UnappliedSplitsDlg.Designer.cs
+++ b/Glyssen/Dialogs/UnappliedSplitsDlg.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Glyssen.Dialogs
+﻿using L10NSharp.TMXUtils;
+
+namespace Glyssen.Dialogs
 {
 	partial class UnappliedSplitsDlg
 	{
@@ -13,10 +15,12 @@
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				L10NSharp.UI.LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
-				components.Dispose();
+				L10NSharp.UI.LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/UnappliedSplitsDlg.cs
+++ b/Glyssen/Dialogs/UnappliedSplitsDlg.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-using Glyssen.Utilities;
+﻿using Glyssen.Utilities;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
-using SIL.Scripture;
+using System;
+using System.IO;
+using System.Windows.Forms;
 
 namespace Glyssen.Dialogs
 {
@@ -29,7 +26,7 @@ namespace Glyssen.Dialogs
 			InitializeComponent();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			m_browser.Disposed += Browser_Disposed;
 		}

--- a/Glyssen/Dialogs/UnappliedSplitsViewModel.cs
+++ b/Glyssen/Dialogs/UnappliedSplitsViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using SIL.Scripture;

--- a/Glyssen/Dialogs/ViewScriptDlg.Designer.cs
+++ b/Glyssen/Dialogs/ViewScriptDlg.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Glyssen.Dialogs
+﻿using L10NSharp.TMXUtils;
+
+namespace Glyssen.Dialogs
 {
 	partial class ViewScriptDlg
 	{
@@ -13,10 +15,12 @@
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				L10NSharp.UI.LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
-				components.Dispose();
+				L10NSharp.UI.LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					 components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/ViewScriptDlg.cs
+++ b/Glyssen/Dialogs/ViewScriptDlg.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using Glyssen.Shared;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -17,7 +18,7 @@ namespace Glyssen.Dialogs
 			m_viewModel = viewModel;
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		private void HandleStringsLocalized()

--- a/Glyssen/Dialogs/VoiceActorAssignmentDlg.Designer.cs
+++ b/Glyssen/Dialogs/VoiceActorAssignmentDlg.Designer.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 using Glyssen.Controls;
-using SIL.Windows.Forms.Widgets.BetterGrid;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -18,12 +17,14 @@ namespace Glyssen.Dialogs
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				L10NSharp.UI.LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
+				L10NSharp.UI.LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
 				if (m_hyperlinkFont != null)
 					m_hyperlinkFont.Dispose();
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorAssignmentDlg.cs
@@ -14,6 +14,7 @@ using Glyssen.Properties;
 using Glyssen.Rules;
 using Glyssen.Utilities;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 using SIL.Reporting;
 using SIL.Extensions;
@@ -75,7 +76,7 @@ namespace Glyssen.Dialogs
 			m_characterDetailsGrid.MultiSelect = true;
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 
 			m_findCharacterBackgroundWorker = new BackgroundWorker { WorkerSupportsCancellation = true };
 			m_findCharacterBackgroundWorker.DoWork += FindCharacter;

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using L10NSharp;
 using L10NSharp.UI;
+using L10NSharp.TMXUtils;
 
 namespace Glyssen.Dialogs
 {
@@ -16,10 +17,12 @@ namespace Glyssen.Dialogs
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				LocalizeItemDlg.StringsLocalized -= HandleStringsLocalized;
-				components.Dispose();
+				LocalizeItemDlg<TMXDocument>.StringsLocalized -= HandleStringsLocalized;
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/Glyssen/Dialogs/VoiceActorInformationDlg.cs
+++ b/Glyssen/Dialogs/VoiceActorInformationDlg.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
-using System.Windows.Forms;
 using Glyssen.Controls;
 using Glyssen.Utilities;
 using Glyssen.VoiceActor;
 using L10NSharp;
+using L10NSharp.TMXUtils;
 using L10NSharp.UI;
 
 namespace Glyssen.Dialogs
@@ -29,7 +29,7 @@ namespace Glyssen.Dialogs
 				m_btnOk.Enabled = m_viewModel.ActiveActors.Any();
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized;
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized;
 		}
 
 		private void VoiceActorInformationDlg_Load(object sender, EventArgs e)

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -65,8 +65,8 @@
     <Reference Include="DesktopAnalytics, Version=1.2.4.11, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DesktopAnalytics.1.2.4.11\lib\net40\DesktopAnalytics.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="EPPlus, Version=4.0.5.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>..\packages\EPPlus.4.0.5\lib\net20\EPPlus.dll</HintPath>
@@ -78,8 +78,8 @@
     <Reference Include="Geckofx-Winforms">
       <HintPath>..\lib\dotnet\Geckofx-Winforms.dll</HintPath>
     </Reference>
-    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.5.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.5.4\lib\net451\icu.net.dll</HintPath>
     </Reference>
     <Reference Include="L10NSharp">
       <HintPath>..\lib\dotnet\L10NSharp.dll</HintPath>
@@ -88,26 +88,26 @@
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
     </Reference>
     <Reference Include="NetSparkle.Net40">
       <HintPath>..\lib\dotnet\NetSparkle.Net40.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Paratext.LexicalContracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9a5af29a0e638a7b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Paratext.LexicalContracts.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -150,11 +150,17 @@
       <HintPath>..\lib\dotnet\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Spart.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Spart.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -699,9 +705,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.8.1.7\build\ParatextData.targets'))" />
+    <Error Condition="!Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.9.0.3\build\ParatextData.targets'))" />
   </Target>
-  <Import Project="..\packages\ParatextData.8.1.7\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" />
+  <Import Project="..\packages\ParatextData.9.0.3\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -26,6 +26,7 @@ using SIL.Reporting;
 using SIL.Windows.Forms;
 using SIL.Windows.Forms.Miscellaneous;
 using Ionic.Zip;
+using L10NSharp.TMXUtils;
 using NetSparkle;
 using Paratext.Data;
 using SIL.Scripture;
@@ -58,7 +59,7 @@ namespace Glyssen
 			m_uiLanguageMenu.ToolTipText = LocalizationManager.GetString("MainForm.UILanguage", "User-interface Language");
 
 			HandleStringsLocalized();
-			LocalizeItemDlg.StringsLocalized += HandleStringsLocalized; // Don't need to unsubscribe since this object will be around as long as the program is running.
+			LocalizeItemDlg<TMXDocument>.StringsLocalized += HandleStringsLocalized; // Don't need to unsubscribe since this object will be around as long as the program is running.
 
 			m_lastExportLocationLink.Text = Empty;
 
@@ -824,7 +825,7 @@ namespace Glyssen
 			{
 				var item = m_uiLanguageMenu.DropDownItems.Add(lang.NativeName);
 				item.Tag = lang;
-				string languageId = ((CultureInfo)item.Tag).IetfLanguageTag;
+				string languageId = ((L10NCultureInfo)item.Tag).IetfLanguageTag;
 				item.Click += ((a, b) =>
 				{
 					Analytics.Track("SetUiLanguage", new Dictionary<string, string> {{"uiLanguage", languageId}, {"reapplyLocalizations", "true"}});
@@ -833,11 +834,11 @@ namespace Glyssen
 					LocalizationManager.SetUILanguage(languageId, true);
 					Settings.Default.UserInterfaceLanguage = languageId;
 					item.Select();
-					m_uiLanguageMenu.Text = ((CultureInfo)item.Tag).NativeName;
+					m_uiLanguageMenu.Text = ((L10NCultureInfo)item.Tag).NativeName;
 				});
 				if (languageId == Settings.Default.UserInterfaceLanguage)
 				{
-					m_uiLanguageMenu.Text = ((CultureInfo)item.Tag).NativeName;
+					m_uiLanguageMenu.Text = ((L10NCultureInfo)item.Tag).NativeName;
 				}
 			}
 
@@ -846,7 +847,7 @@ namespace Glyssen
 				"More...", "Last item in menu of UI languages"));
 			menu.Click += ((a, b) =>
 			{
-				Program.LocalizationManager.ShowLocalizationDialogBox(false);
+				Program.PrimaryLocalizationManager.ShowLocalizationDialogBox(false);
 				SetupUiLanguageMenu();
 			});
 		}

--- a/Glyssen/Program.cs
+++ b/Glyssen/Program.cs
@@ -225,15 +225,15 @@ namespace Glyssen
 			Analytics.ReportException(e.Exception);
 		}
 
-		public static LocalizationManager LocalizationManager { get; private set; }
+		public static ILocalizationManager PrimaryLocalizationManager { get; private set; }
 
 		private static void SetUpLocalization()
 		{
-			string installedStringFileFolder = FileLocator.GetDirectoryDistributedWithApplication("localization");
+			string installedStringFileFolder = FileLocationUtilities.GetDirectoryDistributedWithApplication("localization");
 			string targetTmxFilePath = Path.Combine(GlyssenInfo.kCompany, GlyssenInfo.kProduct);
 			string desiredUiLangId = Settings.Default.UserInterfaceLanguage;
 
-			LocalizationManager = LocalizationManager.Create(desiredUiLangId, GlyssenInfo.kApplicationId, Application.ProductName, Application.ProductVersion,
+			PrimaryLocalizationManager = LocalizationManager.Create(TranslationMemory.Tmx, desiredUiLangId, GlyssenInfo.kApplicationId, Application.ProductName, Application.ProductVersion,
 				installedStringFileFolder, targetTmxFilePath, Resources.glyssenIcon, IssuesEmailAddress, "Glyssen");
 
 			if (string.IsNullOrEmpty(desiredUiLangId))
@@ -248,7 +248,7 @@ namespace Glyssen
 						}
 
 			var uiLanguage = LocalizationManager.UILanguageId;
-			LocalizationManager.Create(uiLanguage, "Palaso", "Palaso", Application.ProductVersion,
+			LocalizationManager.Create(TranslationMemory.Tmx, uiLanguage, "Palaso", "Palaso", Application.ProductVersion,
 				installedStringFileFolder, targetTmxFilePath, Resources.glyssenIcon, IssuesEmailAddress,
 				"SIL.Windows.Forms.WritingSystems", "SIL.DblBundle", "SIL.Windows.Forms.DblBundle", "SIL.Windows.Forms.Miscellaneous");
 		}

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -1258,7 +1258,7 @@ namespace Glyssen
 		private static Project LoadExistingProject(string projectFilePath)
 		{
 			// PG-433, 04 JAN 2015, PH: Let the user know if the project file is not writable
-			var isWritable = !FileUtils.IsFileLocked(projectFilePath);
+			var isWritable = !FileHelper.IsLocked(projectFilePath);
 			if (!isWritable)
 			{
 				MessageBox.Show(LocalizationManager.GetString("Project.NotWritableMsg",

--- a/Glyssen/ProjectExporter.cs
+++ b/Glyssen/ProjectExporter.cs
@@ -180,7 +180,7 @@ namespace Glyssen
 			if (!IsNullOrEmpty(m_customFileName))
 			{
 				// if the directory is not the stored default directory, make the new directory the default
-				if (!DirectoryUtilities.AreDirectoriesEquivalent(Project.Status.LastExportLocation, DefaultDirectory))
+				if (!DirectoryHelper.AreEquivalent(Project.Status.LastExportLocation, DefaultDirectory))
 					Settings.Default.DefaultExportDirectory = Project.Status.LastExportLocation;
 			}
 

--- a/Glyssen/packages.config
+++ b/Glyssen/packages.config
@@ -2,11 +2,14 @@
 <packages>
   <package id="Analytics" version="2.0.2" targetFramework="net461" />
   <package id="DesktopAnalytics" version="1.2.4.11" targetFramework="net461" />
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
   <package id="EPPlus" version="4.0.5" targetFramework="net45" />
+  <package id="icu.net" version="2.5.4" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net461" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="ParatextData" version="8.1.7" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="ParatextData" version="9.0.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/GlyssenTests/App.config
+++ b/GlyssenTests/App.config
@@ -7,15 +7,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.13.3.0" newVersion="1.13.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -39,33 +39,33 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.5.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.5.4\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Paratext.LexicalContracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9a5af29a0e638a7b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Paratext.LexicalContracts.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
@@ -113,10 +113,16 @@
       <HintPath>..\lib\dotnet\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Spart.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Spart.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -273,12 +279,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\ParatextData.8.1.7\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" />
+  <Import Project="..\packages\ParatextData.9.0.3\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.8.1.7\build\ParatextData.targets'))" />
+    <Error Condition="!Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.9.0.3\build\ParatextData.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
+  <package id="icu.net" version="2.5.4" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="ParatextData" version="8.1.7" targetFramework="net461" />
+  <package id="ParatextData" version="9.0.3" targetFramework="net461" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -326,6 +326,8 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
       <ComponentRef Id="icudt56.dll"/>
       <ComponentRef Id="icuin56.dll"/>
       <ComponentRef Id="icuuc56.dll"/>
+	  <ComponentRef Id="System.Runtime.InteropServices.RuntimeInformation.dll"/>
+	  <ComponentRef Id="System.ValueTuple.dll"/>
       <ComponentRef Id="ParatextData.dll"/>
       <ComponentRef Id="PtxUtils.dll"/>
 	  <ComponentRef Id="DotNetZip.dll"/>

--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -234,6 +234,14 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
             <File Id="icuuc56.dll" Name="icuuc56.dll" KeyPath="yes" Source="..\output\release\icuuc56.dll" />
           </Component>
 
+          <Component Id="System.Runtime.InteropServices.RuntimeInformation.dll" Guid="{D60F4F8D-4072-4476-A66C-DDF663206CFE}">
+            <File Id="System.Runtime.InteropServices.RuntimeInformation.dll" Name="System.Runtime.InteropServices.RuntimeInformation.dll" KeyPath="yes" Source="..\output\release\System.Runtime.InteropServices.RuntimeInformation.dll" />
+          </Component
+
+          <Component Id="System.ValueTuple.dll" Guid="{F9E2AC5A-447B-46AC-96ED-A3F5B27E6559}">
+            <File Id="System.ValueTuple.dll" Name="System.ValueTuple.dll" KeyPath="yes" Source="..\output\release\System.ValueTuple.dll" />
+          </Component>
+
           <Component Id="ParatextData.dll" Guid="{64b44ac8-6ebd-4b0f-a0ec-27d4f289af34}">
             <File Id="ParatextData.dll" Name="ParatextData.dll" KeyPath="yes" Source="..\output\release\ParatextData.dll" />
           </Component>

--- a/Installer/Installer.wxs
+++ b/Installer/Installer.wxs
@@ -236,7 +236,7 @@ are trying to support, you're better off using non-advertised shortcuts. "-->
 
           <Component Id="System.Runtime.InteropServices.RuntimeInformation.dll" Guid="{D60F4F8D-4072-4476-A66C-DDF663206CFE}">
             <File Id="System.Runtime.InteropServices.RuntimeInformation.dll" Name="System.Runtime.InteropServices.RuntimeInformation.dll" KeyPath="yes" Source="..\output\release\System.Runtime.InteropServices.RuntimeInformation.dll" />
-          </Component
+          </Component>
 
           <Component Id="System.ValueTuple.dll" Guid="{F9E2AC5A-447B-46AC-96ED-A3F5B27E6559}">
             <File Id="System.ValueTuple.dll" Name="System.ValueTuple.dll" KeyPath="yes" Source="..\output\release\System.ValueTuple.dll" />

--- a/RefTextDevUtilities/RefTextDevUtilities.csproj
+++ b/RefTextDevUtilities/RefTextDevUtilities.csproj
@@ -35,33 +35,33 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="EPPlus, Version=4.0.5.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>..\packages\EPPlus.4.0.5\lib\net20\EPPlus.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.5.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.5.4\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.0.4\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Paratext.LexicalContracts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9a5af29a0e638a7b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Paratext.LexicalContracts.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -72,10 +72,16 @@
       <HintPath>..\lib\dotnet\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.8.1.7\lib\net461\Spart.dll</HintPath>
+      <HintPath>..\packages\ParatextData.9.0.3\lib\net461\Spart.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -114,7 +120,13 @@
     <Content Include="icu64\icuuc54.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\ParatextData.8.1.7\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.8.1.7\build\ParatextData.targets')" />
+  <Import Project="..\packages\ParatextData.9.0.3\build\ParatextData.targets" Condition="Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ParatextData.9.0.3\build\ParatextData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ParatextData.9.0.3\build\ParatextData.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RefTextDevUtilities/app.config
+++ b/RefTextDevUtilities/app.config
@@ -4,15 +4,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RefTextDevUtilities/packages.config
+++ b/RefTextDevUtilities/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net461" />
   <package id="EPPlus" version="4.0.5" targetFramework="net452" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
-  <package id="ParatextData" version="8.1.7" targetFramework="net461" />
+  <package id="icu.net" version="2.5.4" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net461" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="ParatextData" version="9.0.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/Reference Text Utility/App.config
+++ b/Reference Text Utility/App.config
@@ -7,15 +7,27 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="icu.net" publicKeyToken="416fdd914afa6b66" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.2.0" newVersion="2.3.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.5.0.0" newVersion="2.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DotNetZip" publicKeyToken="6583c7c814667745" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.11.0.0" newVersion="1.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.WritingSystems" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SIL.Core" publicKeyToken="cab3c8c5232dfcf2" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/build/Glyssen.proj
+++ b/build/Glyssen.proj
@@ -115,7 +115,8 @@
 		<!-- Note: the Exclude here is (hopefully) a temporary solution.
 		Ultimately, it would be better not to have a dependency on a project
 		which itself contains tests. Let's move the test scaffolding in SIL.DblBundle.Tests
-		into a separate test scaffolding dll -->
+		into a separate test scaffolding dll
+		Note: the following line needs to use backslashes; otherwise, the Exclude directive doesn't work. -->
 		<CreateItem Include="$(RootDir)\output\$(Configuration)\*Tests.dll" Exclude="$(RootDir)\output\$(Configuration)\SIL.DblBundle.Tests.dll">
 			<Output ItemName="TestAssemblies" TaskParameter="Include" />
 		</CreateItem>

--- a/build/Glyssen.proj
+++ b/build/Glyssen.proj
@@ -116,7 +116,7 @@
 		Ultimately, it would be better not to have a dependency on a project
 		which itself contains tests. Let's move the test scaffolding in SIL.DblBundle.Tests
 		into a separate test scaffolding dll -->
-		<CreateItem Include="$(RootDir)/output/$(Configuration)/*Tests.dll" Exclude="$(RootDir)/output/$(Configuration)/SIL.DblBundle.Tests.dll">
+		<CreateItem Include="$(RootDir)\output\$(Configuration)\*Tests.dll" Exclude="$(RootDir)\output\$(Configuration)\SIL.DblBundle.Tests.dll">
 			<Output ItemName="TestAssemblies" TaskParameter="Include" />
 		</CreateItem>
 		<NUnitTeamCity

--- a/build/TestInstallerBuild.bat
+++ b/build/TestInstallerBuild.bat
@@ -1,4 +1,8 @@
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"
+@echo This will only work if the correct version of MSBuild is on the PATH.
+@echo The easiest way to ensure this is to run from the Developer Command Prompt for VS.
+@echo The following line might work from a regular command prompt if this batch file exists,
+@echo but more than likely it will set the path such that the wrong version of MSBuild is first:
+@echo //call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"
 
 pushd .
 MSbuild /target:installer /property:teamcity_build_checkoutDir=..\ /property:Configuration="Release" /property:teamcity_dotnet_nunitlauncher_msbuild_task="notthere" /property:BUILD_NUMBER="*.*.0.001" /property:Minor="18"


### PR DESCRIPTION
libpalaso update actually done via TeamCity (to get updated LogBox) - ParatextData required a newer version.
Note: Using the TMX implementation of L10nSharp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/527)
<!-- Reviewable:end -->
