### PR TITLE
Fixed flaw in MigrateDeprecatedCharacterIds + misc. improvements (comments, tests)

### DIFF
--- a/Glyssen/Block.cs
+++ b/Glyssen/Block.cs
@@ -624,7 +624,7 @@ namespace Glyssen
 		/// This handles the common case where the first Block Element is a Verse and the more
 		/// unusual case where there is a preceding Script Text consisting only of an opening square
 		/// bracket (which indicates a verse that is often omitted because of weak manuscript evidence).
-		/// Technically, any preceding SciptText element that consists entirely of punctuation will be
+		/// Technically, any preceding ScriptText element that consists entirely of punctuation will be
 		/// considered as being part of the following verse.)
 		/// </summary>
 		public bool StartsAtVerseStart

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -28,6 +28,7 @@ namespace Glyssen
 			NoOp,
 			Partial,
 			Complete,
+			UpToDate,
 		}
 
 		public static MigrationResult MigrateProjectData(Project project, int fromControlFileVersion)
@@ -38,10 +39,13 @@ namespace Glyssen
 			if (!project.Books.Any())
 				return MigrationResult.NoOp;
 
-			Logger.WriteEvent($"Migrating project {project.ProjectFilePath} from {fromControlFileVersion} to {ControlCharacterVerseData.Singleton.ControlFileVersion}");
+			if (fromControlFileVersion == ControlCharacterVerseData.Singleton.ControlFileVersion)
+				return MigrationResult.UpToDate;
 
 			if (s_lastProjectMigrated != project)
 				s_migrationsRun = 0;
+
+			Logger.WriteEvent($"Migrating project {project.ProjectFilePath} from {fromControlFileVersion} to {ControlCharacterVerseData.Singleton.ControlFileVersion}");
 
 			var result = MigrationResult.Partial;
 
