### PR TITLE
Prevent update of test parse if bundle is missing

### DIFF
--- a/Glyssen/Dialogs/QuotationMarksDlg.cs
+++ b/Glyssen/Dialogs/QuotationMarksDlg.cs
@@ -92,7 +92,7 @@ namespace Glyssen.Dialogs
 
 				SetFilterControlsFromMode();
 
-				if (m_project.ProjectState == ProjectState.NeedsQuoteSystemConfirmation)
+				if (m_project.ProjectState == ProjectState.NeedsQuoteSystemConfirmation && !readOnly)
 					UpdateTestParse(false);
 
 				ReadOnly = readOnly;


### PR DESCRIPTION
Note: this crash happened to me when I opened a left-over test project. It might be an impossible -- or at least highly improbable -- scenario for normal projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/574)
<!-- Reviewable:end -->
