### PR TITLE
Fixed bad dependency in Block on a static regex

### DIFF
--- a/Glyssen/Character/CharacterAssigner.cs
+++ b/Glyssen/Character/CharacterAssigner.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using GlyssenEngine.Character;
+using GlyssenEngine.Quote;
 using SIL.Scripture;
 
 namespace Glyssen.Character
@@ -8,10 +9,12 @@ namespace Glyssen.Character
 	public class CharacterAssigner
 	{
 		private readonly ICharacterVerseInfo m_cvInfo;
+		private readonly IQuoteInterruptionFinder m_interruptionFinder;
 
-		public CharacterAssigner(ICharacterVerseInfo cvInfo)
+		public CharacterAssigner(ICharacterVerseInfo cvInfo, IQuoteInterruptionFinder interruptionFinder)
 		{
 			m_cvInfo = cvInfo;
+			m_interruptionFinder = interruptionFinder;
 		}
 
 		public void AssignAll(ICollection<BookScript> bookScripts, bool setDefaultForMultipleChoiceCharacters, bool overwriteUserConfirmed = false)
@@ -27,7 +30,7 @@ namespace Glyssen.Character
 			{
 				if (!block.UserConfirmed || overwriteUserConfirmed)
 				{
-					block.SetCharacterAndDelivery(m_cvInfo.GetCharacters(bookNum, block.ChapterNumber, block.AllVerses, bookScript.Versification));
+					block.SetCharacterAndDelivery(m_interruptionFinder, m_cvInfo.GetCharacters(bookNum, block.ChapterNumber, block.AllVerses, bookScript.Versification));
 				}
 				else if (setDefaultForMultipleChoiceCharacters)
 				{

--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -1413,7 +1413,7 @@ namespace Glyssen
 			if (m_projectMetadata.ControlFileVersion != ControlCharacterVerseData.Singleton.ControlFileVersion)
 			{
 				const int kControlFileVersionWhenOnTheFlyAssignmentOfCharacterIdInScriptBegan = 78;
-				new CharacterAssigner(new CombinedCharacterVerseData(this)).AssignAll(m_books,
+				new CharacterAssigner(new CombinedCharacterVerseData(this), QuoteSystem).AssignAll(m_books,
 					m_projectMetadata.ControlFileVersion < kControlFileVersionWhenOnTheFlyAssignmentOfCharacterIdInScriptBegan);
 
 				UpdateControlFileVersion();

--- a/Glyssen/ProjectDataMigrator.cs
+++ b/Glyssen/ProjectDataMigrator.cs
@@ -301,7 +301,7 @@ namespace Glyssen
 										block.CharacterIdInScript = match.ResolvedDefaultCharacter;
 									}
 									else
-										block.SetCharacterAndDelivery(characters);
+										block.SetCharacterAndDelivery(project.QuoteSystem, characters);
 									numberOfChangesMade++;
 								}
 							}

--- a/GlyssenEngine/Quote/IQuoteInterruptionFinder.cs
+++ b/GlyssenEngine/Quote/IQuoteInterruptionFinder.cs
@@ -1,0 +1,8 @@
+﻿namespace GlyssenEngine.Quote
+{
+	public interface IQuoteInterruptionFinder
+	{
+		QuoteInterruption GetNextInterruption(string text, int startCharIndex);
+		bool ProbablyDoesNotContainInterruption(string text);
+	}
+}

--- a/GlyssenEngine/Quote/QuoteInterruption.cs
+++ b/GlyssenEngine/Quote/QuoteInterruption.cs
@@ -1,0 +1,16 @@
+﻿namespace GlyssenEngine.Quote
+{
+	public class QuoteInterruption
+	{
+		public int Index { get; }
+		public int Length { get; }
+		public string Value { get; }
+
+		public QuoteInterruption(int index, int length, string value)
+		{
+			Index = index;
+			Length = length;
+			Value = value;
+		}
+	}
+}

--- a/GlyssenTests/BookScriptTests.cs
+++ b/GlyssenTests/BookScriptTests.cs
@@ -8,10 +8,12 @@ using Glyssen;
 using Glyssen.Shared;
 using GlyssenEngine;
 using GlyssenEngine.Character;
+using GlyssenEngine.Quote;
 using NUnit.Framework;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.Scripture;
+using SIL.WritingSystems;
 using SIL.Xml;
 using Resources = GlyssenTests.Properties.Resources;
 
@@ -26,6 +28,7 @@ namespace GlyssenTests
 		private string m_curStyleTag;
 
 		private ScrVers m_testVersification;
+		private IQuoteInterruptionFinder m_interruptionFinder;
 
 		[TestFixtureSetUp]
 		public void FixtureSetup()
@@ -39,6 +42,8 @@ namespace GlyssenTests
 				File.WriteAllText(tempFile.Path, Resources.TestVersification);
 				m_testVersification = Versification.Table.Implementation.Load(tempFile.Path);
 			}
+
+			m_interruptionFinder = new QuoteSystem(new QuotationMark("—", "—", null, 1, QuotationMarkingSystemType.Narrative));
 		}
 
 		#region GetVerseText Tests
