### PR TITLE
PG-1257: Fixed crash when adding project-specific control file entries

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -201,6 +201,8 @@ namespace Glyssen
 			/// If the Verse number represents a verse bridge, this will be the ending number in the bridge; otherwise 0.
 			/// </summary>
 			public int LastVerseOfBridge { get; private set; }
+
+			public IEnumerable<int> AllVerseNumbers => this.GetAllVerseNumbers();
 		}
 
 		public int LastVerseNum => LastVerse.EndVerse;
@@ -563,6 +565,24 @@ namespace Glyssen
 			get
 			{
 				return !(BlockElements.First() is ScriptText) || (StartsWithScriptTextElementContainingOnlyPunctuation && ContainsVerseNumber);
+			}
+		}
+
+		/// <summary>
+		/// Gets the <see cref="Verse"/> objects covered by this block. This may be single
+		/// verses or bridges. Note that the initial and final verses may not be entirely contained
+		/// within this block.
+		/// </summary>
+		public IEnumerable<IVerse> AllVerses
+		{
+			get
+			{
+				if (IsScripture)
+				{
+					yield return BlockElements.First() as IVerse ?? new Verse(InitialVerseNumberOrBridge);
+					foreach (var subsequentVerse in BlockElements.Skip(1).OfType<Verse>())
+						yield return subsequentVerse;
+				}
 			}
 		}
 

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -144,8 +144,11 @@ namespace Glyssen.Dialogs
 		private void AddPendingProjectCharacterVerseData(Block block, string characterId, Delivery delivery = null)
 		{
 			Debug.Assert(!String.IsNullOrEmpty(characterId));
-			// REVIEW: Probably not strictly necessary, but shouldn't we really add one per verse if this block
-			// covers multiple verses? See block.AllVerses and AddRecordsToProjectCharacterVerseData.
+			// TODO: Probably not strictly necessary, but we should really add one per verse if this block
+			// covers multiple verses. See block.AllVerses and AddRecordsToProjectCharacterVerseData. Note
+			// that this will also require some re-working of GetUniqueCharacterVerseObjectsForBlock because
+			// in some code paths, this method currently only gets called if that method can't find a match,
+			// but it doesn't require the character to be in the control file for every verse.
 			m_pendingCharacterVerseAdditions.Add(new CharacterVerse(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV,
 				characterId,
 				delivery == null ? Delivery.Normal.Text : delivery.Text,

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -144,6 +144,8 @@ namespace Glyssen.Dialogs
 		private void AddPendingProjectCharacterVerseData(Block block, string characterId, Delivery delivery = null)
 		{
 			Debug.Assert(!String.IsNullOrEmpty(characterId));
+			// REVIEW: Probably not strictly necessary, but shouldn't we really add one per verse if this block
+			// covers multiple verses? See block.AllVerses and AddRecordsToProjectCharacterVerseData.
 			m_pendingCharacterVerseAdditions.Add(new CharacterVerse(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV,
 				characterId,
 				delivery == null ? Delivery.Normal.Text : delivery.Text,
@@ -215,7 +217,7 @@ namespace Glyssen.Dialogs
 		private HashSet<CharacterVerse> GetUniqueCharacterVerseObjectsForBlock(Block block)
 		{
 			return new HashSet<CharacterVerse>(m_combinedCharacterVerseData.GetCharacters(CurrentBookNumber,
-				block.ChapterNumber, block.InitialStartVerseNumber, block.InitialEndVerseNumber, versification: Versification));
+				block.ChapterNumber, block.InitialStartVerseNumber, block.LastVerseNum, versification:Versification));
 		}
 
 		public IEnumerable<Character> GetCharactersForCurrentReferenceTextMatchup()
@@ -224,7 +226,7 @@ namespace Glyssen.Dialogs
 			return GetUniqueCharacters(false);
 		}
 
-		public void PopulateCurrentCharactersForCurrentReferenceTextMatchup()
+		private void PopulateCurrentCharactersForCurrentReferenceTextMatchup()
 		{
 			m_currentCharacters = new HashSet<CharacterVerse>();
 			foreach (var block in CurrentReferenceTextMatchup.CorrelatedBlocks)
@@ -409,7 +411,7 @@ namespace Glyssen.Dialogs
 		private void SetCharacterAndDelivery(Block block, Character selectedCharacter, Delivery selectedDelivery)
 		{
 			if (CharacterVerseData.IsCharacterUnclear(selectedCharacter.CharacterId))
-				throw new ArgumentException("Character cannot be confirmed as ambiguous or unknown.", "selectedCharacter");
+				throw new ArgumentException("Character cannot be confirmed as ambiguous or unknown.", nameof(selectedCharacter));
 			// If the user sets a non-narrator to a block we marked as narrator, we want to track it
 			if (!selectedCharacter.IsNarrator && !block.IsQuote)
 				Analytics.Track("NarratorToQuote", new Dictionary<string, string>
@@ -422,7 +424,7 @@ namespace Glyssen.Dialogs
 				});
 
 			if (selectedCharacter.ProjectSpecific || selectedDelivery.ProjectSpecific)
-				AddRecordToProjectCharacterVerseData(block, selectedCharacter, selectedDelivery);
+				AddRecordsToProjectCharacterVerseData(block, selectedCharacter, selectedDelivery);
 
 			SetCharacter(block, selectedCharacter);
 
@@ -490,14 +492,13 @@ namespace Glyssen.Dialogs
 			for (int i = CurrentReferenceTextMatchup.IndexOfStartBlockInBook; i < iLastBlockInMatchup || (i < blocks.Count && blocks[i].IsContinuationOfPreviousBlockQuote); i++)
 			{
 				var block = blocks[i];
-				if (IsBlockAssignedToUnknownCharacterDeliveryPair(block))
+				var verses = GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(block).ToArray();
+				if (verses.Any())
 				{
-					Debug.Assert(block.CharacterId != null);
-					Debug.Assert(block.CharacterId != "");
-					AddRecordToProjectCharacterVerseData(block,
+					AddRecordsToProjectCharacterVerseData(block,
 						GetCharactersForCurrentReferenceTextMatchup().First(c => c.CharacterId == block.CharacterId),
 						string.IsNullOrEmpty(block.Delivery) ? Delivery.Normal :
-							GetDeliveriesForCurrentReferenceTextMatchup().First(d => d.Text == block.Delivery));
+							GetDeliveriesForCurrentReferenceTextMatchup().First(d => d.Text == block.Delivery), verses);
 				}
 			}
 
@@ -521,6 +522,18 @@ namespace Glyssen.Dialogs
 			}
 			return !GetUniqueCharacterVerseObjectsForBlock(block).Any(cv => cv.Character == block.CharacterId &&
 				((cv.Delivery ?? "") == (block.Delivery ?? "")));
+		}
+
+		public IEnumerable<IVerse> GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(Block block)
+		{
+			if (block.CharacterIsStandard)
+			{
+				Debug.Assert(block.Delivery == null);
+				return new Verse[0];
+			}
+			return block.AllVerses.Where(verse => !m_combinedCharacterVerseData.GetCharacters(CurrentBookNumber,
+				block.ChapterNumber, verse.StartVerse, verse.EndVerse, versification: Versification)
+				.Any(cv => cv.Character == block.CharacterId && cv.Delivery == (block.Delivery ?? "")));
 		}
 
 		public void SetReferenceTextMatchupCharacter(int blockIndex, Character selectedCharacter)
@@ -550,22 +563,24 @@ namespace Glyssen.Dialogs
 			// merely split off by the reference text.
 		}
 
-		private void AddRecordToProjectCharacterVerseData(Block block, Character character, Delivery delivery)
+		private void AddRecordsToProjectCharacterVerseData(Block block, Character character, Delivery delivery, IEnumerable<IVerse> verses = null)
 		{
-			CharacterDetail detail;
-			if (m_pendingCharacterDetails.TryGetValue(character.CharacterId, out detail))
+			if (m_pendingCharacterDetails.TryGetValue(character.CharacterId, out var detail))
 			{
 				m_project.AddProjectCharacterDetail(detail);
 				m_project.SaveProjectCharacterDetailData();
 				m_pendingCharacterDetails.Remove(detail.CharacterId);
 			}
 
-			var reference = new BCVRef(GetBlockVerseRef(block, ScrVers.English).BBBCCCVVV);
-			var lastVerse = block.LastVerseNum;
-			do
+			if (verses == null)
+				verses = block.AllVerses;
+
+			foreach (var verseNum in verses.SelectMany(v => v.AllVerseNumbers))
 			{
+				var verseRef = new VerseRef(BCVRef.BookToNumber(CurrentBookId), block.ChapterNumber, verseNum, Versification);
+				verseRef.ChangeVersification(ScrVers.English);
 				var cv = new CharacterVerse(
-					reference,
+					new BCVRef(verseRef.BBBCCCVVV), 
 					character.IsNarrator
 						? CharacterVerseData.GetStandardCharacterId(CurrentBookId, CharacterVerseData.StandardCharacter.Narrator)
 						: character.CharacterId,
@@ -573,8 +588,7 @@ namespace Glyssen.Dialogs
 					character.Alias,
 					character.ProjectSpecific || delivery.ProjectSpecific);
 				m_projectCharacterVerseData.Add(cv);
-				reference.Verse++;
-			} while (reference.Verse <= lastVerse);
+			}
 
 			m_project.SaveProjectCharacterVerseData();
 		}

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -13866,6 +13866,7 @@ MAT	27	32	soldiers, Roman	giving orders		Indirect
 MAT	27	33	narrator-MAT			Quotation		
 MAT	27	35	scripture			Quotation	David	
 MAT	27	37	sign on the cross			Quotation		
