### PR TITLE
PG-1324: Fixed HTML-building logic in SplitBlockViewModel

### DIFF
--- a/Glyssen/Dialogs/SplitBlockViewModel.cs
+++ b/Glyssen/Dialogs/SplitBlockViewModel.cs
@@ -126,17 +126,17 @@ namespace Glyssen.Dialogs
 					bldr.Append(Format(m_characterSelectFmt, splitLocationsForThisBlock[0].Id));
 					processedFirstBlock = true;
 				}
-				bldr.Append(GetSplitTextAsHtml(block, id, m_font.RightToLeftScript, splitLocationsForThisBlock.Skip(processedFirstBlock ? 1 : 0).ToList(), Format(m_characterSelectFmt, id)));
+				bldr.Append(GetSplitTextAsHtml(block, id, m_font.RightToLeftScript, splitLocationsForThisBlock.Skip(processedFirstBlock ? 1 : 0).ToList(), splitId => Format(m_characterSelectFmt, splitId)));
 			}
 			else
 			{
-				bldr.Append(GetSplitTextAsHtml(block, id, m_font.RightToLeftScript, null, Format(m_characterSelectFmt, id)));
+				bldr.Append(GetSplitTextAsHtml(block, id, m_font.RightToLeftScript, null, splitId => Format(m_characterSelectFmt, splitId)));
 			}
 
 			return bldr.ToString();
 		}
 
-		internal string GetSplitTextAsHtml(Block block, int blockId, bool rightToLeftScript, IReadOnlyCollection<BlockSplitData> blockSplits, string characterSelectCode = null)
+		internal string GetSplitTextAsHtml(Block block, int blockId, bool rightToLeftScript, IReadOnlyCollection<BlockSplitData> blockSplits, Func<int, string> getCharacterSelectCode = null)
 		{
 			var bldr = new StringBuilder();
 			var currVerse = block.InitialVerseNumberOrBridge;
@@ -193,7 +193,7 @@ namespace Glyssen.Dialogs
 																	   $"than or equal to the length ({preEncodedContent.Length}) of the content of verse {currVerse}");
 								}
 
-								allContentToInsert.Insert(0, BuildSplitLineHtml(blockSplit.Id) + characterSelectCode);
+								allContentToInsert.Insert(0, BuildSplitLineHtml(blockSplit.Id) + getCharacterSelectCode?.Invoke(blockSplit.Id));
 								preEncodedContent = preEncodedContent.Insert(offsetToInsertExtra, kAwooga);
 							}
 						}

--- a/Glyssen/Dialogs/UnappliedSplitsViewModel.cs
+++ b/Glyssen/Dialogs/UnappliedSplitsViewModel.cs
@@ -11,7 +11,6 @@ namespace Glyssen.Dialogs
 		private const string kHtmlFrame = "<html><head><meta charset=\"UTF-8\"/>" +
 								"<style>{0}</style></head><body>{1}</body></html>";
 
-		private string m_style;
 		private readonly IEnumerable<BookScript> m_books;
 		private readonly bool m_rightToLeft;
 
@@ -27,7 +26,7 @@ namespace Glyssen.Dialogs
 			foreach (var book in m_books.Where(b => b.UnappliedSplits.Any()))
 				bldr.Append(BuildBookHtml(book));
 
-			return Format(kHtmlFrame, m_style, bldr);
+			return Format(kHtmlFrame, Empty, bldr);
 		}
 
 		private string BuildBookHtml(BookScript book)

--- a/GlyssenTests/Dialogs/SplitBlockViewModelTests.cs
+++ b/GlyssenTests/Dialogs/SplitBlockViewModelTests.cs
@@ -46,6 +46,26 @@ namespace GlyssenTests.Dialogs
 			Assert.IsTrue(actual.Contains(expected), string.Format("The output string did not contain: {0}", expected));
 		}
 
+		[Test]
+		public void GetSplitTextAsHtml_WithCharacterSelectFunc_InsertsSelectElement()
+		{
+			var block = new Block("p", 43, 1);
+			block.BlockElements.Add(new Verse("1"));
+			block.BlockElements.Add(new ScriptText("The Lord says: This is what I say. "));
+			block.BlockElements.Add(new Verse("2"));
+			block.BlockElements.Add(new ScriptText("Text of verse two."));
+			var model = new SplitBlockViewModel(new TestFont(), new[] { block }, new ICharacter[0], "ISA");
+
+			string GetSelectCharacter(int splitId) => "<select class=\"select-character\" data-splitid=\"" + splitId + "\"><option value=\"\"></option><option value=\"narrator-ISA\">" +
+				"narrator (ISA)</option><option value=\"God\">God (the LORD)</option><option value=\"Isaiah\">Isaiah</option></select>";
+
+			var expectedToContain = "<div class=\"split-line-top\"></div></div>" + GetSelectCharacter(42) + "<div class=\"splittext\" data-blockid=\"99\"";
+
+			var actual = model.GetSplitTextAsHtml(block, 99, false, new[] { new BlockSplitData(42, block, "1", 15) }, GetSelectCharacter);
+
+			Assert.IsTrue(actual.Contains(expectedToContain), string.Format("The output string did not contain: {0}", expectedToContain));
+		}
+
 		[TestCase("[", "]")]
 		[TestCase("{", "}")]
 		public void GetSplitTextAsHtml_MultipleBlockSplitsProvided_InsertsBlockSplits(string open, string close)


### PR DESCRIPTION
 It now properly formats the body of the select element to include the block-split ID.
Also removed unassigned member from UnappliedSplitsViewModel to eliminate build warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/630)
<!-- Reviewable:end -->