@@ -4292,7 +4297,7 @@ namespace GlyssenTests
 			mrkBlocks.Add(NewPara("q1", "«Yo envío a mi mensajero delante de ti, El cual preparará tu camino.")
 				.AddVerse(3, "Una voz clama en el desierto: “Preparen el camino del Señor; Enderecen sus sendas.”»"));
 			m_curSetupVerse = 3;
-			mrkBlocks.Last().SetCharacterAndDelivery(new CharacterVerse[0]);
+			mrkBlocks.Last().SetCharacterAndDelivery(m_interruptionFinder, new CharacterVerse[0]);
 			mrkBlocks.Add(NewSingleVersePara(4, "Juan se presentó en el desierto, y bautizaba y proclamaba el bautismo de arrepentimiento para el perdón de pecados. ", "MRK")
 				.AddVerse(5, "Toda la gente de la provincia de Judea y de Jerusalén acudía a él, y allí en el río Jordán confesaban sus pecados, y Juan los bautizaba."));
 			m_curSetupVerse = 5;
@@ -4308,7 +4313,7 @@ namespace GlyssenTests
 						"«Después de mí viene uno más poderoso que yo. ¡Yo no soy digno de inclinarme ante él para desatarle la correa de su calzado! ")
 						.AddVerse(8, "A ustedes yo los he bautizado con agua, pero él los bautizará con el Espíritu Santo.»"));
 				m_curSetupVerse = 8;
-				mrkBlocks.Last().SetCharacterAndDelivery(new CharacterVerse[0]);
+				mrkBlocks.Last().SetCharacterAndDelivery(m_interruptionFinder, new CharacterVerse[0]);
 			}
 
 			mrkBlocks.Add(NewPara("s", "El bautismo de Jesús", "MRK"));
@@ -4317,7 +4322,7 @@ namespace GlyssenTests
 				.AddVerse(11, "Y desde los cielos se oyó una voz que decía: "));
 			m_curSetupVerse = 11;
 			mrkBlocks.Add(NewBlock("«Tú eres mi Hijo amado, en quien me complazco.»"));
-			mrkBlocks.Last().SetCharacterAndDelivery(new CharacterVerse[0]);
+			mrkBlocks.Last().SetCharacterAndDelivery(m_interruptionFinder, new CharacterVerse[0]);
 
 			if (includeExtraVersesInChapter1)
 			{
@@ -4326,7 +4331,7 @@ namespace GlyssenTests
 					.AddVerse(15, "Decía: "));
 				m_curSetupVerse = 15;
 				mrkBlocks.Add(NewBlock("«El tiempo se ha cumplido, y el reino de Dios se ha acercado. ¡Arrepiéntanse, y crean en el evangelio!»"));
-				mrkBlocks.Last().SetCharacterAndDelivery(new CharacterVerse[0]);
+				mrkBlocks.Last().SetCharacterAndDelivery(m_interruptionFinder, new CharacterVerse[0]);
 			}
 
 			return mrkBlocks;