+MAT	27	39	passers by	mocking		Potential		
 MAT	27	40	passers by	mocking		Dialogue		
 MAT	27	42	chief priests/teachers of religious law/elders	sneering		Dialogue		MAT 27.42;MRK 15.31-32;LUK 23.35
 MAT	27	43	chief priests/teachers of religious law/elders	sneering		Dialogue		

--- a/GlyssenShared/BlockElement.cs
+++ b/GlyssenShared/BlockElement.cs
@@ -99,6 +99,21 @@ namespace Glyssen.Shared
 		/// If the Verse number represents a verse bridge, this will be the ending number in the bridge; otherwise 0.
 		/// </summary>
 		int LastVerseOfBridge { get; }
+
+		/// <summary>
+		/// All verse numbers from StartVerse to EndVerse as integers. 
+		/// TODO: When we move to C# 8.0, we can use a default implementation instead of the extension method in the class below
+		/// </summary>
+		IEnumerable<int> AllVerseNumbers { get; }
+	}
+
+	public static class IVerseExtensions
+	{
+		public static IEnumerable<int> GetAllVerseNumbers(this IVerse verse)
+		{
+			for (var v = verse.StartVerse; v <= verse.EndVerse; v++)
+					yield return v;
+		}
 	}
 
 	public class Verse : BlockElement, IVerse
