### PR TITLE
Moved unit tests for classes that were previously moved to GlyssenEngine…

### DIFF
--- a/GlyssenEngineTests/Character/NarratorOverridesTests.cs
+++ b/GlyssenEngineTests/Character/NarratorOverridesTests.cs
@@ -4,7 +4,7 @@ using GlyssenEngine.Character;
 using NUnit.Framework;
 using SIL.Scripture;
 
-namespace GlyssenTests.Character
+namespace GlyssenEngineTests.Character
 {
 	// Note: NarratorOverrides does not currently allow the tests to jam in an alternate version of the control-file data in order
 	// to ensure that tests will not be broken by future data changes. My expectation is that the control-file data for the

--- a/GlyssenEngineTests/GlyssenEngineTests.csproj
+++ b/GlyssenEngineTests/GlyssenEngineTests.csproj
@@ -104,6 +104,9 @@
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
+    <Reference Include="SIL.TestUtilities, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\packages\SIL.TestUtilities.8.0.0-beta0037\lib\net461\SIL.TestUtilities.dll</HintPath>
+    </Reference>
     <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.WritingSystems.8.0.0-beta0037\lib\net461\SIL.WritingSystems.dll</HintPath>
     </Reference>
@@ -239,6 +242,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Character\CharacterVerseDataTests.cs" />
+    <Compile Include="Character\NarratorOverridesTests.cs" />
     <Compile Include="Character\RelatedCharactersTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -246,10 +250,14 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Quote\QuoteSystemTests.cs" />
+    <Compile Include="Quote\QuoteUtilsTests.cs" />
     <Compile Include="Utilities\FileSystemUtilsTests.cs" />
     <Compile Include="Utilities\MathUtilitiesTests.cs" />
     <Compile Include="Utilities\UndoActionSequenceTests.cs" />
     <Compile Include="Utilities\UndoStackTests.cs" />
+    <Compile Include="VoiceActor\VoiceActorListTests.cs" />
+    <Compile Include="VoiceActor\VoiceActorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GlyssenEngine\GlyssenEngine.csproj">
@@ -282,6 +290,7 @@
     <Content Include="icu64\icuin54.dll" />
     <Content Include="icu64\icuuc54.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Icu4c.Win.Full.Lib.59.1.15\build\Icu4c.Win.Full.Lib.targets" Condition="Exists('..\packages\Icu4c.Win.Full.Lib.59.1.15\build\Icu4c.Win.Full.Lib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -290,6 +299,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Icu4c.Win.Full.Lib.59.1.15\build\Icu4c.Win.Full.Lib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Full.Lib.59.1.15\build\Icu4c.Win.Full.Lib.targets'))" />
     <Error Condition="!Exists('..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets'))" />
+    <Error Condition="!Exists('..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets'))" />
   </Target>
   <Import Project="..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets" Condition="Exists('..\packages\Icu4c.Win.Min.59.1.7\build\Icu4c.Win.Min.targets')" />
+  <Import Project="..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="Exists('..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
 </Project>

--- a/GlyssenEngineTests/Quote/QuoteSystemTests.cs
+++ b/GlyssenEngineTests/Quote/QuoteSystemTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using SIL.WritingSystems;
 using SIL.Xml;
 
-namespace GlyssenTests.Quote
+namespace GlyssenEngineTests.Quote
 {
 	[TestFixture]
 	class QuoteSystemTests

--- a/GlyssenEngineTests/Quote/QuoteUtilsTests.cs
+++ b/GlyssenEngineTests/Quote/QuoteUtilsTests.cs
@@ -3,7 +3,7 @@ using GlyssenEngine.Quote;
 using NUnit.Framework;
 using SIL.WritingSystems;
 
-namespace GlyssenTests.Quote
+namespace GlyssenEngineTests.Quote
 {
 	[TestFixture]
 	public class QuoteUtilsTests

--- a/GlyssenEngineTests/VoiceActor/VoiceActorListTests.cs
+++ b/GlyssenEngineTests/VoiceActor/VoiceActorListTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using SIL.IO;
 using SIL.TestUtilities;
 
-namespace GlyssenTests.VoiceActor
+namespace GlyssenEngineTests.VoiceActor
 {
 	[TestFixture]
 	class VoiceActorListTests

--- a/GlyssenEngineTests/VoiceActor/VoiceActorTests.cs
+++ b/GlyssenEngineTests/VoiceActor/VoiceActorTests.cs
@@ -2,7 +2,7 @@
 using GlyssenEngine.VoiceActor;
 using NUnit.Framework;
 
-namespace GlyssenTests.VoiceActor
+namespace GlyssenEngineTests.VoiceActor
 {
 	class VoiceActorTests
 	{

--- a/GlyssenEngineTests/packages.config
+++ b/GlyssenEngineTests/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.Win32.Registry.AccessControl" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Win32.SystemEvents" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Windows.Compatibility" version="3.1.0" targetFramework="net472" />
+  <package id="Mono.Posix" version="5.4.0.201" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="NUnit" version="2.6.4" targetFramework="net461" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
@@ -18,6 +19,7 @@
   <package id="SIL.Core" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.TestUtilities" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />
   <package id="System.CodeDom" version="4.7.0" targetFramework="net472" />

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -310,7 +310,6 @@
     <Compile Include="BlockMatchupTests.cs" />
     <Compile Include="BlockNavigatorTests.cs" />
     <Compile Include="Character\ControlCharacterVerseDataTests.cs" />
-    <Compile Include="Character\NarratorOverridesTests.cs" />
     <Compile Include="Dialogs\SplitBlockViewModelTests.cs" />
     <Compile Include="Dialogs\CastSizeCalculationUtilities.cs" />
     <Compile Include="Dialogs\UnappliedSplitsViewModelTests.cs" />
@@ -345,10 +344,8 @@
     <Compile Include="ReferenceTextIdentifierTests.cs" />
     <Compile Include="ReferenceTextTests.cs" />
     <Compile Include="Rules\CharacterGroupsAdjusterTests.cs" />
-    <Compile Include="Quote\QuoteUtilsTests.cs" />
     <Compile Include="Quote\QuoteParserTests.cs" />
     <Compile Include="Quote\QuoteSystemGuesserTests.cs" />
-    <Compile Include="Quote\QuoteSystemTests.cs" />
     <Compile Include="Rules\CharacterGroupGeneratorTests.cs" />
     <Compile Include="Rules\ProximityTests.cs" />
     <Compile Include="Rules\AuthorStatsTests.cs" />
@@ -360,8 +357,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\VerseBridge.cs" />
     <Compile Include="Utilities\VerseRefExtensionsTests.cs" />
-    <Compile Include="VoiceActor\VoiceActorListTests.cs" />
-    <Compile Include="VoiceActor\VoiceActorTests.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
…and which do not have dependencies on classes still in Glyssen or GlyssenTests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/613)
<!-- Reviewable:end -->