--- a/GlyssenTests/Character/CharacterAssignerTests.cs
+++ b/GlyssenTests/Character/CharacterAssignerTests.cs
@@ -6,9 +6,11 @@ using Glyssen.Character;
 using Glyssen.Shared;
 using GlyssenEngine;
 using GlyssenEngine.Character;
+using GlyssenEngine.Quote;
 using NUnit.Framework;
 using Rhino.Mocks;
 using SIL.Scripture;
+using SIL.WritingSystems;
 using SIL.Xml;
 
 namespace GlyssenTests.Character
@@ -18,6 +20,13 @@ namespace GlyssenTests.Character
 	{
 		private static readonly int kMATbookNum = BCVRef.BookToNumber("MAT");
 		private static readonly int kMRKbookNum = BCVRef.BookToNumber("MRK");
+		private IQuoteInterruptionFinder m_interruptionFinder;
+
+		[TestFixtureSetUp]
+		public void FixtureSetup()
+		{
+			m_interruptionFinder = new QuoteSystem(new QuotationMark("—", "—", null, 1, QuotationMarkingSystemType.Narrative));
+		}
 
 		private BookScript GetSimpleBookScript()
 		{
@@ -75,7 +84,7 @@ namespace GlyssenTests.Character
 			var cvInfo = MockRepository.GenerateMock<ICharacterVerseInfo>();
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, "King Saul");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English, "Jesus");
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, false);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, false);
 			Assert.AreEqual("King Saul", bookScript[1].CharacterId);
 			Assert.AreEqual("Thomas/Andrew/Bartholomew", bookScript[2].CharacterId);
 			Assert.AreEqual("Thomas/Andrew/Bartholomew", bookScript[2].CharacterIdInScript);
@@ -89,7 +98,7 @@ namespace GlyssenTests.Character
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, "John the Baptist");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English, "King Saul");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 6, ScrVers.English, new CharacterSpeakingMode[0]);
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, true);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, true);
 			Assert.AreEqual("John the Baptist", bookScript[1].CharacterId);
 			Assert.AreEqual("King Saul", bookScript[2].CharacterId);
 		}
@@ -102,7 +111,7 @@ namespace GlyssenTests.Character
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, new[] { new CharacterSpeakingMode("Thomas/Andrew/Bartholomew", null, null, false, QuoteType.Normal, "Andrew") });
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English, "James/John");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 6, ScrVers.English, new CharacterSpeakingMode[0]);
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, true, true);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, true, true);
 			Assert.AreEqual("Thomas/Andrew/Bartholomew", bookScript[1].CharacterId);
 			Assert.AreEqual("Andrew", bookScript[1].CharacterIdInScript);
 			Assert.AreEqual("James/John", bookScript[2].CharacterId);
@@ -120,7 +129,7 @@ namespace GlyssenTests.Character
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, "Made Up Guy");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English,
 				new[] { new CharacterSpeakingMode("Thomas/Andrew/Bartholomew", null, null, false) }, true);
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, true, false);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, true, false);
 			Assert.AreEqual("Made Up Guy", bookScript[1].CharacterId);
 			Assert.AreEqual("Made Up Guy", bookScript[1].CharacterIdInScript);
 			Assert.AreEqual("Thomas/Andrew/Bartholomew", bookScript[2].CharacterId);
@@ -138,7 +147,7 @@ namespace GlyssenTests.Character
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, "Made Up Guy");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English,
 				new[] { new CharacterSpeakingMode("Thomas/Andrew/Bartholomew", null, null, false, QuoteType.Normal, "Andrew") }, true);
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, true, false);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, true, false);
 			Assert.AreEqual("Thomas/Andrew/Bartholomew", bookScript[2].CharacterId);
 			Assert.AreEqual("Andrew", bookScript[2].CharacterIdInScript);
 		}
@@ -151,7 +160,7 @@ namespace GlyssenTests.Character
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 4, ScrVers.English, "John the Baptist");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 5, ScrVers.English, "King Saul");
 			StubGetCharactersForSingleVerse(cvInfo, kMRKbookNum, 1, 6, ScrVers.English, new CharacterSpeakingMode[0]);
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, true);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, true);
 			Assert.AreEqual("narrator-MRK", bookScript[0].CharacterId);
 		}
 
