### PR TITLE
PG-1336: Prevent creation of matchup that splits between two blocks that end/start with same verse

### DIFF
--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -13,17 +13,13 @@ namespace GlyssenEngine.Script
 	public class BlockMatchup
 	{
 		private readonly BookScript m_vernacularBook;
-		private readonly int m_iStartBlock;
 		private readonly PortionScript m_portion;
-		private int m_numberOfBlocksAddedBySplitting = 0;
 		private readonly IReferenceLanguageInfo m_referenceLanguageInfo;
-		private ScrVers m_versification;
 
 		public BlockMatchup(BookScript vernacularBook, int iBlock, Action<PortionScript> splitBlocks,
 			Func<Block, bool> isOkayToBreakBeforeBlock, IReferenceLanguageInfo heSaidProvider, uint predeterminedBlockCount = 0)
 		{
 			m_vernacularBook = vernacularBook;
-			int bookNum = m_vernacularBook.BookNumber;
 			m_referenceLanguageInfo = heSaidProvider;
 			var blocks = m_vernacularBook.GetScriptBlocks();
 			var originalAnchorBlock = blocks[iBlock];
@@ -40,9 +36,9 @@ namespace GlyssenEngine.Script
 					blocksForVersesCoveredByBlock = new List<Block> {originalAnchorBlock};
 					indexOfAnchorBlockInVerse = 0;
 				}
-				m_iStartBlock = iBlock - indexOfAnchorBlockInVerse;
+				IndexOfStartBlockInBook = iBlock - indexOfAnchorBlockInVerse;
 				var firstIncludedScriptureBlock = blocksForVersesCoveredByBlock.First();
-				while (m_iStartBlock > 0)
+				while (IndexOfStartBlockInBook > 0)
 				{
 					if (firstIncludedScriptureBlock.InitialStartVerseNumber < originalAnchorBlock.InitialStartVerseNumber &&
 						!firstIncludedScriptureBlock.IsVerseBreak)
@@ -52,24 +48,29 @@ namespace GlyssenEngine.Script
 						if (prepend.Count > 1)
 						{
 							prepend.RemoveAt(prepend.Count - 1);
-							m_iStartBlock -= prepend.Count;
+							IndexOfStartBlockInBook -= prepend.Count;
 							blocksForVersesCoveredByBlock.InsertRange(0, prepend);
 							firstIncludedScriptureBlock = blocksForVersesCoveredByBlock.First();
 						}
 					}
 					// PG-1297: In the unusual case where our "anchor" verse is verse 0, we definitely don't want to include earlier verses (from previous chapter).
-					if (m_iStartBlock == 0 || isOkayToBreakBeforeBlock(firstIncludedScriptureBlock) || firstIncludedScriptureBlock.InitialStartVerseNumber == 0)
+					// PG-1336: In the unusual case where a verse number is repeated (e.g., broken into two segments or used as the last number in one bridge and
+					// the first number in the next bridge), we can't split between those two blocks - we need to keep looking backward.
+					if (IndexOfStartBlockInBook == 0 ||
+						(isOkayToBreakBeforeBlock(firstIncludedScriptureBlock) &&
+							firstIncludedScriptureBlock.InitialStartVerseNumber != blocks[IndexOfStartBlockInBook - 1].LastVerseNum) ||
+						firstIncludedScriptureBlock.InitialStartVerseNumber == 0)
 					{
 						break;
 					}
 
-					m_iStartBlock--;
-					var blockToInsert = blocks[m_iStartBlock];
+					IndexOfStartBlockInBook--;
+					var blockToInsert = blocks[IndexOfStartBlockInBook];
 					if (blockToInsert.IsScripture)
 						firstIncludedScriptureBlock = blockToInsert;
 					blocksForVersesCoveredByBlock.Insert(0, blockToInsert);
 				}
