### PR TITLE
Engine-related cleanup and tightening of interface for setting quote system

### DIFF
--- a/Glyssen/App.config
+++ b/Glyssen/App.config
@@ -109,9 +109,6 @@
   </runtime>
     <applicationSettings>
         <Glyssen.Properties.Settings>
-            <setting name="ParserVersion" serializeAs="String">
-                <value>49</value>
-            </setting>
             <setting name="TargetPercentageOfQuotesFound" serializeAs="String">
                 <value>95</value>
             </setting>

--- a/Glyssen/Dialogs/QuotationMarksDlg.cs
+++ b/Glyssen/Dialogs/QuotationMarksDlg.cs
@@ -365,9 +365,8 @@ namespace Glyssen.Dialogs
 			{
 				if ((m_project.QuoteSystemStatus & QuoteSystemStatus.NotParseReady) > 0)
 				{
-					m_project.QuoteSystemStatus = QuoteSystemStatus.Reviewed;
-					// Kicks off the quote parse (which we haven't run yet)
-					m_project.QuoteSystem = currentQuoteSystem;
+					// This kicks off the quote parse (which we haven't run yet)
+					m_project.SetQuoteSystem(QuoteSystemStatus.Reviewed, currentQuoteSystem);
 				}
 				else
 					HandleAnalysisCompleted(this, null);
@@ -431,9 +430,7 @@ namespace Glyssen.Dialogs
 				});
 
 			// Want to set the status even if already UserSet because that triggers setting QuoteSystemDate
-			m_project.QuoteSystemStatus = QuoteSystemStatus.UserSet;
-
-			m_project.QuoteSystem = currentQuoteSystem;
+			m_project.SetQuoteSystem(QuoteSystemStatus.UserSet, currentQuoteSystem);
 			// After setting this, the user could get a subsequent dialog box giving them the chance to review the settings,
 			// but since we've already saved their changes, they can't really "Cancel" those saved changes anymore.
 			m_btnCancel.DialogResult = DialogResult.OK;

--- a/Glyssen/Properties/Settings.Designer.cs
+++ b/Glyssen/Properties/Settings.Designer.cs
@@ -71,15 +71,6 @@ namespace Glyssen.Properties {
             }
         }
         
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("49")]
-        public int ParserVersion {
-            get {
-                return ((int)(this["ParserVersion"]));
-            }
-        }
-        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]

--- a/Glyssen/Properties/Settings.settings
+++ b/Glyssen/Properties/Settings.settings
@@ -14,9 +14,6 @@
     <Setting Name="DefaultExportDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="ParserVersion" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">49</Value>
-    </Setting>
     <Setting Name="DefaultSfmDirectory" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/GlyssenEngine/Bundle/GlyssenDblTextMetadata.cs
+++ b/GlyssenEngine/Bundle/GlyssenDblTextMetadata.cs
@@ -273,7 +273,7 @@ namespace GlyssenEngine.Bundle
 		[DefaultValue(QuoteSystemStatus.Unknown)]
 		public QuoteSystemStatus QuoteSystemStatus
 		{
-			get { return m_quoteSystemStatus; }
+			get => m_quoteSystemStatus;
 			set
 			{
 				if (m_quoteSystemStatus == value)

--- a/GlyssenEngineTests/Bundle/GlyssenBundleTests.cs
+++ b/GlyssenEngineTests/Bundle/GlyssenBundleTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using GlyssenEngine;
 using GlyssenEngine.Bundle;
 using SIL.DblBundle.Tests.Text;
 using SIL.IO;
@@ -9,6 +10,13 @@ namespace GlyssenEngineTests.Bundle
 	internal static class GlyssenBundleTests
 	{
 		public const string kTestBundleIdPrefix = "test~~ProjectTests";
+
+		static GlyssenBundleTests()
+		{
+			if (Project.FontRepository == null)
+				Project.FontRepository = new TestProject.TestFontRepository();
+		}
+
 		private static string GetUniqueBundleId()
 		{
 			return kTestBundleIdPrefix + Path.GetFileNameWithoutExtension(Path.GetTempFileName());


### PR DESCRIPTION
Removed ParserVersion from settings (previously turned into a constant)
Replaced two quote system-related setters in Project with a method that ensures they are called int he required order (made setters private)
Added call to ensure FontRepository implementation is set for all unit tests that need it.
Fixed logic error whereby QuoteSystemDate was not getting updated if the user changed the quote system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/636)
<!-- Reviewable:end -->
