### PR TITLE
PG-1311: Prevent crash caused by bug in SplitBlock

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -1177,8 +1177,10 @@ namespace Glyssen
 							return null;
 					}
 
+					var newScriptText = (characterOffsetToSplit < content.Length) ? new ScriptText(content.Substring(characterOffsetToSplit)) : null;
+
 					int initialStartVerse, initialEndVerse;
-					if (characterOffsetToSplit == content.Length)
+					if ((newScriptText == null || newScriptText.ContainsNoWords) && indexOfFirstElementToRemove >= 0)
 					{
 						var firstVerseAfterSplit = (Verse)BlockElements[indexOfFirstElementToRemove];
 						initialStartVerse = firstVerseAfterSplit.StartVerse;
@@ -1196,8 +1198,8 @@ namespace Glyssen
 						Delivery = Delivery,
 						UserConfirmed = UserConfirmed
 					};
-					if (characterOffsetToSplit < content.Length)
-						newBlock.BlockElements.Add(new ScriptText(content.Substring(characterOffsetToSplit)));
+					if (newScriptText != null)
+						newBlock.BlockElements.Add(newScriptText);
 					if (text != null)
 						text.Content = content.Substring(0, characterOffsetToSplit);
 				}

--- a/Glyssen/BookBlockIndices.cs
+++ b/Glyssen/BookBlockIndices.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Xml.Serialization;
-using Microsoft.DotNet.PlatformAbstractions;
+using SIL.Reporting;
 
 namespace Glyssen
 {
@@ -56,7 +55,10 @@ namespace Glyssen
 			if (IsMultiBlock)
 				throw new InvalidOperationException($"Invalid attempt to extend a multi-block {GetType()} based on a {matchup.GetType()}.");
 			if (matchup.IndexOfStartBlockInBook != BlockIndex)
-				throw new InvalidOperationException($"This  {GetType()} does not correspond to the given {matchup.GetType()}.");
+			{
+				Logger.WriteEvent($"Error: matchup.IndexOfStartBlockInBook = {matchup.IndexOfStartBlockInBook}; BlockIndex = {BlockIndex}; BookIndex = {BookIndex}");
+				throw new InvalidOperationException($"This {GetType()} does not correspond to the given {matchup.GetType()}.");
+			}
 			if (matchup.OriginalBlockCount == 1)
 				return false;
 			ExtendToIncludeMoreBlocks((uint)matchup.OriginalBlockCount - 1); // -1 because the first one is already implicitly included

--- a/Glyssen/DataMigrator.cs
+++ b/Glyssen/DataMigrator.cs
@@ -9,7 +9,6 @@ using Glyssen.Bundle;
 using Glyssen.Properties;
 using Glyssen.Shared;
 using GlyssenEngine.Utilities;
-using L10NSharp;
 using SIL;
 using SIL.DblBundle;
 using SIL.IO;

--- a/Glyssen/Dialogs/SplitBlockDlg.cs
+++ b/Glyssen/Dialogs/SplitBlockDlg.cs
@@ -220,6 +220,8 @@ namespace Glyssen.Dialogs
 				{
 					newOffset = 0;
 				}
+				// ENHANCE: Prevent splitting such that the new segment is nothing but punctuation, with the exception
+				// of opening "brace" (parenthesis, square bracket, etc.) punctuation. (See test code in BlockTests for PG-1311.)
 				else if (segmentText.Substring(newOffset).IsWhitespace())
 				{
 					newOffset = segmentText.Length;

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -77,6 +77,8 @@ namespace Glyssen
 				}
 				if (fromControlFileVersion < 151)
 					MigrateDuplicatedReferenceTextFromJoining(project.Books);
+				if (fromControlFileVersion < 152)
+					MigrateInvalidInitialStartVerseNumberFromSplitBeforePunctuation(project.Books);
 				MigrateDeprecatedCharacterIds(project);
 
 				result = MigrationResult.Complete;
@@ -472,6 +474,34 @@ namespace Glyssen
 				else
 				{
 					lastScriptTextElement.Content = lastScriptTextElement.Content.TrimEnd();
+				}
+			}
+		}
+
+		public static void MigrateInvalidInitialStartVerseNumberFromSplitBeforePunctuation(IReadOnlyList<BookScript> books)
+		{
+			foreach (var book in books)
+			{
+				foreach (var block in book.GetScriptBlocks().Where(b => b.IsScripture))
+				{
+					if (block.BlockElements.First() is ScriptText text && text.ContainsNoWords)
+					{
+						var firstVerse = block.BlockElements.Skip(1).OfType<Verse>().FirstOrDefault();
+						if (firstVerse == null)
+						{
+							// This is almost certainly an error in the data, but just in case there's some edge case
+							// I can't think of, I'll play it safe and log it rather than crashing.
+							var error = "Unexpected block data encountered in Data migration: Block starts with an element having no word-forming" +
+								$"characters and has no subsequent {typeof(Verse).Name} element. Block: {block.ToString(true, book.BookId)}";
+							Logger.WriteEvent(error);
+							Debug.Fail("error");
+						}
+						else
+						{
+							block.InitialStartVerseNumber = firstVerse.StartVerse;
+							block.InitialEndVerseNumber = firstVerse.EndVerse;
+						}
+					}
 				}
 			}
 		}

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -38,7 +38,7 @@ namespace Glyssen
 			if (!project.Books.Any())
 				return MigrationResult.NoOp;
 