-				int iLastBlock = m_iStartBlock + blocksForVersesCoveredByBlock.Count - 1;
+				int iLastBlock = IndexOfStartBlockInBook + blocksForVersesCoveredByBlock.Count - 1;
 				int i = iLastBlock;
 				AdvanceToCleanVerseBreak(blocks, isOkayToBreakBeforeBlock, ref i);
 				if (i > iLastBlock)
@@ -84,12 +85,12 @@ namespace GlyssenEngine.Script
 
 				try
 				{
-					CorrelatedAnchorBlock = m_portion.GetScriptBlocks()[iBlock - m_iStartBlock];
+					CorrelatedAnchorBlock = m_portion.GetScriptBlocks()[iBlock - IndexOfStartBlockInBook];
 				}
 				catch (Exception ex)
 				{
 					Logger.WriteEvent(ex.Message);
-					Logger.WriteEvent($"iBlock = {iBlock}; m_iStartBlock = {m_iStartBlock}");
+					Logger.WriteEvent($"iBlock = {iBlock}; m_iStartBlock = {IndexOfStartBlockInBook}");
 					foreach (var block in m_portion.GetScriptBlocks())
 						Logger.WriteEvent($"block = {block}");
 					throw;
@@ -97,7 +98,7 @@ namespace GlyssenEngine.Script
 			}
 			else
 			{
-				m_iStartBlock = iBlock;
+				IndexOfStartBlockInBook = iBlock;
 				m_portion = new PortionScript(vernacularBook, vernacularBook.GetScriptBlocks().Skip(iBlock).Take((int)predeterminedBlockCount).Select(b => b.Clone()));
 				CorrelatedAnchorBlock = m_portion.GetScriptBlocks().First();
 			}
@@ -106,17 +107,17 @@ namespace GlyssenEngine.Script
 			{
 				int origCount = m_portion.GetScriptBlocks().Count;
 				splitBlocks(m_portion);
-				m_numberOfBlocksAddedBySplitting = m_portion.GetScriptBlocks().Count - origCount;
+				CountOfBlocksAddedBySplitting = m_portion.GetScriptBlocks().Count - origCount;
 			}
 		}
 
-		public int OriginalBlockCount => CorrelatedBlocks.Count - m_numberOfBlocksAddedBySplitting;
+		public int OriginalBlockCount => CorrelatedBlocks.Count - CountOfBlocksAddedBySplitting;
 
 		public string BookId => m_vernacularBook.BookId;
 
-		public IEnumerable<Block> OriginalBlocks => m_vernacularBook.GetScriptBlocks().Skip(m_iStartBlock).Take(OriginalBlockCount);
+		public IEnumerable<Block> OriginalBlocks => m_vernacularBook.GetScriptBlocks().Skip(IndexOfStartBlockInBook).Take(OriginalBlockCount);
 
-		public int CountOfBlocksAddedBySplitting => m_numberOfBlocksAddedBySplitting;
+		public int CountOfBlocksAddedBySplitting { get; private set; } = 0;
 
 		public IReadOnlyList<Block> CorrelatedBlocks => m_portion.GetScriptBlocks();
 
@@ -124,7 +125,7 @@ namespace GlyssenEngine.Script
 		{
 			get
 			{
-				if (m_numberOfBlocksAddedBySplitting > 0)
+				if (CountOfBlocksAddedBySplitting > 0)
 					return true;
 				int i = 0;
 				foreach (var realBlock in OriginalBlocks)
@@ -144,10 +145,7 @@ namespace GlyssenEngine.Script
 
 		public bool AllScriptureBlocksMatch => CorrelatedBlocks.All(b => b.MatchesReferenceText);
 
-		public int IndexOfStartBlockInBook
-		{
-			get { return m_iStartBlock; }
-		}
+		public int IndexOfStartBlockInBook { get; }
 
 		public Block CorrelatedAnchorBlock { get; private set; }
 
@@ -180,32 +178,25 @@ namespace GlyssenEngine.Script
 			}
 		}
 
