### PR TITLE
Reworked plumbing in GenerateCharacterGroups_IsCancelable

### DIFF
--- a/GlyssenSharedTests/packages.config
+++ b/GlyssenSharedTests/packages.config
@@ -7,12 +7,12 @@
   <package id="Mono.Posix" version="5.4.0.201" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net461" />
-  <package id="NUnit.Console" version="3.10.0" targetFramework="net461" />
-  <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net461" />
+  <package id="NUnit.Console" version="3.11.1" targetFramework="net472" />
+  <package id="NUnit.ConsoleRunner" version="3.11.1" targetFramework="net472" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.8.0" targetFramework="net472" />
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
-  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.6" targetFramework="net461" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net461" />
   <package id="SIL.Core" version="8.0.0-beta0071" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />

--- a/build/TestBuild.bat
+++ b/build/TestBuild.bat
@@ -1,0 +1,12 @@
+@echo This will only work if the correct version of MSBuild is on the PATH.
+@echo The easiest way to ensure this is to run from the Developer Command Prompt for VS.
+@echo The following line might work from a regular command prompt if this batch file exists,
+@echo but more than likely it will set the path such that the wrong version of MSBuild is first:
+@echo //call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"
+
+pushd .
+MSbuild /target:Test /property:Configuration="Release" /property:Platform=x64 /property:ExtraExcludeCategories="SkipOnTeamCity"
+popd
+PAUSE
+
+#/verbosity:detailed


### PR DESCRIPTION
This should ensure that worker thread finishes before checking results and ending the test, preventing this test from affecting another case in the same fixture.
Also Upgraded GlyssenSharedTests to latest version of NUnit 3.

(Note: I had previously added this attribute to the one test that had begun failing on TeamCity, but I couldn't find any reason why any of these tests could safely be run in parallel, so I wanted to apply that decision to all of them and document why.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/652)
<!-- Reviewable:end -->