-			Logger.WriteEvent("Migrating project " + project.ProjectFilePath);
+			Logger.WriteEvent($"Migrating project {project.ProjectFilePath} from {fromControlFileVersion} to {ControlCharacterVerseData.Singleton.ControlFileVersion}");
 
 			if (s_lastProjectMigrated != project)
 				s_migrationsRun = 0;

--- a/Glyssen/ReferenceText.cs
+++ b/Glyssen/ReferenceText.cs
@@ -249,8 +249,8 @@ namespace Glyssen
 			} : (Action < PortionScript >)null;
 
 			var matchup = new BlockMatchup(vernacularBook, iBlock, splitBlocks,
-			nextVerse => IsOkayToSplitAtVerse(nextVerse, vernacularBook.Versification, verseSplitLocationsBasedOnRef),
-			this, predeterminedBlockCount);
+				nextVerse => IsOkayToSplitAtVerse(nextVerse, vernacularBook.Versification, verseSplitLocationsBasedOnRef),
+				this, predeterminedBlockCount);
 
 			if (!matchup.AllScriptureBlocksMatch)
 			{

--- a/Glyssen/Resources/CharacterVerse.txt
+++ b/Glyssen/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	151
+Control File Version	152
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5
 GEN	1	3	God		God (the LORD)	Normal		

--- a/Glyssen/UsxParser.cs
+++ b/Glyssen/UsxParser.cs
@@ -338,17 +338,7 @@ namespace Glyssen
 					block.BlockElements.Remove(lastBlockElement);
 					return true;
 				}