-		public void Apply(ScrVers versification = null)
+		public void Apply()
 		{
 			if (!AllScriptureBlocksMatch)
 				throw new InvalidOperationException("Cannot apply reference blocks unless all Scripture blocks have corresponding reference blocks.");
 
-			if (versification != null)
+			if (CountOfBlocksAddedBySplitting > 0)
 			{
-				if (m_versification != null && m_versification != versification)
-					throw new ArgumentException("Apply called with unexpected versification!", nameof(versification));
-				m_versification = versification;
-			}
-
-			if (m_numberOfBlocksAddedBySplitting > 0)
-			{
-				m_vernacularBook.ReplaceBlocks(m_iStartBlock, OriginalBlockCount, CorrelatedBlocks.Select(b => b.Clone()).ToList());
+				m_vernacularBook.ReplaceBlocks(IndexOfStartBlockInBook, OriginalBlockCount, CorrelatedBlocks.Select(b => b.Clone()).ToList());
 			}
 			int bookNum = BCVRef.BookToNumber(BookId);
 			var origBlocks = m_vernacularBook.GetScriptBlocks();
 			for (int i = 0; i < CorrelatedBlocks.Count; i++)
 			{
-				var vernBlock = origBlocks[m_iStartBlock + i];
+				var vernBlock = origBlocks[IndexOfStartBlockInBook + i];
 
 				var refBlock = CorrelatedBlocks[i].ReferenceBlocks.Single();
 				vernBlock.SetMatchedReferenceBlock(refBlock.Clone(Block.ReferenceBlockCloningBehavior.CloneListAndAllReferenceBlocks));
 				var basedOnBlock = CorrelatedBlocks[i].CharacterIsUnclear ? refBlock : CorrelatedBlocks[i];
-				vernBlock.SetCharacterAndDeliveryInfo(basedOnBlock, bookNum, m_versification);
+				vernBlock.SetCharacterAndDeliveryInfo(basedOnBlock, bookNum, m_vernacularBook.Versification);
 				if (vernBlock.CharacterIsStandard)
 					vernBlock.MultiBlockQuote = MultiBlockQuote.None;
 
@@ -218,12 +209,12 @@ namespace GlyssenEngine.Script
 			}
 			// No need to update following continuation blocks here if m_numberOfBlocksAddedBySplitting > 0 because the call to
 			// ReplaceBlocks (above) already did it.
-			if (m_numberOfBlocksAddedBySplitting == 0)
-				m_vernacularBook.UpdateFollowingContinuationBlocks(m_iStartBlock + OriginalBlockCount - 1);
+			if (CountOfBlocksAddedBySplitting == 0)
+				m_vernacularBook.UpdateFollowingContinuationBlocks(IndexOfStartBlockInBook + OriginalBlockCount - 1);
 			else
-				m_numberOfBlocksAddedBySplitting = 0;
+				CountOfBlocksAddedBySplitting = 0;
 
-			for (int i = m_iStartBlock; i < m_iStartBlock + CorrelatedBlocks.Count; i++)
+			for (int i = IndexOfStartBlockInBook; i < IndexOfStartBlockInBook + CorrelatedBlocks.Count; i++)
 			{
 				if (origBlocks[i].MultiBlockQuote == MultiBlockQuote.Start)
 				{
@@ -296,7 +287,9 @@ namespace GlyssenEngine.Script
 				var nextBlock = blockList[i + 1];
 				if (nextBlock.IsScripture) // If it's not Scripture, we take a wait-and-see approach. Add it on for now, but the loop below might strip it off.
 				{
-					if (nextBlock.StartsAtVerseStart && isOkayToBreakBeforeBlock(nextBlock))
+					// PG-1336: Because of verse segments (and the possibility of an errant repeated verse), if the next block starts with a verse that
+					// continues the verse from the previous block, it is not a valid clean break location.
+					if (nextBlock.StartsAtVerseStart && nextBlock.InitialStartVerseNumber != blockList[i].LastVerseNum && isOkayToBreakBeforeBlock(nextBlock))
 						break;
 				}
 				i++;
@@ -318,9 +311,9 @@ namespace GlyssenEngine.Script
 			return OriginalBlocks.Contains(block) || CorrelatedBlocks.Contains(block);
 		}
 
-		public void MatchAllBlocks(ScrVers versification)
+		public void MatchAllBlocks()
 		{
-			m_versification = versification;
+			var versification = m_vernacularBook.Versification;
 			int bookNum = BCVRef.BookToNumber(BookId);
 			Block prevBlock = null;
 			foreach (var block in CorrelatedBlocks)
@@ -341,7 +334,7 @@ namespace GlyssenEngine.Script
 				{
 					block.SetMatchedReferenceBlock(bookNum, versification, m_referenceLanguageInfo);
 					if (block.CharacterIsUnclear)
-						block.SetCharacterAndDeliveryInfo(block.ReferenceBlocks.Single(), bookNum, m_versification);
+						block.SetCharacterAndDeliveryInfo(block.ReferenceBlocks.Single(), bookNum, versification);
 				}
 
 				if (block.CharacterIsStandard && block.MultiBlockQuote != MultiBlockQuote.None)

--- a/GlyssenEngine/Script/BookScript.cs
+++ b/GlyssenEngine/Script/BookScript.cs
@@ -653,7 +653,7 @@ namespace GlyssenEngine.Script
 						targetBlock.UserConfirmed = sourceBlock.UserConfirmed;
 					}
 				}
-				targetMatchup.Apply(Versification);
+				targetMatchup.Apply();
 			}
 		}
 

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -830,7 +830,7 @@ namespace GlyssenEngine.ViewModels
 				currentIndices.BlockIndex, currentIndices.MultiBlockCount);
 			if (m_currentRefBlockMatchups != null)
 			{
-				m_currentRefBlockMatchups.MatchAllBlocks(m_project.Versification);
+				m_currentRefBlockMatchups.MatchAllBlocks();
 				// We might have gotten here by ad-hoc navigation (clicking or using the Verse Reference control). Since we are in "rainbow mode"
 				// the filter holds *groups* of relevant blocks (rather than individual ones), so if the new current matchup corresponds to one
 				// of those groups (i.e., it is relevant), we need to set indices based on the group rather than the individual block. Otherwise,
@@ -883,7 +883,7 @@ namespace GlyssenEngine.ViewModels
 			var insertions = m_currentRefBlockMatchups.CountOfBlocksAddedBySplitting;
 			var insertionIndex = m_currentRelevantIndex;
 
-			m_currentRefBlockMatchups.Apply(m_project.Versification);
+			m_currentRefBlockMatchups.Apply();
 			if (insertionIndex < 0)
 			{
 				var indicesOfFirstBlock = BlockAccessor.GetIndicesOfSpecificBlock(m_currentRefBlockMatchups.OriginalBlocks.First());

--- a/GlyssenEngineTests/Bundle/GlyssenBundleTests.cs
+++ b/GlyssenEngineTests/Bundle/GlyssenBundleTests.cs
@@ -14,9 +14,9 @@ namespace GlyssenEngineTests.Bundle
 
 		static GlyssenBundleTests()
 		{
+			GlyssenInfo.Product = "GlyssenTests";
 			if (Project.FontRepository == null)
 				Project.FontRepository = new TestProject.TestFontRepository();
-			GlyssenInfo.Product = "GlyssenTests";
 		}
 
 		private static string GetUniqueBundleId()

--- a/GlyssenEngineTests/ProjectTests.cs
+++ b/GlyssenEngineTests/ProjectTests.cs
@@ -308,7 +308,7 @@ namespace GlyssenEngineTests
 				if (!CharacterDetailData.Singleton.GetDictionary().ContainsKey(character))
 					testProject.AddProjectCharacterDetail(new CharacterDetail { CharacterId = character, Age = CharacterAge.Elder, Gender = CharacterGender.Male });
 
-				matchup.Apply(testProject.Versification);
+				matchup.Apply();
 
 				var newQuoteSystem = new QuoteSystem(testProject.QuoteSystem);
 				newQuoteSystem.AllLevels.Add(new QuotationMark("=+", "#$", "^&", newQuoteSystem.FirstLevel.Level, QuotationMarkingSystemType.Narrative));
@@ -425,7 +425,7 @@ namespace GlyssenEngineTests
 				if (!CharacterDetailData.Singleton.GetDictionary().ContainsKey(character))
 					testProject.AddProjectCharacterDetail(new CharacterDetail { CharacterId = character, Age = CharacterAge.Elder, Gender = CharacterGender.Male });
 
-				matchup.Apply(testProject.Versification);
+				matchup.Apply();
 
 				bool complete = false;
 
@@ -481,7 +481,7 @@ namespace GlyssenEngineTests
 				if (!CharacterDetailData.Singleton.GetDictionary().ContainsKey(character))
 					testProject.AddProjectCharacterDetail(new CharacterDetail { CharacterId = character, Age = CharacterAge.Elder, Gender = CharacterGender.Male });
 
-				matchup.Apply(testProject.Versification);
+				matchup.Apply();
 
 				bool complete = false;
 
@@ -1117,7 +1117,7 @@ namespace GlyssenEngineTests
 			var matchup = testProject.ReferenceText.GetBlocksForVerseMatchedToReferenceText(mark, mark8V5);
 			Assert.AreEqual(4, matchup.CorrelatedBlocks.Count);
 			Assert.IsTrue(matchup.CorrelatedBlocks.All(b => b.ReferenceBlocks.Count == 1));
-			matchup.MatchAllBlocks(null);
+			matchup.MatchAllBlocks();
 			matchup.Apply();
 			var matchedVernBlocks = blocks.Skip(mark8V5).Take(4).ToList();
 			Assert.IsTrue(matchedVernBlocks.All(b => b.MatchesReferenceText));
@@ -1135,7 +1135,7 @@ namespace GlyssenEngineTests
 			var expectedEnglishRefTextForMark9V9 = englishRefBlocks[mark9V9EnglishRefText].GetText(true) + " " +
 				englishRefBlocks[mark9V9EnglishRefText + 1].GetText(true);
 			Assert.AreEqual(expectedEnglishRefTextForMark9V9, matchup.CorrelatedBlocks[0].GetPrimaryReferenceText());
-			matchup.MatchAllBlocks(null);
+			matchup.MatchAllBlocks();
 			matchup.Apply();
 			matchedVernBlocks = blocks.Skip(mark9V9).Take(3).ToList();
 			Assert.IsTrue(matchedVernBlocks.All(b => b.MatchesReferenceText));
@@ -1197,7 +1197,7 @@ namespace GlyssenEngineTests
 			matchup.SetReferenceText(3, "This is not going to match the corresponding English text in the French test reference text.");
 			matchup.SetReferenceText(4, englishTextOfLastNarrtorBlock.Substring(iQuoteMark));
 			matchup.CorrelatedBlocks.Last().SetNonDramaticCharacterId(mark.NarratorCharacterId);
-			matchup.MatchAllBlocks(null);
+			matchup.MatchAllBlocks();
 			matchup.Apply();
 			var matchedVernBlocks = blocks.Skip(mark5V41).Take(4).ToList();
 			Assert.IsTrue(matchedVernBlocks.All(b => b.MatchesReferenceText));

--- a/GlyssenEngineTests/Script/BlockMatchupTests.cs
+++ b/GlyssenEngineTests/Script/BlockMatchupTests.cs
@@ -137,7 +137,7 @@ namespace GlyssenEngineTests.Script
 			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(9, "Habiendo resucitado Jesús, apareció a María Magdalena. ")
 				.AddVerse($"10-{leadingVerseBridgeEnd}", "Ella lo hizo saber a los demas, pero no le creian. "));
 			vernacularBlocks.Add(new Block("p", 1, 11, 12) { ChapterNumber = 1, CharacterId = vernacularBlocks.Last().CharacterId,
-				BlockElements = new List<BlockElement>() {new Verse(trailingVerseBridgeStart), new ScriptText("Ellas dieron las instrucciones a los hombres.") }}
+				BlockElements = new List<BlockElement> {new Verse($"{trailingVerseBridgeStart}-12"), new ScriptText("Ellas dieron las instrucciones a los hombres.") }}
 				.AddVerse(13, "Y después, Jesús envió por medio de ellos el mensaje de salvación."));
 			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
 			var matchup = new BlockMatchup(vernBook, iBlock, null, i => true, null);

