### PR TITLE
PG-1162: Fixes in JOL and ReferenceTextUtility 

### DIFF
--- a/DistFiles/reference_texts/English/JOL.xml
+++ b/DistFiles/reference_texts/English/JOL.xml
@@ -179,7 +179,7 @@
     <verse num="20" />
     <text>But I will remove the northern army far away from you, and will drive it into a barren and desolate land, its front into the eastern sea, and its back into the western sea; and its stench will come up, and its bad smell will rise.”</text>
   </block>
-  <block style="p" chapter="2" initialStartVerse="21" characterId="narrator-JOL">
+  <block style="p" chapter="2" initialStartVerse="20" characterId="narrator-JOL">
     <text>Surely he has done great things. </text>
     <verse num="21" />
     <text>Land, don't be afraid. Be glad and rejoice, for God has done great things.</text>


### PR DESCRIPTION
Fixed InitialStartVerse in JOL 2:20
Made ReferenceTextUtility able to output FCBH mappings for OT and NT together

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/597)
<!-- Reviewable:end -->
