### PR TITLE
PG-1343: When splitting a block, ensure that all relevant characters are included

### DIFF
--- a/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
+++ b/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
@@ -239,6 +239,12 @@ namespace GlyssenEngine.ViewModels
 			return GetUniqueCharacters(expandIfNone);
 		}
 
+		public IEnumerable<Character> GetUniqueCharactersForBlock(Block block, bool expandIfNone = true)
+		{
+			m_currentCharacters = new HashSet<ICharacterDeliveryInfo>(GetUniqueCharacterVerseObjectsForBlock(block));
+			return GetUniqueCharacters(expandIfNone);
+		}
+
 		private IEnumerable<Character> GetUniqueCharacters(bool expandIfNone = true)
 		{
 			var listToReturn = new List<Character>(new SortedSet<Character>(

--- a/GlyssenEngine/ViewModels/SplitBlockViewModel.cs
+++ b/GlyssenEngine/ViewModels/SplitBlockViewModel.cs
@@ -32,7 +32,7 @@ namespace GlyssenEngine.ViewModels
 
 		public SplitBlockViewModel(AssignCharacterViewModel<TFont> assignCharacterViewModel, Block blockToSplit) :
 			this(assignCharacterViewModel.FontInfo, assignCharacterViewModel.GetAllBlocksWhichContinueTheQuoteStartedByBlock(blockToSplit),
-				assignCharacterViewModel.GetUniqueCharactersForCurrentReference(), assignCharacterViewModel.CurrentBookId)
+				assignCharacterViewModel.GetUniqueCharactersForBlock(blockToSplit), assignCharacterViewModel.CurrentBookId)
 		{
 		}
 


### PR DESCRIPTION
In rainbow mode, we were only getting the characters for the piece of the block that corresponded to the current matchup block (which is often only part of the corresponding original block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/655)
<!-- Reviewable:end -->
