### PR TITLE
PG-1310: Prevent incorrect matchup display after splitting

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1769,7 +1769,7 @@ namespace Glyssen.Dialogs
 
 		private void HandleResetMatchupClick(object sender, EventArgs e)
 		{
-			m_viewModel.SetBlockMatchupForCurrentVerse();
+			m_viewModel.SetBlockMatchupForCurrentLocation();
 		}
 
 		private void HandleMouseEnterInsertHeSaidButton(object sender, EventArgs e)

--- a/Glyssen/Dialogs/AssignCharacterViewModel.cs
+++ b/Glyssen/Dialogs/AssignCharacterViewModel.cs
@@ -175,7 +175,7 @@ namespace Glyssen.Dialogs
 			{
 				if (CurrentReferenceTextMatchup == null || !CurrentReferenceTextMatchup.IncludesBlock(CurrentBlock))
 				{
-					SetBlockMatchupForCurrentVerse();
+					SetBlockMatchupForCurrentLocation();
 				}
 				else
 				{
@@ -631,7 +631,7 @@ namespace Glyssen.Dialogs
 				if (AttemptRefBlockMatchup)
 				{
 					// A split will always require the current matchup to be re-constructed.
-					SetBlockMatchupForCurrentVerse();
+					SetBlockMatchupForCurrentLocation();
 				}
 
 

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -751,11 +751,11 @@ namespace GlyssenTests.Dialogs
 		}
 
 		[Test]
-		public void SetBlockMatchupForCurrentVerse_AttemptRefBlockMatchupIsFalse_DoesNothing()
+		public void SetBlockMatchupForCurrentLocation_AttemptRefBlockMatchupIsFalse_DoesNothing()
 		{
 			m_model.SetMode(m_model.Mode, false);
 			FindRefInMark(8, 5);
-			m_model.SetBlockMatchupForCurrentVerse();
+			m_model.SetBlockMatchupForCurrentLocation();
 			Assert.IsNull(m_model.CurrentReferenceTextMatchup);
 		}
 


### PR DESCRIPTION
Changed SetBlockMatchupForCurrentLocation (formerly SetBlockMatchupForCurrentVerse) to always use the current start index when building a new matchup so that it will cover the correct range even if a subsequent block in the matchup is the "anchor" block. This prevents incorrect display after splitting a block that is not the first block in the matchup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/587)
<!-- Reviewable:end -->