@@ -146,6 +161,8 @@ namespace Glyssen.Shared
 				return endVerse == startVerse ? 0 : endVerse;
 			}
 		}
+
+		public IEnumerable<int> AllVerseNumbers => this.GetAllVerseNumbers();
 	}
 
 	[XmlInclude(typeof(Pause))]

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -312,6 +312,57 @@ namespace GlyssenTests.Dialogs
 		}
 
 		[Test]
+		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithoutMatchAndSubsequentVerseWithMatch_ReturnsFalse()
+		{
+			var block = new Block("p", 14, 1) { CharacterId = "chief priests/teachers of religious law/elders" }
+				.AddText("“Let us arrest Jesus secretly and kill him, ")
+				.AddVerse(2, "but not during the festival,” ");
+			Assert.IsFalse(m_model.IsBlockAssignedToUnknownCharacterDeliveryPair(block));
+		}
+
+		[Test]
+		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithMatchAndSubsequentVerseWithoutMatch_ReturnsFalse()
+		{
+			var block = new Block("p", 14, 32) { CharacterId = "Jesus" }
+				.AddText("“Sit here while I pray. ")
+				.AddVerse(33, "Peter, James and John, You three come along with me.” ");
+			Assert.IsFalse(m_model.IsBlockAssignedToUnknownCharacterDeliveryPair(block));
+		}
+
+		[Test]
+		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithoutMatchAndSubsequentVerseWithMatch_ReturnsFirstVerse()
+		{
+			var block = new Block("p", 14, 1) { CharacterId = "chief priests/teachers of religious law/elders" }
+				.AddText("“Let us arrest Jesus secretly and kill him, ")
+				.AddVerse(2, "but not during the festival,” ");
+			Assert.AreEqual(1, m_model.GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(block).Single().StartVerse);
+		}
+
+		[Test]
+		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasTwoVersesWithNormalAndIndirectMatch_ReturnsNothing()
+		{
+			var block = new Block("p", 14, 32) { CharacterId = "Jesus" }
+				.AddText("“Sit here while I pray. ")
+				.AddVerse(33, "Peter, James and John, You three come along with me.” ");
+			Assert.IsFalse(m_model.GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(block).Any());
+		}
+
+		[Test]
+		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasLeadingVersesWithMatchAndSubsequentVersesWithoutMatch_ReturnsSubsequentVerses()
+		{
+			var block = new Block("p", 12, 38) {CharacterId = "Jesus"}
+				.AddText("“Watch out for the teachers. ")
+				.AddVerse(39, "They like the most important seats. ")
+				.AddVerse(40, "They devour widows’ houses ,")
+				.AddVerse(41, "Now let's sit and watch people give their money. See how the rich people give a lot. ")
+				.AddVerse(42, "Now see how this poor widow is putting in two small coins.”");
+			var results = m_model.GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(block).ToList();
+			Assert.AreEqual(2, results.Count);
+			Assert.AreEqual(41, results[0].StartVerse);
+			Assert.AreEqual(42, results[1].StartVerse);
+		}
+
+		[Test]
 		public void SetMode_AlternateBetweenModes_AssignedBlockCountDoesNotGrowContinuously()
 		{
 			Assert.AreEqual(0, m_model.CompletedBlockCount);
@@ -1379,12 +1430,21 @@ namespace GlyssenTests.Dialogs
 		}
 
 		[Test]
