### PR TITLE
PG-1262: Changed UsxParser to handle odd verse bridges

### DIFF
--- a/Glyssen.sln.DotSettings
+++ b/Glyssen.sln.DotSettings
@@ -10,4 +10,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb_AaBb"&gt;&lt;ExtraRule Prefix="m_" Suffix="" Style="aaBb_AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="k" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Glyssen/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Matchup/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Matchup/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Glyssen.sln.DotSettings
+++ b/Glyssen.sln.DotSettings
@@ -12,4 +12,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Glyssen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Matchup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=USFM/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -82,7 +82,7 @@
     <applicationSettings>
         <Glyssen.Properties.Settings>
             <setting name="ParserVersion" serializeAs="String">
-                <value>46</value>
+                <value>47</value>
             </setting>
             <setting name="DataFormatVersion" serializeAs="String">
                 <value>4</value>

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -157,7 +157,8 @@ namespace Glyssen.Dialogs
 				return actualCount + adjustment;
 			}
 		}
-		public int RelevantBlockCount { get { return m_relevantBookBlockIndices.Count; } }
+		public int RelevantBlockCount => m_relevantBookBlockIndices.Count;
+
 		public int CurrentBlockDisplayIndex
 		{
 			get
@@ -893,12 +894,12 @@ namespace Glyssen.Dialogs
 			if (insertionIndex < 0)
 			{
 				var indicesOfFirstBlock = BlockAccessor.GetIndicesOfSpecificBlock(m_currentRefBlockMatchups.OriginalBlocks.First());
-				insertionIndex = GetIndexOfClosestRelevantBlock(m_relevantBookBlockIndices, indicesOfFirstBlock, false, 0, m_relevantBookBlockIndices.Count - 1);
-				if (insertionIndex == -1)
-					insertionIndex = m_relevantBookBlockIndices.Count;
+				insertionIndex = GetIndexOfClosestRelevantBlock(m_relevantBookBlockIndices, indicesOfFirstBlock, false, 0, RelevantBlockCount - 1);
+				if (insertionIndex < 0)
+					insertionIndex = RelevantBlockCount;
 			}
-			else if (insertionIndex > m_relevantBookBlockIndices.Count) // PG-823: We just removed multiple relevant blocks, such that the insertion index is out of range.
-				insertionIndex = m_relevantBookBlockIndices.Count;
+			else if (insertionIndex > RelevantBlockCount) // PG-823: We just removed multiple relevant blocks, such that the insertion index is out of range.
+				insertionIndex = RelevantBlockCount;
 
 			var origRelevantBlockCount = RelevantBlockCount;
 
@@ -934,6 +935,13 @@ namespace Glyssen.Dialogs
 			{
 				var currentBookIndex = BlockAccessor.GetIndices().BookIndex;
 				var startIndex = insertionIndex + RelevantBlockCount - origRelevantBlockCount;
+				// PG-1263: Could not figure out what went wrong, so I'm adding this check to try to analyze the
+				// individual pieces if this ever happens again.
+				if (startIndex < 0)
+					throw new IndexOutOfRangeException($"Start index should never be negative. " +
+						$"{nameof(insertionIndex)} = {insertionIndex}; " +
+						$"{nameof(RelevantBlockCount)} = {RelevantBlockCount}; " +
+						$"{nameof(origRelevantBlockCount)} = {origRelevantBlockCount}; ");
 				if (m_currentRelevantIndex >= 0 && BlockAccessor.GetIndices().IsMultiBlock)
 				{
 					// Since this "relevant passage" is a multi-block matchup (as opposed to a single block), rather than incrementing the

--- a/Glyssen/Properties/Settings.Designer.cs
+++ b/Glyssen/Properties/Settings.Designer.cs
@@ -73,7 +73,7 @@ namespace Glyssen.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("46")]
+        [global::System.Configuration.DefaultSettingValueAttribute("47")]
         public int ParserVersion {
             get {
                 return ((int)(this["ParserVersion"]));

--- a/Glyssen/Properties/Settings.settings
+++ b/Glyssen/Properties/Settings.settings
@@ -15,7 +15,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ParserVersion" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">46</Value>
+      <Value Profile="(Default)">47</Value>
     </Setting>
     <Setting Name="DefaultSfmDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/Glyssen/UsxParser.cs
+++ b/Glyssen/UsxParser.cs
@@ -228,6 +228,21 @@ namespace Glyssen
 			return blocks;
 		}
 
+		/// <summary>
+		/// If the existing block begins with a verse number, followed by "verse text" that consists
+		/// merely of a single dash, and we are now processing another (higher) verse number, the
+		/// block is doctored up to interpret this as verse bridge. Although it is not clear whether
+		/// this has ever been considered valid USFM, it has been done in real projects. Since Paratext
+		/// does not currently (as of 9.0 beta) flag this as a missing verse, handling the data this
+		/// way allows Glyssen to interpret it as it was probably intended and not treat it as a missing
+		/// verse.
+		/// </summary>
+		/// <example>For example, if USFM looks like this: \v 1 - \v 2 Text of the two verses.
+		/// Then in the USXParser, we will have a block with {1} - and a subsequent verse number 2.
+		/// This method will produce a block with the verse bridge {1-2} (and, as yet, no verse text
+		/// element).</example>
+		/// <returns><c>true</c> if a mal-formed verse range is turned into a valid verse bridge,
+		/// </returns>
 		private bool HandleVerseBridgeInSeparateVerseFields(Block block, ref string verseNumStr)
 		{
 			var iLastElem = block.BlockElements.Count - 1;

--- a/GlyssenTests/UsxParserTests.cs
+++ b/GlyssenTests/UsxParserTests.cs
@@ -745,14 +745,17 @@ namespace GlyssenTests
 				"Verse 4 text</para>");
 			var parser = GetUsxParser(doc);
 			var blocks = parser.Parse().ToList();
-			Assert.AreEqual(2, blocks.Count);
+			Assert.AreEqual(2, blocks.Count, "Should only have chapter number block and v. 4 block. " +
+				"Empty verse bridge block should have been discarded.");
+			Assert.IsTrue(blocks[0].CharacterIs("MRK", CharacterVerseData.StandardCharacter.BookOrChapter));
+			Assert.AreEqual(1, blocks[0].ChapterNumber);
 			Assert.AreEqual(4, blocks[1].InitialStartVerseNumber);
 			Assert.AreEqual(0, blocks[1].InitialEndVerseNumber);
 			Assert.AreEqual("{4}\u00A0Verse 4 text", blocks[1].GetText(true));
 		}
 
 		[TestCase("-", 3)]
-		[TestCase(" - ", 2)]
+		[TestCase("-", 2)]
 		public void Parse_VerseConsistsOfDashButFollowingVerseLessThanOrEqualToPrevNumber_DiscardedAsEmptyVerse(string dash, int followingVerseNum)
 		{
 			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"p\">" +

--- a/GlyssenTests/UsxParserTests.cs
+++ b/GlyssenTests/UsxParserTests.cs
@@ -716,6 +716,57 @@ namespace GlyssenTests
 			Assert.AreEqual(3, blocks[2].InitialEndVerseNumber);
 		}
 
+		[TestCase("-")]
+		[TestCase("- ")]
+		[TestCase(" -")]
+		[TestCase(" - ")]
+		public void Parse_OddlyFormedVerseBridgeInAdjacentVFields_CorrectlyInterpretsAsVerseBridge(string dash)
+		{
+			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"p\">" +
+				"<verse number=\"1\" style=\"v\" />" +
+				dash +
+				"<verse number=\"3\" style=\"v\" />" +
+				"Verse 1-3 text</para>");
+			var parser = GetUsxParser(doc);
+			var blocks = parser.Parse().ToList();
+			Assert.AreEqual(2, blocks.Count);
+			Assert.AreEqual(1, blocks[1].InitialStartVerseNumber);
+			Assert.AreEqual(3, blocks[1].InitialEndVerseNumber);
+			Assert.AreEqual("{1-3}\u00A0Verse 1-3 text", blocks[1].GetText(true));
+		}
+
+		[TestCase("-")]
+		[TestCase(" - ")]
+		public void Parse_VerseConsistsOfDashButPreviousVerseIsABridge_DiscardedAsEmptyVerse(string dash)
+		{
+			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"p\">" +
+				"<verse number=\"1-3\" style=\"v\" />" + dash + // This one should get discarded
+				"<verse number=\"4\" style=\"v\" />" +
+				"Verse 4 text</para>");
+			var parser = GetUsxParser(doc);
+			var blocks = parser.Parse().ToList();
+			Assert.AreEqual(2, blocks.Count);
+			Assert.AreEqual(4, blocks[1].InitialStartVerseNumber);
+			Assert.AreEqual(0, blocks[1].InitialEndVerseNumber);
+			Assert.AreEqual("{4}\u00A0Verse 4 text", blocks[1].GetText(true));
+		}
+
+		[TestCase("-", 3)]
+		[TestCase(" - ", 2)]
+		public void Parse_VerseConsistsOfDashButFollowingVerseLessThanOrEqualToPrevNumber_DiscardedAsEmptyVerse(string dash, int followingVerseNum)
+		{
+			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"p\">" +
+				"<verse number=\"3\" style=\"v\" />" + dash + // This one should get discarded
+				$"<verse number=\"{followingVerseNum}\" style=\"v\" />" +
+				"Verse text</para>");
+			var parser = GetUsxParser(doc);
+			var blocks = parser.Parse().ToList();
+			Assert.AreEqual(2, blocks.Count);
+			Assert.AreEqual(followingVerseNum, blocks[1].InitialStartVerseNumber);
+			Assert.AreEqual(0, blocks[1].InitialEndVerseNumber);
+			Assert.AreEqual("{" + followingVerseNum + "}\u00A0Verse text", blocks[1].GetText(true));
+		}
+
 		[Test]
 		public void Parse_NodeWithNoChildren_IgnoresNode()
 		{


### PR DESCRIPTION
PG-1262: It's not entirely clear whether in some past version of the standard it was considered acceptable to indicate a verse bridge formed by two verse fields with a dash in the text of the first one, but since Paratext does not flag it as an error, I've modified the USX Parser to handle it.

PG-1263: Added check to try to track down mysterious ArgumentOutOfRangeException exception.
Also did a little bit of refactoring and typo cleanup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/535)
<!-- Reviewable:end -->
