### PR TITLE
PG-1271: Fixed bug that caused a crash when no matching delivery was …

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -501,7 +501,8 @@ namespace Glyssen.Dialogs
 					AddRecordsToProjectCharacterVerseData(block,
 						GetCharactersForCurrentReferenceTextMatchup().First(c => c.CharacterId == block.CharacterId),
 						string.IsNullOrEmpty(block.Delivery) ? Delivery.Normal :
-							GetDeliveriesForCurrentReferenceTextMatchup().First(d => d.Text == block.Delivery), verses);
+							GetDeliveriesForCurrentReferenceTextMatchup().FirstOrDefault(d => d.Text == block.Delivery) ??
+							new Delivery(block.Delivery, true), verses);
 				}
 			}
 

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	141
+Control File Version	142
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5								
 # PSA will be handled as complete units, each psalm will be spoken by one voice								
@@ -13262,8 +13262,8 @@ MAT	11	25	Jesus	praying		Normal
 MAT	11	26	Jesus	praying		Normal		
 MAT	11	27	Jesus			Normal		
 MAT	11	28	Jesus	compassionately		Normal		
-MAT	11	29	Jesus			Normal		
-MAT	11	30	Jesus			Normal		
+MAT	11	29	Jesus	compassionately		Normal		
+MAT	11	30	Jesus	compassionately		Normal		
 MAT	12	2	Pharisees, some	angry		Dialogue		
 MAT	12	3	Jesus			Normal		
 MAT	12	4	Jesus			Normal		


### PR DESCRIPTION
…found (within matchup blocks) for a following block that was part of a continued quote.

Although not strictly necessary to fix the bug, I also added the "compassionately" delivery for the other verses in MAT 11 where Jesus is inviting people to find rest in him.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/538)
<!-- Reviewable:end -->
