### PR TITLE
PG-1289: Prevented inconsistent state in TryLoadBlock

### DIFF
--- a/Glyssen/BlockNavigator.cs
+++ b/Glyssen/BlockNavigator.cs
@@ -86,6 +86,8 @@ namespace Glyssen
 
 		public BookBlockIndices GetIndicesOfFirstBlockAtReference(VerseRef verseRef, bool allowMidQuoteBlock = false)
 		{
+			if (!verseRef.Valid)
+				return null;
 			var bookId = verseRef.Book;
 			int bookIndex = -1;
 			BookScript book = null;

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -770,14 +770,9 @@ namespace Glyssen.Dialogs
 						return i;
 					}
 				}
-				catch (IndexOutOfRangeException e)
+				catch (Exception e) when (e is IndexOutOfRangeException || e is ArgumentOutOfRangeException)
 				{
 					throw new IndexOutOfRangeException($"Index out of range. RelevantBlockCount = {RelevantBlockCount}. " +
-						$"m_currentRelevantIndex = {m_currentRelevantIndex}. i = {i}.", e);
-				}
-				catch (ArgumentOutOfRangeException e)
-				{
-					throw new ArgumentOutOfRangeException($"Index out of range. RelevantBlockCount = {RelevantBlockCount}. " +
 						$"m_currentRelevantIndex = {m_currentRelevantIndex}. i = {i}.", e);
 				}
 			}

--- a/Glyssen/Dialogs/BlockNavigatorViewModel.cs
+++ b/Glyssen/Dialogs/BlockNavigatorViewModel.cs
@@ -689,8 +689,8 @@ namespace Glyssen.Dialogs
 			if (indices == null)
 				return false;
 
-			m_currentRelevantIndex = m_relevantBookBlockIndices.IndexOf(indices);
-			if (m_currentRelevantIndex < 0)
+			var indexOfRelevantBlock = m_relevantBookBlockIndices.IndexOf(indices);
+			if (indexOfRelevantBlock < 0)
 			{
 				var block = GetBlock(indices);
 				if (CharacterVerseData.IsCharacterExtraBiblical(block.CharacterId))
@@ -699,6 +699,8 @@ namespace Glyssen.Dialogs
 			}
 			else
 				m_temporarilyIncludedBookBlockIndices = null;
+
+			m_currentRelevantIndex = indexOfRelevantBlock;
 			SetBlock(indices);
 			return true;
 		}
@@ -768,9 +770,14 @@ namespace Glyssen.Dialogs
 						return i;
 					}
 				}
-				catch(IndexOutOfRangeException e)
+				catch (IndexOutOfRangeException e)
 				{
 					throw new IndexOutOfRangeException($"Index out of range. RelevantBlockCount = {RelevantBlockCount}. " +
+						$"m_currentRelevantIndex = {m_currentRelevantIndex}. i = {i}.", e);
+				}
+				catch (ArgumentOutOfRangeException e)
+				{
+					throw new ArgumentOutOfRangeException($"Index out of range. RelevantBlockCount = {RelevantBlockCount}. " +
 						$"m_currentRelevantIndex = {m_currentRelevantIndex}. i = {i}.", e);
 				}
 			}

--- a/GlyssenTests/BlockNavigatorTests.cs
+++ b/GlyssenTests/BlockNavigatorTests.cs
@@ -530,6 +530,14 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void GetIndicesOfFirstBlockAtReference_InvalidRef_ReturnsNull()
+		{
+			VerseRef.TryParse("REV 5:5-3", out var verseRef);
+			var result = m_navigator.GetIndicesOfFirstBlockAtReference(verseRef);
+			Assert.IsNull(result);
+		}
+
+		[Test]
 		public void GetIndicesOfSpecificBlock_FirstBlock()
 		{
 			var result = m_navigator.GetIndicesOfSpecificBlock(m_books.First().GetScriptBlocks()[0]);

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -947,6 +947,19 @@ namespace GlyssenTests.Dialogs
 			Assert.IsTrue(m_model.CurrentBlockDisplayIndex > 0);
 		}
 
+		[TestCase(41001000)] // MRK 1:0
+		[TestCase(41000001)] // MRK 0:1
+		public void TryLoadBlock_FromRelevantBlockToNonScriptureBlock_NotLoaded(int bbbcccvvv)
+		{
+			m_model.AttemptRefBlockMatchup = true;
+			m_model.Mode = BlocksToDisplay.NotAlignedToReferenceText;
+			m_model.LoadNextRelevantBlock();
+			Assert.AreEqual(2, m_model.CurrentBlockDisplayIndex);
+
+			Assert.IsFalse(m_model.TryLoadBlock(new VerseRef(bbbcccvvv, ScrVers.English)));
+			Assert.AreEqual(2, m_model.CurrentBlockDisplayIndex);
+		}
+
 		[Test]
 		public void LoadNextRelevantBlock_FollowingInsertionOfBlockByApplyingMatchupWithSplits_LoadsARelevantBlock()
 		{


### PR DESCRIPTION
This prevents a crash if the user attempts to navigate to the next relevant block, after failing to load a block based on a reference that corresponds to chapter 0 or verse 0.
Also put in a safeguard against an invalid VerseRef (though currently this can't happen in production code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/555)
<!-- Reviewable:end -->