@@ -240,6 +244,7 @@ namespace Glyssen
 
 				foreach (Block block in book.GetScriptBlocks().Where(block => block.CharacterId != null &&
 					block.CharacterId != CharacterVerseData.kUnexpectedCharacter &&
+					block.CharacterId != CharacterVerseData.kNeedsReview &&
 					!CharacterVerseData.IsCharacterStandard(block.CharacterId)))
 				{
 					if (block.CharacterId == CharacterVerseData.kAmbiguousCharacter)

--- a/GlyssenTests/BookScriptTests.cs
+++ b/GlyssenTests/BookScriptTests.cs
@@ -6,10 +6,8 @@ using System.Linq;
 using System.Text;
 using Glyssen;
 using Glyssen.Shared;
-using Glyssen.Utilities;
 using GlyssenEngine;
 using GlyssenEngine.Character;
-using GlyssenEngine.Utilities;
 using NUnit.Framework;
 using SIL.Extensions;
 using SIL.IO;
@@ -1248,7 +1246,6 @@ namespace GlyssenTests
 		[Test]
 		public void GetCloneWithJoinedBlocks_SingleVoiceWithReferenceTexts_BlocksCombinedByOrigParagraphAndReferenceTextIgnored()
 		{
-            Fonts.Default = new WinFormsFonts();
 			var testProject = TestProject.CreateTestProject(TestProject.TestBook.JUD);
 			var jude = testProject.IncludedBooks.Single();
 			var countOfOrigParagraphs = jude.GetScriptBlocks().Count(b => b.IsParagraphStart || CharacterVerseData.IsCharacterOfType(b.CharacterId, CharacterVerseData.StandardCharacter.BookOrChapter));

--- a/GlyssenTests/Character/CharacterAssignerTests.cs
+++ b/GlyssenTests/Character/CharacterAssignerTests.cs
@@ -4,10 +4,8 @@ using System.Linq;
 using Glyssen;
 using Glyssen.Character;
 using Glyssen.Shared;
-using Glyssen.Utilities;
 using GlyssenEngine;
 using GlyssenEngine.Character;
-using GlyssenEngine.Utilities;
 using NUnit.Framework;
 using Rhino.Mocks;
 using SIL.Scripture;
@@ -303,7 +301,6 @@ namespace GlyssenTests.Character
 		[Test]
 		public void AssignAll_FreshlyParsedProject_AssignAllChangesNothing()
 		{
-            Fonts.Default = new WinFormsFonts();
 			var booksToIncludeInTestProject = Enum.GetValues(typeof(TestProject.TestBook)).Cast<TestProject.TestBook>().ToArray();
 			var freshTestProject = TestProject.CreateTestProject(booksToIncludeInTestProject);
 			var testProjectToAssign = TestProject.CreateTestProject(booksToIncludeInTestProject);

--- a/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
+++ b/GlyssenTests/Dialogs/BlockNavigatorViewModelTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Glyssen;
-using Glyssen.Character;
 using Glyssen.Dialogs;
 using Glyssen.Shared;
 using GlyssenEngine;
@@ -1406,7 +1405,7 @@ namespace GlyssenTests.Dialogs
 				b.AllVerses.Skip(1).Any() &&
 				b.CharacterIs("MRK", CharacterVerseData.StandardCharacter.Narrator));
 			// We have to manually split the block to separate the initial verses which already don't match
-			// the reference text from the last two verse, which are just plain narrator verses in both the
+			// the reference text from the last two verses, which are just plain narrator verses in both the
 			// Vernacular and the English reference text.
 			lastBlockInChapter = mark.SplitBlock(lastBlockInChapter,
 				((Verse)(lastBlockInChapter.AllVerses.Reverse().ElementAt(2))).Number,

--- a/GlyssenTests/ProjectDataMigratorTests.cs
+++ b/GlyssenTests/ProjectDataMigratorTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Glyssen;
-using Glyssen.Character;
 using Glyssen.Shared;
 using GlyssenEngine;
 using GlyssenEngine.Character;

--- a/GlyssenTests/ProjectTests.cs
+++ b/GlyssenTests/ProjectTests.cs
@@ -9,13 +9,11 @@ using Glyssen.Character;
 using Glyssen.Paratext;
 using Glyssen.Shared;
 using Glyssen.Shared.Bundle;
-using Glyssen.Utilities;
 using GlyssenEngine;
 using GlyssenEngine.Bundle;
 using GlyssenEngine.Character;
 using GlyssenEngine.Paratext;
 using GlyssenEngine.Quote;
-using GlyssenEngine.Utilities;
 using GlyssenTests.Bundle;
 using NUnit.Framework;
 using SIL.DblBundle.Text;
@@ -1278,7 +1276,6 @@ namespace GlyssenTests
 		[Test]
 		public void CalculateSpeechDistributionScore_BoazInProjectThatOnlyIncludesRuth_ReturnsResultFromMaxBook()
 		{
-            Fonts.Default = new WinFormsFonts();
 			var testProject = TestProject.CreateTestProject(TestProject.TestBook.RUT);
 			TestProject.SimulateDisambiguationForAllBooks(testProject);
 			Assert.IsTrue(testProject.SpeechDistributionScoreByCharacterId["Boaz"] >= 7);

--- a/GlyssenTests/TestProject.cs
+++ b/GlyssenTests/TestProject.cs
@@ -9,10 +9,12 @@ using Glyssen;
 using Glyssen.Bundle;
 using Glyssen.Shared;
 using Glyssen.Shared.Bundle;
+using Glyssen.Utilities;
 using GlyssenEngine;
 using GlyssenEngine.Bundle;
 using GlyssenEngine.Character;
 using GlyssenEngine.Quote;
+using GlyssenEngine.Utilities;
 using SIL.DblBundle.Text;
 using SIL.DblBundle.Usx;
 using SIL.IO;
@@ -60,6 +62,11 @@ namespace GlyssenTests
 		}
 
 		private const string kTest = "test~~";
+
+		static TestProject()
+		{
+			Fonts.Default = new WinFormsFonts();
+		}
 
 		public static void DeleteTestProjectFolder()
 		{


### PR DESCRIPTION
Moved Fonts.Default initialization into static constructor for TestPr…ject so that all unit tests that rely on that can be run independently and not depend on the order of tests.

Added early return in MigrateProjectData to avoid logging the no-op case when we're already on the correct version. Note: This means that MigrateDeprecatedCharacterIds will NOT be called if the version is already up-to-date. (I think this should be okay.)
Prevented overwriting a "Needs Review" character assignment in MigrateDeprecatedCharacterIds. (There is some special logic in the parser to assign this when blocks include verses with both implicit and non-implicit characters, and the logic in this method was clobbering those.)
Fixed typos in comments in BlockNavigatorViewModelTests.cs and Block.cs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/601)
<!-- Reviewable:end -->