@@ -171,7 +180,7 @@ namespace GlyssenTests.Character
 			Assert.True(bookScript[2].UserConfirmed);
 			Assert.True(bookScript[3].UserConfirmed);
 
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, true);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, true);
 			Assert.AreEqual(CharacterVerseData.kAmbiguousCharacter, bookScript[2].CharacterId);
 			Assert.False(bookScript[2].UserConfirmed);
 			Assert.AreEqual(CharacterVerseData.kUnexpectedCharacter, bookScript[3].CharacterId);
@@ -189,7 +198,7 @@ namespace GlyssenTests.Character
 			Assert.True(bookScript[0].UserConfirmed);
 			Assert.True(bookScript[1].UserConfirmed);
 
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, false);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, false);
 			Assert.AreEqual(CharacterVerseData.kAmbiguousCharacter, bookScript[0].CharacterId);
 			Assert.AreEqual(CharacterVerseData.kAmbiguousCharacter, bookScript[1].CharacterId);
 			Assert.AreEqual("firstCharacter", bookScript[2].CharacterId);
@@ -231,7 +240,7 @@ namespace GlyssenTests.Character
 
 			Assert.IsFalse(bookScript.GetScriptBlocks().Any(b => b.UserConfirmed));
 
-			new CharacterAssigner(cvInfo).AssignAll(new[] { bookScript }, false, false);
+			new CharacterAssigner(cvInfo, m_interruptionFinder).AssignAll(new[] { bookScript }, false, false);
 			Assert.AreEqual("Jesus", bookScript[0].CharacterId);
 			Assert.AreEqual(CharacterVerseData.kAmbiguousCharacter, bookScript[1].CharacterId);
 			Assert.AreEqual("Jesus", bookScript[2].CharacterId);
@@ -289,7 +298,7 @@ namespace GlyssenTests.Character
 			Assert.AreEqual(MultiBlockQuote.Start, bookScript.Blocks[0].MultiBlockQuote);
 			Assert.AreEqual(MultiBlockQuote.Continuation, bookScript.Blocks[1].MultiBlockQuote);
 
-			var characterAssigner = new CharacterAssigner(cvInfo);
+			var characterAssigner = new CharacterAssigner(cvInfo, m_interruptionFinder);
 			characterAssigner.AssignAll(new[] { bookScript }, false);
 
 			Assert.AreEqual("Jesus", bookScript.Blocks[0].CharacterId);
@@ -305,7 +314,7 @@ namespace GlyssenTests.Character
 			var freshTestProject = TestProject.CreateTestProject(booksToIncludeInTestProject);
 			var testProjectToAssign = TestProject.CreateTestProject(booksToIncludeInTestProject);
 
-			var characterAssigner = new CharacterAssigner(ControlCharacterVerseData.Singleton);
+			var characterAssigner = new CharacterAssigner(ControlCharacterVerseData.Singleton, m_interruptionFinder);
 			characterAssigner.AssignAll(testProjectToAssign.Books.ToList(), false);
 
 			var expected = freshTestProject.Books;

--- a/GlyssenTests/ProjectTests.cs
+++ b/GlyssenTests/ProjectTests.cs
@@ -145,7 +145,7 @@ namespace GlyssenTests
 			var firstBook = project.Books[0];
 			var block = firstBook.GetScriptBlocks().Last();
 			var verseRef = new BCVRef(BCVRef.BookToNumber(firstBook.BookId), block.ChapterNumber, block.InitialStartVerseNumber);
-			block.SetCharacterAndDelivery(new List<CharacterVerse>(
+			block.SetCharacterAndDelivery(project.QuoteSystem, new List<CharacterVerse>(
 				new [] { new CharacterVerse(verseRef, "Wilma", "agitated beyond belief", null, true) }));
 			block.UserConfirmed = true;
 


### PR DESCRIPTION
...rather than having the quote interruption logic be based on the actual quote system in use.

In some cases, the order in which tests were run could potentially lead to failures.
Added some additional Block tests to deal with condition where the quote system did/did not include a long dash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/610)
<!-- Reviewable:end -->
