### PR TITLE
PG-1316: Clone reference text blocks in Apply to avoid possibly cross-linking

### DIFF
--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -329,9 +329,7 @@ namespace GlyssenEngine.Script
 				return "";
 			if (depth == 0)
 				return GetPrimaryReferenceText();
-			if (ReferenceBlocks.Count == 1)
-				return ReferenceBlocks[0].GetReferenceTextAtDepth(depth - 1);
-			return null;
+			return ReferenceBlocks.OnlyOrDefault()?.GetReferenceTextAtDepth(depth - 1);
 		}
 
 		public string GetEmptyVerseReferenceTextAtDepth(int depth)

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -203,7 +203,7 @@ namespace GlyssenEngine.Script
 				var vernBlock = origBlocks[m_iStartBlock + i];
 
 				var refBlock = CorrelatedBlocks[i].ReferenceBlocks.Single();
-				vernBlock.SetMatchedReferenceBlock(refBlock);
+				vernBlock.SetMatchedReferenceBlock(refBlock.Clone(Block.ReferenceBlockCloningBehavior.CloneListAndAllReferenceBlocks));
 				var basedOnBlock = CorrelatedBlocks[i].CharacterIsUnclear ? refBlock : CorrelatedBlocks[i];
 				vernBlock.SetCharacterAndDeliveryInfo(basedOnBlock, bookNum, m_versification);
 				if (vernBlock.CharacterIsStandard)


### PR DESCRIPTION
(We allow unmatched blocks to be cross-linked because they are always volatile and never live beyond a matchup, export, etc. But matched blocks are held onto for the life of the owning BookScript, so any subsequent change to a reference text block could potentially change the reference block held as the matched reference block of a vernacular block.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/635)
<!-- Reviewable:end -->
