### PR TITLE
PG-1279: Prevent index out of range in MatchVernBlocksToReferenceTextBlocks

### DIFF
--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -298,7 +298,11 @@ namespace Glyssen
 						if (bookId != "MRK")
 							Logger.WriteMinorEvent("Reference text matching went off end of ref block list for " +
 								$"vern block {currentVernBlock}");
-						iRefBlock = refBook.GetIndexOfFirstBlockForVerse(currentVernBlock.ChapterNumber, currentVernBlock.InitialStartVerseNumber);
+						var verse = currentVernBlock.StartRef(bookNum, vernacularVersification);
+						verse.ChangeVersification(Versification);
+						iRefBlock = refBook.GetIndexOfFirstBlockForVerse(verse.ChapterNum, verse.VerseNum);
+						if (iRefBlock < 0)
+							break;
 					}
 					else
 					{

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -3580,6 +3580,26 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void GetBlocksForVerseMatchedToReferenceText_VernBlockHasExtraChapterBeyondLastChapterOfRefText_VernVersesInExtraChapterRemainsUnmatched()
+		{
+			var vernacularBlocks = new List<Block> {
+				CreateNarratorBlockForVerse(24, "Köszöntsétek minden elõljárótokat és a szenteket mind. Köszöntenek titeket az Olaszországból valók. ", true, 13, "HEB")
+					.AddVerse(25, "Kegyelem mindnyájatokkal! Ámen!"),
+				NewChapterBlock("HEB", 14),
+				CreateNarratorBlockForVerse(1, "Alright, who's the wise guy?", true, 14, "HEB"),
+				CreateNarratorBlockForVerse(2, "This is not supposed to be here", true, 14, "HEB")
+			};
+			var vernBook = new BookScript("HEB", vernacularBlocks, m_vernVersification);
+
+			var refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 2);
+			Assert.IsFalse(matchup.CorrelatedBlocks.Last().MatchesReferenceText);
+			matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 3);
+			Assert.IsFalse(matchup.CorrelatedBlocks.Last().MatchesReferenceText);
+		}
+
+		[Test]
 		public void GetBlocksForVerseMatchedToReferenceText_VernBlockHasLeadingSquareBracket_BlockIsNotSplitBetweenBracketAndVerseNumber()
 		{
 			var vernacularBlocks = new List<Block> {


### PR DESCRIPTION
This handles the unlikely (probably caused by using versification that is incompatible with vern text) scenario where there are more chapters in the vernacular than the reference text.

Also noticed and fixed flaw logic that attempts to get things back on track. We were assuming that the vernacular chapter and verse numbers could be used to find correct location in reference text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/556)
<!-- Reviewable:end -->
