### PR TITLE
Pared down MessageModal enums to a more limited set of options.

### DIFF
--- a/Glyssen/DataMigrator.cs
+++ b/Glyssen/DataMigrator.cs
@@ -289,7 +289,7 @@ namespace Glyssen
 						var msg = GetAudioAudioProblemPreamble(unsafeReplacements.Count) +
 							String.Join(Environment.NewLine, unsafeReplacements.Select(r => r.Item1)) + Environment.NewLine + Environment.NewLine +
 							String.Format(fmt, GlyssenInfo.kProduct, Constants.kSupportSite);
-						MessageModal.Show(msg, GlyssenInfo.kProduct, Buttons.OK, Icon.Exclamation);
+						MessageModal.Show(msg, GlyssenInfo.kProduct, Buttons.OK, Icon.Warning);
 					}
 					if (unsafeReplacements.Any() || safeReplacements.Any())
 						retVal = false;

--- a/Glyssen/Dialogs/WinFormsMessageBox.cs
+++ b/Glyssen/Dialogs/WinFormsMessageBox.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
 using GlyssenEngine.Utilities;
 
 namespace Glyssen.Dialogs
@@ -19,49 +20,29 @@ namespace Glyssen.Dialogs
 				case Buttons.OK:
 					messageBoxButtons = MessageBoxButtons.OK;
 					break;
-				case Buttons.OKCancel:
-					messageBoxButtons = MessageBoxButtons.OKCancel;
-					break;
 				case Buttons.RetryCancel:
 					messageBoxButtons = MessageBoxButtons.RetryCancel;
 					break;
 				case Buttons.YesNo:
 					messageBoxButtons = MessageBoxButtons.YesNo;
 					break;
-				default: // Buttons.YesNoCancel
-					messageBoxButtons = MessageBoxButtons.YesNoCancel;
-					break;
+				default:
+					throw new NotImplementedException("Unexpected MessageModal button!");
 			}
 
 			switch (icon)
 			{
-				case Icon.Asterisk:
-					messageBoxIcon = MessageBoxIcon.Asterisk;
-					break;
-				case Icon.Error:
-					messageBoxIcon = MessageBoxIcon.Error;
-					break;
 				case Icon.Exclamation:
 					messageBoxIcon = MessageBoxIcon.Exclamation;
-					break;
-				case Icon.Hand:
-					messageBoxIcon = MessageBoxIcon.Hand;
-					break;
-				case Icon.Information:
-					messageBoxIcon = MessageBoxIcon.Information;
 					break;
 				case Icon.None:
 					messageBoxIcon = MessageBoxIcon.None;
 					break;
-				case Icon.Question:
-					messageBoxIcon = MessageBoxIcon.Question;
-					break;
-				case Icon.Stop:
-					messageBoxIcon = MessageBoxIcon.Stop;
-					break;
-				default: // Icon.Warning
+				case Icon.Warning:
 					messageBoxIcon = MessageBoxIcon.Warning;
 					break;
+				default:
+					throw new NotImplementedException("Unexpected MessageModal icon!");
 			}
 
 			switch (defaultButton)
@@ -72,9 +53,11 @@ namespace Glyssen.Dialogs
 				case DefaultButton.Button2:
 					messageBoxDefaultButton = MessageBoxDefaultButton.Button2;
 					break;
-				default: // DefaultButton.Button3
+				case DefaultButton.Button3:
 					messageBoxDefaultButton = MessageBoxDefaultButton.Button3;
 					break;
+				default:
+					throw new NotImplementedException("Unexpected MessageModal default button!");
 			}
 
 			DialogResult result = MessageBox.Show(text, caption, messageBoxButtons, messageBoxIcon, messageBoxDefaultButton);

--- a/GlyssenEngine/Utilities/MessageModal.cs
+++ b/GlyssenEngine/Utilities/MessageModal.cs
@@ -42,14 +42,8 @@ namespace GlyssenEngine.Utilities
 
     public enum Icon
     {
-        Asterisk,
-        Error,
         Exclamation,
-        Hand,
-        Information,
         None,
-        Question,
-        Stop,
         Warning
     }
 
@@ -57,10 +51,8 @@ namespace GlyssenEngine.Utilities
     {
         AbortRetryIgnore,
         OK,
-        OKCancel,
         RetryCancel,
         YesNo,
-        YesNoCancel
     }
 
     public enum DefaultButton


### PR DESCRIPTION
Note: Exclamation and Warning are already synonymous, but I'm leaving Exclamation for now to avoid a messy merge conflict since I know the code that uses it is getting moved in a separate PR.
Further paring down should be possible after we refactor things to move more user interaction into the UI layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/614)
<!-- Reviewable:end -->
