### PR TITLE
Removed unnecessary call to RobustFile.Delete(FallbackVersificationFilePath)…

### DIFF
--- a/Glyssen/Project.cs
+++ b/Glyssen/Project.cs
@@ -1818,7 +1818,6 @@ namespace Glyssen
 		public string ExportShare(Action<string> handleCustomReferenceText)
 		{
 			{
-				RobustFile.Delete(FallbackVersificationFilePath);
 				PrepareForExport();
 
 				try


### PR DESCRIPTION
…that was accidentally added in previous PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/627)
<!-- Reviewable:end -->