+		public void GetCharacterToSelectForCurrentBlock_NarratorBlockWithVersesThatHaveOtherExpectedCharacters_ReturnsNarrator()
+		{
+			Assert.IsTrue(m_model.TryLoadBlock(new VerseRef(041003010))); // This block has verses 7-11
+			var characters = m_model.GetUniqueCharactersForCurrentReference(false).ToList();
+			Assert.IsTrue(characters.Count > 1, "Test setup: expected conditions not met");
+			Assert.AreEqual(AssignCharacterViewModel.Character.Narrator, m_model.GetCharacterToSelectForCurrentBlock(null));
+		}
+
+		[Test]
 		public void GetCharacterToSelectForCurrentBlock_Narrator_ReturnsGenericNarratorCharacter()
 		{
-			Assert.IsTrue(m_model.TryLoadBlock(new VerseRef(041003010)));
+			Assert.IsTrue(m_model.TryLoadBlock(new VerseRef(041001039)));
 			var characters = m_model.GetUniqueCharactersForCurrentReference(false).ToList();
-			Assert.AreEqual(1, characters.Count);
-			Assert.IsTrue(characters[0].IsNarrator);
+			Assert.AreEqual(1, characters.Count, "Test setup: expected conditions not met");
+			Assert.IsTrue(characters[0].IsNarrator, "Test setup: expected conditions not met");
 			Assert.AreEqual(AssignCharacterViewModel.Character.Narrator, m_model.GetCharacterToSelectForCurrentBlock(null));
 		}
 

--- a/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
+++ b/GlyssenTests/Dialogs/AssignCharacterViewModelTests.cs
@@ -314,25 +314,62 @@ namespace GlyssenTests.Dialogs
 		[Test]
 		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithoutMatchAndSubsequentVerseWithMatch_ReturnsFalse()
 		{
-			var block = new Block("p", 14, 1) { CharacterId = "chief priests/teachers of religious law/elders" }
+			Assert.IsNull(ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 1, 1, 
+				versification:m_testProject.Versification).SingleOrDefault(), "Test setup conditions not met");
+			var cvMrk14V2 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 2, 2,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("chief priests/teachers of religious law/elders", cvMrk14V2.Character,
+				"Test setup conditions not met");
+
+			var block = new Block("p", 14, 1) { CharacterId = cvMrk14V2.Character }
 				.AddText("“Let us arrest Jesus secretly and kill him, ")
 				.AddVerse(2, "but not during the festival,” ");
 			Assert.IsFalse(m_model.IsBlockAssignedToUnknownCharacterDeliveryPair(block));
 		}
 
 		[Test]
-		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithMatchAndSubsequentVerseWithoutMatch_ReturnsFalse()
+		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithNormalMatchAndSubsequentVerseWithIndirectMatch_ReturnsFalse()
 		{
-			var block = new Block("p", 14, 32) { CharacterId = "Jesus" }
+			var cvMrk14V32 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 32, 32,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("Jesus", cvMrk14V32.Character, "Test setup conditions not met");
+			Assert.AreEqual(QuoteType.Normal, cvMrk14V32.QuoteType, "Test setup conditions not met");
+			Assert.AreEqual(QuoteType.Indirect, ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 33, 33,
+				versification: m_testProject.Versification).Single(cv => cv.Character == cvMrk14V32.Character).QuoteType,
+				"Test setup conditions not met");
+
+			var block = new Block("p", 14, 32) { CharacterId = cvMrk14V32.Character }
 				.AddText("“Sit here while I pray. ")
 				.AddVerse(33, "Peter, James and John, You three come along with me.” ");
 			Assert.IsFalse(m_model.IsBlockAssignedToUnknownCharacterDeliveryPair(block));
 		}
 
 		[Test]
