### PR TITLE
Merge prevent migration crash when same character occurs in multiple verses of block bridge

### DIFF
--- a/Glyssen/Character/CharacterVerseData.cs
+++ b/Glyssen/Character/CharacterVerseData.cs
@@ -184,7 +184,7 @@ namespace Glyssen.Character
 
 		private static readonly Regex s_narratorRegex = new Regex($"{kNarratorPrefix}(?<bookId>...)");
 
-		private readonly IEqualityComparer<ICharacterDeliveryInfo> m_characterDeliveryEqualityComparer = new CharacterDeliveryEqualityComparer();
+		private readonly CharacterDeliveryEqualityComparer m_characterDeliveryEqualityComparer = new CharacterDeliveryEqualityComparer();
 		private ISet<CharacterVerse> m_data = new HashSet<CharacterVerse>();
 		private ILookup<int, CharacterVerse> m_lookup;
 		private IReadOnlySet<ICharacterDeliveryInfo> m_uniqueCharacterAndDeliveries;
@@ -225,7 +225,8 @@ namespace Glyssen.Character
 				result = new List<CharacterVerse>();
 				do
 				{
-					result = result.Union(m_lookup[verseRef.BBBCCCVVV]).ToList();
+					result = result.Union(m_lookup[verseRef.BBBCCCVVV],
+						(IEqualityComparer<CharacterVerse>)m_characterDeliveryEqualityComparer).ToList();
 					verseRef.NextVerse();
 					// ReSharper disable once LoopVariableIsNeverChangedInsideLoop - NextVerse changes verseRef
 				} while (verseRef <= initialEndRef);

--- a/GlyssenTests/Character/CharacterVerseDataTests.cs
+++ b/GlyssenTests/Character/CharacterVerseDataTests.cs
@@ -78,6 +78,13 @@ namespace GlyssenTests.Character
 			Assert.AreEqual("believers, circumcised", character.Character);
 		}
 
+		[Test]
+		public void GetCharacters_ControlHasSameCharacterEntryForInitialStartAndInitialEndVerse_GetsOnlyOneEntryForCharacter()
+		{
+			var character = ControlCharacterVerseData.Singleton.GetCharacters(kGENbookNum, 1, 14, 15).Single();
+			Assert.AreEqual("God", character.Character);
+		}
+
 		[TestCase(false)]
 		[TestCase(true)]
 		public void GetCharacters_RussianOrthodoxVersificationWithInitialVerseBridge_FindsCharacterAfterChangingVersification(bool includeNarratorOverrides)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/545)
<!-- Reviewable:end -->
