### PR TITLE
PG-1309: Prevented addition of project-specific entries for standard characters

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -543,6 +543,8 @@ namespace Glyssen.Dialogs
 
 		private void AddRecordsToProjectControlFilesIfNeeded(Block block)
 		{
+			if (block.CharacterIsStandard)
+				return;
 			if (m_pendingCharacterDetails.TryGetValue(block.CharacterId, out var detail))
 			{
 				m_project.AddProjectCharacterDetail(detail);

--- a/GlyssenTests/ProjectTests.cs
+++ b/GlyssenTests/ProjectTests.cs
@@ -837,7 +837,7 @@ namespace GlyssenTests
 			}
 		}
 
-		[Test]
+		[Test, Timeout(10000)]
 		public void Constructor_CreateNewProjectFromBundle_BundleHasNoLdmlFile_WsLdmlHasCountrySpecified_ProjectIsCreatedSuccessfully()
 		{
 			Sldr.Initialize();


### PR DESCRIPTION
Specifically, we want to avoid adding narrator entries, but just in case this ever got called with any other "standard" character type, we'd skip those also.
(This is primarily to prevent spurious Analytics calls, but it should also avoid needless bloat of project-specific files.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/585)
<!-- Reviewable:end -->
