### PR TITLE
PG-1298: Prevent orphaned trailing punctuation in USX parser

### DIFF
--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -110,7 +110,7 @@
     <applicationSettings>
         <Glyssen.Properties.Settings>
             <setting name="ParserVersion" serializeAs="String">
-                <value>48</value>
+                <value>49</value>
             </setting>
             <setting name="DataFormatVersion" serializeAs="String">
                 <value>4</value>

--- a/Glyssen/Properties/Settings.Designer.cs
+++ b/Glyssen/Properties/Settings.Designer.cs
@@ -73,7 +73,7 @@ namespace Glyssen.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("48")]
+        [global::System.Configuration.DefaultSettingValueAttribute("49")]
         public int ParserVersion {
             get {
                 return ((int)(this["ParserVersion"]));

--- a/Glyssen/Properties/Settings.settings
+++ b/Glyssen/Properties/Settings.settings
@@ -15,7 +15,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="ParserVersion" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">48</Value>
+      <Value Profile="(Default)">49</Value>
     </Setting>
     <Setting Name="DefaultSfmDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/Glyssen/UsxParser.cs
+++ b/Glyssen/UsxParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using Glyssen.Shared;
@@ -95,6 +96,8 @@ namespace Glyssen
 		private int m_currentChapter;
 		private int m_currentStartVerse;
 		private int m_currentEndVerse;
+
+		private readonly Regex m_regexStartsWithClosingPunctuation = new Regex(@"^(\p{Pd}|\p{Pe}|\p{Pf}|\p{Po})+\s+");
 
 		public UsxParser(string bookId, IStylesheet stylesheet, XmlNodeList nodeList)
 		{
@@ -219,12 +222,25 @@ namespace Glyssen
 									var textToAppend = childNode.InnerText;
 									if (ControlCharacterVerseData.IsCharStyleThatMapsToSpecificCharacter(block.StyleTag) && textToAppend.Any(IsLetter))
 									{
-										if (sb.Length > 0 && sb[sb.Length - 1] != ' ' && textToAppend.StartsWith(" "))
+										if (sb.Length > 0 && sb[sb.Length - 1] != ' ')
 										{
-											// Not terribly important (in fact, we don't even need the trailing space either), but if blocks have
-											// leading spaces, it might look funny in some places in the display.
-											sb.Append(" ");
-											textToAppend = textToAppend.TrimStart();
+											if (textToAppend.StartsWith(" "))
+											{
+												// Not terribly important (in fact, we don't even need the trailing space either), but if blocks have
+												// leading spaces, it might look funny in some places in the display.
+												sb.Append(" ");
+												textToAppend = textToAppend.TrimStart();
+											}
+											else
+											{
+												// This logic implements PG-1298
+												var match = m_regexStartsWithClosingPunctuation.Match(textToAppend);
+												if (match.Success)
+												{
+													sb.Append(match.Value);
+													textToAppend = textToAppend.Remove(0, match.Length);
+												}
+											}
 										}
 										FinalizeCharacterStyleBlock(sb, ref block, blocks, usxPara.StyleTag);
 									}

--- a/GlyssenTests/UsxParserTests.cs
+++ b/GlyssenTests/UsxParserTests.cs
@@ -486,6 +486,31 @@ namespace GlyssenTests
 		}
 
 		[Test]
+		public void Parse_PoetryParagraphsWithQuotedText_QtMarkersgnored()
+		{
+			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"q1\">" +
+				"<verse number=\"23\" style=\"v\" />" +
+				"<char style=\"qt\">N'qe, sinboriwo</char></para>" +
+				"<para style =\"q1\">" +
+				"<char style=\"qt\">wi baga laala taa</char></para>" +
+				"<para style =\"q2\">" +
+				"<char style=\"qt\">be nagabile sii</char>,</para>" +
+				"<para style =\"q1\">" +
+				"<char style=\"qt\">pe beri wi yeri</char></para>" +
+				"<para style =\"q\">" +
+				"<char style=\"qt\">Emanuweli</char>. Kire wi jo “Kulocelie ye ne we ni.” " +
+				"<verse number=\"24\" style=\"v\" />" +
+				"Ba Yusufu wi keni ye ngonimo ne be.</para>");
+			var parser = GetUsxParser(doc);
+			var blocks = parser.Parse().ToList();
+			Assert.AreEqual(7, blocks.Count, "Should have a chapter block, 4 \"scripture\" blocks, and one regular \\q block.");
+			Assert.IsTrue(blocks.Skip(1).Take(4).All(b => b.CharacterId == "scripture"));
+			Assert.IsTrue(blocks[5].GetText(true).StartsWith("Emanuweli."), "Period should get pulled into the \"scripture\" block with \"Emanuweli.\" " +
+				"We probably don't really care if the trailing space is retained or not.");
+			Assert.AreEqual("Kire wi jo “Kulocelie ye ne we ni.” {24}\u00A0Ba Yusufu wi keni ye ngonimo ne be.", blocks.Last().GetText(true));
+		}
+
+		[Test]
 		public void Parse_ParaStartsWithVerseNumber_BlocksGetCorrectChapterAndVerseNumbers()
 		{
 			var doc = UsxDocumentTests.CreateMarkOneDoc("<para style=\"p\">" +


### PR DESCRIPTION
If USX has punctuation following a character style (\qt or \wj) that gets broken off into a separate block and that punctuation appears to belong to the preceding block, append it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/599)
<!-- Reviewable:end -->