+		public void IsBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithMatchAndSubsequentVerseWithoutMatch_ReturnsFalse()
+		{
+			var cvMrk14V25 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 25, 25,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("Jesus", cvMrk14V25.Character, "Test setup conditions not met");
+			Assert.IsNull(ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 26, 26,
+				versification: m_testProject.Versification).SingleOrDefault(), "Test setup conditions not met");
+
+			var block = new Block("p", 14, 25) { CharacterId = cvMrk14V25.Character }
+				.AddText("“This is all I can say, ")
+				.AddVerse(26, "because I am not supposed to talk in this verse.” ");
+			Assert.IsFalse(m_model.IsBlockAssignedToUnknownCharacterDeliveryPair(block));
+		}
+
+		[Test]
 		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasFirstVerseWithoutMatchAndSubsequentVerseWithMatch_ReturnsFirstVerse()
 		{
-			var block = new Block("p", 14, 1) { CharacterId = "chief priests/teachers of religious law/elders" }
+			Assert.IsNull(ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 1, 1,
+				versification: m_testProject.Versification).SingleOrDefault(), "Test setup conditions not met");
+			var cvMrk14V2 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 2, 2,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("chief priests/teachers of religious law/elders", cvMrk14V2.Character,
+				"Test setup conditions not met");
+
+			var block = new Block("p", 14, 1) { CharacterId = cvMrk14V2.Character }
 				.AddText("“Let us arrest Jesus secretly and kill him, ")
 				.AddVerse(2, "but not during the festival,” ");
 			Assert.AreEqual(1, m_model.GetVersesInBlockAssignedToUnknownCharacterDeliveryPair(block).Single().StartVerse);
@@ -341,6 +378,14 @@ namespace GlyssenTests.Dialogs
 		[Test]
 		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasTwoVersesWithNormalAndIndirectMatch_ReturnsNothing()
 		{
+			var cvMrk14V32 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 32, 32,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("Jesus", cvMrk14V32.Character, "Test setup conditions not met");
+			Assert.AreEqual(QuoteType.Normal, cvMrk14V32.QuoteType, "Test setup conditions not met");
+			Assert.AreEqual(QuoteType.Indirect, ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 14, 33, 33,
+					versification: m_testProject.Versification).Single(cv => cv.Character == cvMrk14V32.Character).QuoteType,
+				"Test setup conditions not met");
+
 			var block = new Block("p", 14, 32) { CharacterId = "Jesus" }
 				.AddText("“Sit here while I pray. ")
 				.AddVerse(33, "Peter, James and John, You three come along with me.” ");
@@ -350,6 +395,18 @@ namespace GlyssenTests.Dialogs
 		[Test]
 		public void GetVersesInBlockAssignedToUnknownCharacterDeliveryPair_BlockHasLeadingVersesWithMatchAndSubsequentVersesWithoutMatch_ReturnsSubsequentVerses()
 		{
+			var cvMrk12V38 = ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 12, 38, 38,
+				versification: m_testProject.Versification).Single();
+			Assert.AreEqual("Jesus", cvMrk12V38.Character, "Test setup conditions not met");
+			Assert.AreEqual(cvMrk12V38.Character, ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 12, 39, 39,
+				versification: m_testProject.Versification).Single().Character);
+			Assert.AreEqual(cvMrk12V38.Character, ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 12, 40, 40,
+				versification: m_testProject.Versification).Single().Character);
+			Assert.IsNull(ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 12, 41, 41,
+				versification: m_testProject.Versification).SingleOrDefault(), "Test setup conditions not met");
+			Assert.IsNull(ControlCharacterVerseData.Singleton.GetCharacters(m_model.CurrentBookNumber, 12, 42, 42,
+				versification: m_testProject.Versification).SingleOrDefault(), "Test setup conditions not met");
+
 			var block = new Block("p", 12, 38) {CharacterId = "Jesus"}
 				.AddText("“Watch out for the teachers. ")
 				.AddVerse(39, "They like the most important seats. ")


### PR DESCRIPTION
This addresses both the underlying cause of the crash reported in PG-1257 as well as adding the missing entry (for MAT 27:39) to the factory control file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/528)
<!-- Reviewable:end -->