-				// Originally, the last part of this condition was:
-				// text.Content.All(c => char.IsPunctuation(c) || char.IsWhiteSpace(c))
-				// because char.IsLetter doesn't know what to do with PUA characters and
-				// I didn't want to run the risk of accidentally deleting a verse that
-				// might have all PUA characters, but upon further consideration, I decided
-				// that was extremely unlikely, and there was probably a greater risk of
-				// some other symbol, number, separator, etc. being the only thing in the
-				// text. And it would be slow and unwieldy to check all the other possibilities
-				// and something might still fall through the cracks.
-				if (lastBlockElement is ScriptText text && block.BlockElements.Count > 1 &&
-					!text.Content.Any(IsLetter))
+				if (lastBlockElement is ScriptText text && block.BlockElements.Count > 1 && text.ContainsNoWords)
 				{
 					if (!(block.BlockElements[block.BlockElements.Count - 2] is Verse))
 					{

--- a/GlyssenShared/BlockElement.cs
+++ b/GlyssenShared/BlockElement.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 using SIL.Scripture;
+using static System.Char;
 
 namespace Glyssen.Shared
 {
@@ -75,6 +77,17 @@ namespace Glyssen.Shared
 			get { return m_content ?? String.Empty; }
 			set { m_content = value; }
 		}
+
+		// Originally (a long time ago, and when this logic was in UsxParser), this condition was:
+		// Content.All(c => char.IsPunctuation(c) || char.IsWhiteSpace(c))
+		// because char.IsLetter doesn't know what to do with PUA characters and
+		// I didn't want to run the risk of accidentally deleting a verse that
+		// might have all PUA characters, but upon further consideration, I decided
+		// that was extremely unlikely, and there was probably a greater risk of
+		// some other symbol, number, separator, etc. being the only thing in the
+		// text. And it would be slow and unwieldy to check all the other possibilities
+		// and something might still fall through the cracks.
+		public bool ContainsNoWords => !Content.Any(IsLetter);
 
 		public bool StartsWithEllipsis => s_startsWithEllipsis.IsMatch(Content);
 

--- a/GlyssenTests/BlockTests.cs
+++ b/GlyssenTests/BlockTests.cs
@@ -1769,7 +1769,36 @@ namespace GlyssenTests
 			var newBlock = block.SplitBlock("2", 1);
 
 			Assert.AreEqual("({2}\u00A0a", block.GetText(true));
+			Assert.AreEqual(2, block.InitialStartVerseNumber);
 			Assert.AreEqual("bcdef ghi) {3}\u00A0jk lmno p", newBlock.GetText(true));
+			Assert.AreEqual(2, newBlock.InitialStartVerseNumber);
+		}
+
+		/// <summary>
+		/// PG-1311: Test that the initial start verse number for the new block is set correctly (based on first actual verse element)
+		/// </summary>
+		[TestCase("[")] // This is the likely case
+		[TestCase(".")] // This would probably be a mistake (see ENHANCE comment in SplitBlockDlg.DetermineSplitLocatino),
+						// but if the user did it, we would also need this same behavior.
+		public void SplitBlock_SplitBeforeTrailingPunctuation_NewBlockInitialVerseNumberBasedOnFirstVerseNumber(string trailingPunctuation)
+		{
+			var block = new Block("p", 1, 2)
+			{
+				BlockElements =
+				{
+					new Verse("2"),
+					new ScriptText($"abcdef ghi{trailingPunctuation} "),
+					new Verse("3"),
+					new ScriptText("jk lmno p")
+				}
+			};
+
+			var newBlock = block.SplitBlock("2", 10);
+
+			Assert.AreEqual("{2}\u00A0abcdef ghi", block.GetText(true));
+			Assert.AreEqual(2, block.InitialStartVerseNumber);
+			Assert.AreEqual(trailingPunctuation + " {3}\u00A0jk lmno p", newBlock.GetText(true));
+			Assert.AreEqual(3, newBlock.InitialStartVerseNumber);
 		}
 
 		[Test]

--- a/GlyssenTests/ReferenceTextTests.cs
+++ b/GlyssenTests/ReferenceTextTests.cs
@@ -3408,6 +3408,32 @@ namespace GlyssenTests
 			Assert.IsTrue(referenceBlocks.Skip(1).Take(4).Select(r => r.GetText(true)).SequenceEqual(result.Select(v => v.GetPrimaryReferenceText())));
 		}
 
+		/// <summary>
+		/// PG-1311: Block has multiple verses. Last verse bleeds into subsequent block, but a verse is missing so the first verse number
+		/// present in the subsequent block is > the initial verse number + 1.
+		/// </summary>
+		[Test]
+		public void GetBlocksForVerseMatchedToReferenceText_MultipleVersesInVernBlockNextBlockStartsWith_ReturnsMatchupCoveringInitialBlockOnly()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(CreateBlockForVerse("Jesus", 31, "«Dœ olonœ asœmœ, uzu á nœ ye sœ ɓa sœnda, tshe ye ga mangba ye nene. ", false, 17)
+				.AddVerse(32, "'E gbetshelœ 'e tœ upu nœ awo Lota kane. ")
+				.AddVerse(33, "Uzu neke á tshe para awa ndœ kœgbɔndœ soro tshu; kashe tsheneke nœ nene dá she. ")
+				.AddVerse(34, "Mœ sœ 'e, lœ butshɔnœ asœmœ, ayakoshe: endje za anga bale, yé anga œ sœpe. ")
+				.AddVerse(35, "Ayashe bisha œ sœ kœtɔ œrœ tœ œsœnœ bale: endje za anga bale, yé anga œ sœpe. "));
+			vernacularBlocks.Add(CreateBlockForVerse(CharacterVerseData.kUnexpectedCharacter, 37, "[ ", false, 17)
+				.AddVerse(37, "Ayambarœ nœ Yisu yu she adœke:"));
+			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, " «Œrœnœ atamœ œ mbœrœtœ endje kpœta Gbozu?» ", "p");
+			AddNarratorBlockForVerseInProgress(vernacularBlocks, "é tshe kœgi fœ endje adœke: ", "LUK");
+			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kAmbiguousCharacter, "«Osho á oko sœ tœnœ, œ kœngbɔtœ endje ɓa zœ.»", "p");
+			var vernBook = new BookScript("LUK", vernacularBlocks, m_vernVersification);
+
+			var refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 0);
+			Assert.AreEqual(1, matchup.OriginalBlockCount);
+		}
+
 		[TestCase(1)]
 		[TestCase(2)]
 		[TestCase(3)]


### PR DESCRIPTION
Note that the scenario in PG-1311 is probably related to conditions in PG-1310 that we have been unable to reproduce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/586)
<!-- Reviewable:end -->