--- a/GlyssenEngineTests/Script/BookScriptTests.cs
+++ b/GlyssenEngineTests/Script/BookScriptTests.cs
@@ -2341,7 +2341,7 @@ namespace GlyssenEngineTests.Script
 		/// <param name="matchup"></param>
 		private static void MatchUpBlocksAndApplyToSource(BlockMatchup matchup)
 		{
-			matchup.MatchAllBlocks(ScrVers.English);
+			matchup.MatchAllBlocks();
 			var narrator = CharacterVerseData.GetStandardCharacterId(matchup.BookId, CharacterVerseData.StandardCharacter.Narrator);
 			foreach (var block in matchup.CorrelatedBlocks.Where(b => b.CharacterIsUnclear ||
 				(b.MultiBlockQuote != MultiBlockQuote.None && b.CharacterIsStandard)))

--- a/GlyssenEngineTests/TestProject.cs
+++ b/GlyssenEngineTests/TestProject.cs
@@ -46,8 +46,8 @@ namespace GlyssenEngineTests
 
 		static TestProject()
 		{
-			Project.FontRepository = new TestFontRepository();
 			GlyssenInfo.Product = "GlyssenTests";
+			Project.FontRepository = new TestFontRepository();
 		}
 
 		private static Exception m_errorDuringProjectCreation;

--- a/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
@@ -1184,7 +1184,7 @@ namespace GlyssenEngineTests.ViewModelTests
 
 			var matchup = m_model.CurrentReferenceTextMatchup;
 			Assert.IsNotNull(matchup);
-			matchup.MatchAllBlocks(m_testProject.Versification);
+			matchup.MatchAllBlocks();
 
 			m_model.ApplyCurrentReferenceTextMatchup();
 
@@ -1258,7 +1258,7 @@ namespace GlyssenEngineTests.ViewModelTests
 			var matchup = m_model.CurrentReferenceTextMatchup;
 
 			Assert.IsTrue(m_model.CurrentDisplayIndex >= m_model.RelevantBlockCount);
-			matchup.MatchAllBlocks(m_testProject.Versification);
+			matchup.MatchAllBlocks();
 			foreach (var block in matchup.CorrelatedBlocks.Where(b => b.CharacterIsUnclear))
 				block.SetCharacterIdAndCharacterIdInScript("Paul", m_model.CurrentBookNumber, m_testProject.Versification);
 			Assert.IsTrue(matchup.HasOutstandingChangesToApply);
@@ -1322,7 +1322,7 @@ namespace GlyssenEngineTests.ViewModelTests
 			Assert.IsFalse(model.IsCurrentLocationRelevant);
 			var matchup = model.CurrentReferenceTextMatchup;
 			Assert.IsNotNull(matchup);
-			matchup.MatchAllBlocks(m_testProject.Versification);
+			matchup.MatchAllBlocks();
 
 			model.ApplyCurrentReferenceTextMatchup();
 


### PR DESCRIPTION
This deals with the In the unusual case where a verse number is repeated in two adjacent blocks.

Simplified a couple BlockMatchup methods that were taking Versification. (We can get that from the book now.)
Fixed problem in unit tests where we were getting a data migration warning because we were accessing Project class before setting GlyssenInfo.Product to the test folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/650)
<!-- Reviewable:end -->
