### PR TITLE
Instead of having errors in versification files ignored, alert the user

### DIFF
--- a/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
+++ b/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
@@ -97,10 +97,10 @@
       <HintPath>..\packages\ParatextData.9.1.1-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.WritingSystems.8.0.0-beta0077\lib\net461\SIL.WritingSystems.dll</HintPath>

--- a/ControlDataIntegrityTests/packages.config
+++ b/ControlDataIntegrityTests/packages.config
@@ -21,8 +21,8 @@
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net461" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />
   <package id="System.CodeDom" version="4.7.0" targetFramework="net472" />

--- a/DevTools/DevTools.csproj
+++ b/DevTools/DevTools.csproj
@@ -93,13 +93,13 @@
       <HintPath>..\packages\ParatextData.9.1.1-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.DblBundle, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.DblBundle.8.0.0-beta0037\lib\net461\SIL.DblBundle.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.WritingSystems.8.0.0-beta0077\lib\net461\SIL.WritingSystems.dll</HintPath>

--- a/DevTools/packages.config
+++ b/DevTools/packages.config
@@ -14,9 +14,9 @@
   <package id="Microsoft.Windows.Compatibility" version="3.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />
   <package id="System.CodeDom" version="4.7.0" targetFramework="net472" />

--- a/DistFiles/localization/Glyssen.es.tmx
+++ b/DistFiles/localization/Glyssen.es.tmx
@@ -11836,6 +11836,15 @@
         <seg>No se pudo crear el sistema de escritura basado en archivo LDML para el proyecto {0} {1}.</seg>
       </tuv>
     </tu>
+    <tu tuid="Project.FallingBackToDefaultEnglishVersification">
+      <note>Param: “English” (versification name)</note>
+      <tuv xml:lang="en">
+        <seg>Therefore, the {0} versification is being used by default. If this is not the correct versification for this project, some things will not work as expected.</seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>Así que la versificación {0} se usará por defecto. Si ésta no es la correcta versificación para este proyecto, se esperan algunos problemas.</seg>
+      </tuv>
+    </tu>
     <tu tuid="Project.IgnoreToRepairLdmlFile">
       <note>Param 0: "Ignore" button label; Param 1: Product name (e.g., "Glyssen")</note>
       <tuv xml:lang="en">
@@ -11949,13 +11958,22 @@
         <seg>Para actualizar el proyecto {0}, el proyecto {2} debe estar disponible en {1}, pero no lo está.</seg>
       </tuv>
     </tu>
-    <tu tuid="Project.ParatextProjectMissingNoFallbackVersificationFile">
-      <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: Glyssen recording project name; Param 3: “English” (versification mame)</note>
+    <tu tuid="Project.ParatextProjectFallbackVersificationInvalid">
+      <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: Glyssen recording project name; Param 3: Error details</note>
       <tuv xml:lang="en">
-        <seg>{0} project {1} is not available and project {2} does not have a fallback versification file; therefore, the {3} versification is being used by default. If this is not the correct versification for this project, some things will not work as expected.</seg>
+        <seg>{0} project {1} is not available and the fallback versification in project {2} is invalid:\n {3}\n</seg>
       </tuv>
       <tuv xml:lang="es">
-        <seg>El proyecto {0} {1} no está disponible y el proyecto {2} no tiene un archivo de versificación de respaldo. Así que la versificación {3} se usará por defecto. Si ésta no es la correcta versificación para este proyecto, se esperan algunos problemas.</seg>
+        <seg>El proyecto {0} {1} no está disponible y el archivo de versificación de respaldo en el proyecto {2} es inválido:\n {3}\n</seg>
+      </tuv>
+    </tu>
+    <tu tuid="Project.ParatextProjectNoFallbackVersification">
+      <note>Param 0: "Paratext" (product name); Param 1: Paratext project short name (unique project identifier); Param 2: Glyssen recording project name</note>
+      <tuv xml:lang="en">
+        <seg>{0} project {1} is not available and project {2} does not have a fallback versification file. </seg>
+      </tuv>
+      <tuv xml:lang="es">
+        <seg>El proyecto {0} {1} no está disponible y el proyecto {2} no tiene un archivo de versificación de respaldo. </seg>
       </tuv>
     </tu>
     <tu tuid="Project.ParatextProjectNotFound">

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -173,7 +173,7 @@
       <HintPath>..\packages\ParatextData.9.1.1-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core.Desktop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.Desktop.8.0.0-beta0077\lib\net461\SIL.Core.Desktop.dll</HintPath>
@@ -182,7 +182,7 @@
       <HintPath>..\packages\SIL.DblBundle.8.0.0-beta0037\lib\net461\SIL.DblBundle.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Windows.Forms.8.0.0-beta0077\lib\net461\SIL.Windows.Forms.dll</HintPath>
@@ -574,6 +574,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\ProgressUtilsImpl.cs" />
     <Compile Include="Utilities\VerseRefExtensions.cs" />
     <Compile Include="Utilities\WinFormsErrorAnalytics.cs" />
     <Compile Include="Utilities\WinFormsFontRepositoryAdapter.cs" />

--- a/Glyssen/Program.cs
+++ b/Glyssen/Program.cs
@@ -20,6 +20,7 @@ using L10NSharp.UI;
 using Paratext.Data;
 using Paratext.Data.Users;
 using PtxUtils;
+using PtxUtils.Progress;
 using SIL;
 using SIL.IO;
 using SIL.Reporting;
@@ -84,6 +85,8 @@ namespace Glyssen
 			Logger.Init();
 			Trace.Listeners.Add(new LogFileTraceListener());
 
+			GlyssenVersificationTable.Initialize();
+			ProgressUtils.Implementation = new ProgressUtilsImpl();
 			Alert.Implementation = new AlertImpl(); // Do this before calling Initialize, just in case Initialize tries to display an alert.
 			if (ParatextInfo.IsParatextInstalled)
 			{

--- a/Glyssen/Utilities/AlertImpl.cs
+++ b/Glyssen/Utilities/AlertImpl.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows.Forms;
+using GlyssenEngine.Utilities;
 using PtxUtils;
 using PtxUtils.Progress;
 using SIL.Reporting;
@@ -15,7 +17,7 @@ namespace Glyssen.Utilities
         #region Alert implementation methods
         protected override void ShowLaterInternal(string text, string caption, AlertLevel alertLevel)
         {
-            MessageBoxIcon icon = GetIconForAlertLevel(alertLevel);
+	        MessageBoxIcon icon = GetIconForAlertLevel(alertLevel);
             ProgressUtils.InvokeLaterOnUIThread(() => MessageBox.Show(text, caption, MessageBoxButtons.OK, icon));
         }
 

--- a/Glyssen/Utilities/ProgressUtilsImpl.cs
+++ b/Glyssen/Utilities/ProgressUtilsImpl.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Windows.Forms;
+using PtxUtils;
+using PtxUtils.Progress;
+using SIL.Reporting;
+
+namespace Glyssen.Utilities
+{
+    /// <summary>
+    /// Utilities for running actions in the background or with progress bar
+    /// </summary>
+    public class ProgressUtilsImpl : ProgressUtils
+    {
+        /// <summary>
+        /// Event that fires before a synchronous (InvokeOnUIThread not InvokeLaterOnUIThread) call to the UI thread occurs.
+        /// </summary>
+        public event EventHandler BeforeUIThreadSynchronization = delegate { };
+
+        /// <summary>InvokeLaterOnUIThread reentry protection</summary>
+        private bool m_runningInvokeLaterOnUIThreadAction;
+        private volatile ManualResetEvent m_executeOnSameThreadComplete = new ManualResetEvent(true);
+
+        /// <summary>
+        /// If Reentry occurs while processing a InvokeLaterOnUIThread action, then the second action gets moved
+        /// into this List. When the original action is finished then the saved actions are re-posted to the
+        /// synchronization context, and this list is cleared.
+        /// </summary>
+        private readonly List<ThreadStart> m_postponedInvokeLaterOnUIThreadActions = new List<ThreadStart>();
+
+        private readonly SynchronizationContext m_uiSynchronizationContext;
+        private readonly Thread m_uiSynchronizationThread;
+
+        /// <summary>
+        /// Stores key to EventHandler map for InvokeLaterOnIdle
+        /// </summary>
+        private readonly Dictionary<string, EventHandler> m_actionToEventHandlers = new Dictionary<string, EventHandler>();
+
+        /// <summary>
+        /// Creates a new instance. This must be created on the UI thread of the application as
+        /// soon as possible (like in the Main method before anything else is done).
+        /// </summary>
+        public ProgressUtilsImpl()
+        {
+            // Create the smallest UI item possible that will initialize the SynchronizationContext.Current.
+            // ReSharper disable once ObjectCreationAsStatement
+            new Control();
+
+            m_uiSynchronizationContext = SynchronizationContext.Current;
+            m_uiSynchronizationThread = Thread.CurrentThread;
+        }
+
+        #region Implementation of ProgressUtils
+        protected override bool OnMainUiThreadInternal
+        {
+            get
+            {
+                // True if no UI context
+                if (m_uiSynchronizationContext == null)
+                    return true;
+
+                // It's the same thread as our UI thread. (Fixes some tests that seem to change the current SynchronizationContext).
+                if (m_uiSynchronizationThread != null && m_uiSynchronizationThread.Equals(Thread.CurrentThread))
+                    return true;
+
+                // Note: Assumes that synchronization context of UI thread is only on UI thread
+                return m_uiSynchronizationContext.Equals(SynchronizationContext.Current);
+            }
+        }
+
+        protected override void InvokeOnUIThreadInternal(ThreadStart action, bool exclusively)
+        {
+            if (action == null)
+                return;
+
+            // Run directly if no UI context or if already on UI thread
+            if (OnMainUiThread)
+            {
+                action();
+                return;
+            }
+
+            Exception caughtException = null;
+            bool finished = false;
+
+            // Looping may be necessary to run exclusively
+            while (!finished)
+            {
+                BeforeUIThreadSynchronization(Thread.CurrentThread, EventArgs.Empty);
+                // Wait for the UI Thread
+                if (Progress.ExhaustiveDebugging)
+                    ErrorUtils.LogStackTrace("Invoking the UI thread");
+                m_uiSynchronizationContext.Send(delegate
+                {
+	                try
+                    {
+                        action();
+                    }
+                    catch (Exception exception)
+                    {
+                        ErrorUtils.SaveStackTrace(exception);
+                        caughtException = exception;
+                    }
+                    finally
+                    {
+                        finished = true;
+                    }
+                }, null);
+
+                // We can only get here if we are running exclusively and if ExecuteOnSameThread was running.
+                // Wait for ExecuteOnSameThread to finish
+                if (!finished)
+                    m_executeOnSameThreadComplete.WaitOne();
+            }
+
+            if (caughtException == null)
+                return;
+
+            Trace.TraceError("Original exception before being re-thrown: {0}", caughtException);
+
+            throw caughtException; // would like to wrap this in TargetInvocationException, but some code depends on getting original exception type.
+        }
+
+        protected override void InvokeLaterOnUIThreadInternal(ThreadStart action)
+        {
+            if (action == null)
+                return;
+
+            // Run directly if no UI context
+            if (m_uiSynchronizationContext == null)
+            {
+                action();
+                return;
+            }
+
+            SendOrPostCallback cb = state =>
+            {
+                if (Progress.ExhaustiveDebugging)
+                    ErrorUtils.LogStackTrace("Invoking the UI thread Later. Post-invoke.");
+
+                if (m_runningInvokeLaterOnUIThreadAction)
+                {
+                    m_postponedInvokeLaterOnUIThreadActions.Add((ThreadStart)state);
+                    return;
+                }
+
+                // If Application Message pump has quit, Ignore Later actions.
+                // Mono: mono is setting Application.MessageLoop to false when showing
+                // a modal dialog and not setting it to true when closing the dialog.
+                if (Platform.IsDotNet && !Application.MessageLoop)
+                    return;
+
+                Debug.Assert(Thread.CurrentThread == m_uiSynchronizationThread, "Invoked on wrong thread");
+
+                m_runningInvokeLaterOnUIThreadAction = true;
+                try
+                {
+                    ((ThreadStart)state)();
+                }
+                finally
+                {
+                    m_runningInvokeLaterOnUIThreadAction = false;
+                }
+
+                foreach (var postponedAction in m_postponedInvokeLaterOnUIThreadActions)
+                    InvokeLaterOnUIThread(postponedAction);
+
+                m_postponedInvokeLaterOnUIThreadActions.Clear();
+            };
+
+            if (Progress.ExhaustiveDebugging)
+                ErrorUtils.LogStackTrace("Invoking the UI thread Later. Pre-invoke.");
+
+            m_uiSynchronizationContext.Post(cb, action);
+        }
+
+        protected override void InvokeLaterOnUIThreadAllowingReEntryInternal(ThreadStart action)
+        {
+            // Run directly if no UI context
+            if (m_uiSynchronizationContext == null)
+            {
+                action();
+                return;
+            }
+
+            if (Progress.ExhaustiveDebugging)
+                ErrorUtils.LogStackTrace("Invoking the UI thread Later. Pre-invoke.");
+
+            m_uiSynchronizationContext.Post(state =>
+            {
+                Debug.Assert(Thread.CurrentThread == m_uiSynchronizationThread, "Invoked on wrong thread");
+                if (Progress.ExhaustiveDebugging)
+                    ErrorUtils.LogStackTrace("Invoking the UI thread Later. Post-invoke.");
+                action();
+            }, null);
+        }
+
+        protected override EventHandler InvokeLaterOnIdleInternal(ThreadStart action, EventHandler cancelIdleEvent)
+        {
+            return InvokeLaterOnIdleInternal(action, cancelIdleEvent, 0);
+        }
+
+        protected override EventHandler InvokeLaterOnIdleInternal(ThreadStart action, EventHandler cancelIdleEvent, int msDelay)
+        {
+            AssertOnMainUiThread();
+
+            if (cancelIdleEvent != null)
+                Application.Idle -= cancelIdleEvent;
+
+            EventHandler idleAction = null;
+            var waitUntilTime = DateTime.Now + TimeSpan.FromMilliseconds(msDelay);
+            idleAction = (s, e) =>
+            {
+                if (DateTime.Now < waitUntilTime)
+                    return;
+
+                Application.Idle -= idleAction;
+                action?.Invoke();
+            };
+
+            Application.Idle += idleAction;
+            return idleAction;
+        }
+
+        protected override void CancelInvokeLaterOnIdleInternal(EventHandler idleEvent)
+        {
+            if (idleEvent != null)
+                Application.Idle -= idleEvent;
+        }
+
+        protected override void InvokeLaterOnIdleInternal(ThreadStart action)
+        {
+            string key = action.Target.GetHashCode() + action.Method.ToString();
+
+            void NewIdleAction(object s, EventArgs e)
+            {
+	            lock (m_actionToEventHandlers)
+	            {
+		            m_actionToEventHandlers.Remove(key);
+		            Application.Idle -= NewIdleAction;
+	            }
+
+	            action();
+            }
+
+            lock (m_actionToEventHandlers)
+            {
+	            if (m_actionToEventHandlers.TryGetValue(key, out var prevIdleAction))
+                    Application.Idle -= prevIdleAction;
+                m_actionToEventHandlers[key] = NewIdleAction;
+                Application.Idle += NewIdleAction;
+            }
+        }
+
+        protected override void ExecuteInternal(string title, CancelModes cancelMode, ThreadStart action, bool topMost)
+        {
+	        Logger.WriteEvent(title);
+	        Debug.Fail("Did not expect: " + title);
+        }
+
+        /// <summary>
+        /// Execute the specified action on the UI thread (must be called from the UI thread).
+        /// </summary>
+        protected override void ExecuteOnSameThreadInternal(string title, CancelModes cancelMode, ThreadStart action)
+        {
+	        Logger.WriteEvent(title);
+	        Debug.Fail("Did not expect: " + title);
+        }
+
+        protected override BackgroundExecution CurrentExecutingBackgroundSingleAsyncInternal(BackgroundExecutionAction action)
+        {
+	        Debug.Fail("Did not expect CurrentExecutingBackgroundSingleAsyncInternal to be called");
+	        return null;
+        }
+
+        protected override void ExecuteInBackgroundSingleAsyncInternal(IComponent parentControl, string title,
+            CancelModes cancelMode, BackgroundExecutionAction action,
+            ThreadStart cancelAction, ExceptionHandlerDelegate exceptionHandler)
+        {
+	        Logger.WriteEvent(title);
+	        Debug.Fail("Did not expect: " + title);
+        }
+
+        protected override BackgroundExecution ExecuteInBackgroundInternal(IComponent parent, string title,
+            CancelModes cancelMode, Action<IProgressControl> action,
+            ThreadStart cancelAction, ExceptionHandlerDelegate exceptionHandler, ProgressBarOptions options = null)
+        {
+	        Logger.WriteEvent(title);
+	        Debug.Fail("Did not expect: " + title);
+	        return null;
+        }
+        #endregion
+    }
+}
+

--- a/Glyssen/packages.config
+++ b/Glyssen/packages.config
@@ -32,11 +32,11 @@
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="PangoSharp" version="3.22.24.37" targetFramework="net472" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Core.Desktop" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.ReleaseTasks" version="2.2.0" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Windows.Forms" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.Windows.Forms.DblBundle" version="8.0.0-beta0033" targetFramework="net472" />
   <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="8.0.0-beta0033" targetFramework="net472" />

--- a/GlyssenEngine/DataMigrator.cs
+++ b/GlyssenEngine/DataMigrator.cs
@@ -108,7 +108,7 @@ namespace GlyssenEngine
 									bundle.CopyVersificationFile(versificationPath);
 									try
 									{
-										ProjectBase.LoadVersification(versificationPath);
+										ProjectBase.LoadVersification(versificationPath, GlyssenVersificationTable.InvalidVersificationLineExceptionHandling.Throw);
 									}
 									catch (InvalidVersificationLineException ex)
 									{

--- a/GlyssenEngine/GlyssenEngine.csproj
+++ b/GlyssenEngine/GlyssenEngine.csproj
@@ -48,9 +48,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="ParatextData" Version="9.1.1-beta" />
-    <PackageReference Include="SIL.Core" Version="8.0.0-beta0077" />
+    <PackageReference Include="SIL.Core" Version="8.0.0-beta0091" />
     <PackageReference Include="SIL.DblBundle" Version="8.0.0-beta0037" />
-    <PackageReference Include="SIL.Scripture" Version="8.0.0-beta0037" />
+    <PackageReference Include="SIL.Scripture" Version="8.0.0-beta0091" />
     <PackageReference Include="SIL.WritingSystems" Version="8.0.0-beta0077" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -155,20 +155,22 @@ namespace GlyssenEngine
 			}
 			else
 			{
-				msgPart1 = Format(Localizer.GetString("Project.ParatextProjectFallbackVersificationInvalid",
-					"{0} project {1} is not available and project {2} does not have a fallback versification file",
+				msgPart1 = Format(Localizer.GetString("Project.ParatextProjectNoFallbackVersification",
+					"{0} project {1} is not available and project {2} does not have a fallback versification file. ",
 					"Param 0: \"Paratext\" (product name); " +
 					"Param 1: Paratext project short name (unique project identifier); " +
 					"Param 2: Glyssen recording project name"),
 					ParatextScrTextWrapper.kParatextProgramName,
 					ParatextProjectName,
 					Name);
+				if (!char.IsWhiteSpace(msgPart1.Last()))
+					msgPart1 += " ";
 			}
 
 			MessageModal.Show(msgPart1 + Format(Localizer.GetString("Project.FallingBackToDefaultEnglishVersification",
 				"Therefore, the {0} versification is being used by default. If this is not the correct versification " +
 				"for this project, some things will not work as expected.",
-				"Param: “English” (versification mame)"),
+				"Param: “English” (versification name)"),
 				"“English”"));
 
 			SetVersification(ScrVers.English);

--- a/GlyssenEngine/ProjectBase.cs
+++ b/GlyssenEngine/ProjectBase.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Glyssen.Shared;
 using Glyssen.Shared.Bundle;
 using GlyssenEngine.Script;
+using GlyssenEngine.Utilities;
 using SIL;
 using SIL.DblBundle;
 using SIL.Scripture;
@@ -17,8 +18,15 @@ namespace GlyssenEngine
 		public const string kShareFileExtension = ".glyssenshare";
 		public const string kFallbackVersificationPrefix = "fallback_";
 
-		public static ScrVers LoadVersification(string vrsPath)
+		static ProjectBase()
 		{
+			GlyssenVersificationTable.Initialize();
+		}
+
+		public static ScrVers LoadVersification(string vrsPath, GlyssenVersificationTable.InvalidVersificationLineExceptionHandling versificationLineExceptionHandling)
+		{
+			((GlyssenVersificationTable)SIL.Scripture.Versification.Table.Implementation).VersificationLineExceptionHandling =
+				versificationLineExceptionHandling;
 			return SIL.Scripture.Versification.Table.Implementation.Load(vrsPath, Localizer.GetString("Project.DefaultCustomVersificationName",
 				"custom", "Used as the versification name when the versification file does not contain a name."));
 		}

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -8,6 +8,7 @@ using Glyssen.Shared;
 using Glyssen.Shared.Bundle;
 using GlyssenEngine.Character;
 using GlyssenEngine.Script;
+using GlyssenEngine.Utilities;
 using SIL.Reporting;
 using SIL.Scripture;
 
@@ -115,7 +116,7 @@ namespace GlyssenEngine
 			Debug.Assert(m_referenceTextType == ReferenceTextType.Custom);
 			if (File.Exists(VersificationFilePath))
 			{
-				SetVersification(LoadVersification(VersificationFilePath));
+				SetVersification(LoadVersification(VersificationFilePath, GlyssenVersificationTable.InvalidVersificationLineExceptionHandling.Throw));
 			}
 			else
 			{

--- a/GlyssenEngine/Utilities/GlyssenVersificationTable.cs
+++ b/GlyssenEngine/Utilities/GlyssenVersificationTable.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Paratext.Data;
+using SIL.Scripture;
+using SIL;
+using static System.String;
+
+namespace GlyssenEngine.Utilities
+{
+	public class GlyssenVersificationTable : ParatextVersificationTable
+	{
+		public enum InvalidVersificationLineExceptionHandling
+		{
+			ReportIndividually,
+			BatchErrors,
+			Throw,
+		}
+
+		private InvalidVersificationLineExceptionHandling m_errorHandling = InvalidVersificationLineExceptionHandling.ReportIndividually;
+
+		private Dictionary<string, Dictionary<VersificationLoadErrorType, List<string>>> m_errors;
+
+		public InvalidVersificationLineExceptionHandling VersificationLineExceptionHandling
+		{
+			get => m_errorHandling;
+			set
+			{
+				m_errorHandling = value;
+				if (m_errorHandling == InvalidVersificationLineExceptionHandling.BatchErrors)
+				{
+					m_errors = new Dictionary<string, Dictionary<VersificationLoadErrorType, List<string>>>();
+				}
+			}
+		}
+
+		protected override bool HandleVersificationLineError(InvalidVersificationLineException ex)
+		{
+			if (VersificationLineExceptionHandling == InvalidVersificationLineExceptionHandling.BatchErrors)
+			{
+				if (!m_errors.TryGetValue(ex.FileName, out var errorList))
+					m_errors[ex.FileName] = errorList = new Dictionary<VersificationLoadErrorType, List<string>>();
+				if (!errorList.TryGetValue(ex.Type, out var errorsOfCurrentType))
+				{
+					errorList[ex.Type] = errorsOfCurrentType = new List<string>();
+				}
+				errorsOfCurrentType.Add(ex.LineText);
+				// Returning true means that we have handled the error, so it will not be thrown.
+				return true;
+			}
+
+			return VersificationLineExceptionHandling == InvalidVersificationLineExceptionHandling.ReportIndividually &&
+				base.HandleVersificationLineError(ex);
+		}
+
+		public static void Initialize()
+		{
+			if (!(Implementation is GlyssenVersificationTable))
+				Implementation = new GlyssenVersificationTable();
+		}
+
+		public string GetBatchedErrorString(string versificationKey)
+		{
+			Debug.Assert(VersificationLineExceptionHandling == InvalidVersificationLineExceptionHandling.BatchErrors);
+			if (m_errors.TryGetValue(versificationKey, out var errors))
+			{
+				var sb = new StringBuilder();
+
+				foreach (var type in errors.Keys)
+				{
+					switch (type)
+					{
+						case VersificationLoadErrorType.InvalidSyntax:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.InvalidSyntax", "Invalid syntax:"));
+							break;
+						case VersificationLoadErrorType.MissingName:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.MissingName", "Versification file must contain a name line"));
+							break;
+						case VersificationLoadErrorType.NoSegmentsDefined:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.NoSegmentsDefined", "No segments defined:"));
+							break;
+						case VersificationLoadErrorType.DuplicateExcludedVerse:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.DuplicateExcludedVerse", "Duplicate excluded verse in line:"));
+							break;
+						case VersificationLoadErrorType.DuplicateSegment:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.DuplicateSegment", "Duplicate verse segment in line:"));
+							break;
+						case VersificationLoadErrorType.InvalidManyToOneMap:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.InvalidManyToOneMap", "Must map to or from a single verse in line:"));
+							break;
+						case VersificationLoadErrorType.UnspecifiedSegmentLocation:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.UnspecifiedSegmentLocation", "Special '-' segment must be first segment in line:"));
+							break;
+						default:
+							sb.Append(Localizer.GetString("VersificationLoadErrorType.UnexpectedErrorType", "Unexpected error type:"));
+							break;
+					}
+
+					var singleError = errors[type].OnlyOrDefault();
+					if (singleError != null)
+					{
+						sb.Append(" ");
+						sb.Append(singleError);
+					}
+					else
+					{
+						foreach (var line in errors[type])
+						{
+							sb.Append(Environment.NewLine);
+							sb.Append(" -- ");
+							sb.Append(line.Truncate(50));
+						}
+					}
+
+					sb.Append(Environment.NewLine);
+				}
+
+				return sb.ToString();
+			}
+
+			return null;
+		}
+	}
+}

--- a/GlyssenEngine/Utilities/GlyssenVersificationTable.cs
+++ b/GlyssenEngine/Utilities/GlyssenVersificationTable.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using Paratext.Data;
 using SIL.Scripture;
 using SIL;
-using static System.String;
 
 namespace GlyssenEngine.Utilities
 {
@@ -53,6 +51,10 @@ namespace GlyssenEngine.Utilities
 
 			return VersificationLineExceptionHandling == InvalidVersificationLineExceptionHandling.ReportIndividually &&
 				base.HandleVersificationLineError(ex);
+		}
+
+		private  GlyssenVersificationTable()
+		{
 		}
 
 		public static void Initialize()

--- a/GlyssenEngine/Utilities/StringExtensions.cs
+++ b/GlyssenEngine/Utilities/StringExtensions.cs
@@ -63,5 +63,24 @@ namespace GlyssenEngine.Utilities
 		{
 			return Path.GetFileName(Path.GetDirectoryName(text));
 		}
+
+		public static string Truncate(this string text, int to, string ellipses = "\u2026")
+		{
+			if (text == null)
+				throw new ArgumentNullException(nameof(text));
+			if (ellipses == null)
+				throw new ArgumentNullException(nameof(ellipses));
+			if (to <= ellipses.Length)
+				throw new ArgumentOutOfRangeException(nameof(to), $"String cannot be truncated to a length less than or equal to the length of {nameof(ellipses)} ({ellipses.Length}).");
+
+			if (text.Length <= to)
+				return text;
+			var truncated = text.TrimEnd();
+			if (truncated.Length <= to)
+				return truncated;
+			if (to + ellipses.Length >= truncated.Length)
+				return truncated;
+			return truncated.Substring(0, to).TrimEnd() + ellipses;
+		}
 	}
 }

--- a/GlyssenEngine/Utilities/StringExtensions.cs
+++ b/GlyssenEngine/Utilities/StringExtensions.cs
@@ -64,6 +64,21 @@ namespace GlyssenEngine.Utilities
 			return Path.GetFileName(Path.GetDirectoryName(text));
 		}
 
+		/// <summary>
+		/// Truncates a string such that the resulting length is guaranteed to be no longer than
+		/// the specified length plus the length of the ellipses character(s). If the string ends
+		/// in whitespace and it is longer than the specified, it will first be trimmed. If it is
+		/// still longer than the specified length, it will be truncated. If truncated, it is
+		/// guaranteed that the ellipses character(s) will never be preceded by whitespace. (Thus
+		/// truncation can result in a string that is shorter than the specified length plus the
+		/// length of the ellipses characters).
+		/// </summary>
+		/// <param name="text">The string to truncate</param>
+		/// <param name="to">The position at which truncation is to occur if needed</param>
+		/// <param name="ellipses">The ellipses character (default) or other string to indicate
+		/// that the string was truncated. (The ellipses string will be applied as is, with no
+		/// trimming, so if leading or trailing whitespace is desired, it can be included.</param>
+		/// <returns>The resulting (possibly truncated and/or trimmed) text</returns>
 		public static string Truncate(this string text, int to, string ellipses = "\u2026")
 		{
 			if (text == null)

--- a/GlyssenEngine/Utilities/StringExtensions.cs
+++ b/GlyssenEngine/Utilities/StringExtensions.cs
@@ -76,8 +76,6 @@ namespace GlyssenEngine.Utilities
 			if (text.Length <= to)
 				return text;
 			var truncated = text.TrimEnd();
-			if (truncated.Length <= to)
-				return truncated;
 			if (to + ellipses.Length >= truncated.Length)
 				return truncated;
 			return truncated.Substring(0, to).TrimEnd() + ellipses;

--- a/GlyssenEngineTests/GlyssenEngineTests.csproj
+++ b/GlyssenEngineTests/GlyssenEngineTests.csproj
@@ -100,7 +100,7 @@
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.DblBundle, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.DblBundle.8.0.0-beta0037\lib\net461\SIL.DblBundle.dll</HintPath>
@@ -109,7 +109,7 @@
       <HintPath>..\packages\SIL.DblBundle.Tests.8.0.0-beta0037\lib\net461\SIL.DblBundle.Tests.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.TestUtilities, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.TestUtilities.8.0.0-beta0071\lib\net461\SIL.TestUtilities.dll</HintPath>
@@ -302,6 +302,7 @@
     <Compile Include="UndoActionsTests\UndoStackTests.cs" />
     <Compile Include="Casting\VoiceActorListTests.cs" />
     <Compile Include="Casting\VoiceActorTests.cs" />
+    <Compile Include="Utilities\StringExtensionsTests.cs" />
     <Compile Include="Utilities\VerseBridge.cs" />
     <Compile Include="ViewModelTests\AddCharactersToGroupViewModelTests.cs" />
     <Compile Include="ViewModelTests\AssignCharacterViewModelTests.cs" />

--- a/GlyssenEngineTests/Utilities/StringExtensionsTests.cs
+++ b/GlyssenEngineTests/Utilities/StringExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using GlyssenEngine.Utilities;
+using NUnit.Framework;
+
+namespace GlyssenEngineTests.Utilities
+{
+	[TestFixture]
+	public class StringExtensionsTests
+	{
+		[Test]
+		public void Truncate_NullString_ThrowsArgumentNullException()
+		{
+			string nullStr = null;
+			Assert.Throws<ArgumentNullException>(() => nullStr.Truncate(1));
+		}
+
+		[Test]
+		public void Truncate_NullEllipses_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>(() => "Blah".Truncate(100, null));
+		}
+
+		[TestCase(0)]
+		[TestCase(-1)]
+		[TestCase(1)]
+		public void Truncate_TruncateToNonPositiveLength_ThrowsArgumentOutOfRangeException(int truncateAt)
+		{
+			Assert.Throws<ArgumentOutOfRangeException>(() => "Blah".Truncate(truncateAt));
+		}
+
+		[TestCase("S")]
+		[TestCase("Short string")]
+		[TestCase("This is a super-duper very long string, my friend.")]
+		public void Truncate_ShorterOrEqualToLengthSpecified_NoChange(string input)
+		{
+			var maxLen = Math.Max(2, input.Length);
+			Assert.AreEqual(input, input.Truncate(maxLen));
+			Assert.AreEqual(input, input.Truncate(maxLen + 1));
+		}
+
+		[TestCase("Short string", "...")]
+		[TestCase("This is a super-duper very long string, my friend.", "\u2026")]
+		public void Truncate_TruncatingAndAddingEllipsesWouldMakeSameOrLonger_NoChange(string input, string ellipses)
+		{
+			var maxLen = input.Length - 1;
+			Assert.AreEqual(input, input.Truncate(maxLen, ellipses));
+			for (int i = ellipses.Length - 1; i > 0; i--)
+				Assert.AreEqual(input, input.Truncate(maxLen - i, ellipses));
+		}
+
+		[TestCase("Short string", 7, "...", ExpectedResult = "Short s...")]
+		[TestCase("Short string", 6, "...", ExpectedResult = "Short...")]
+		[TestCase("Short string", 5, "...", ExpectedResult = "Short...")]
+		[TestCase("Short string", 8, "...", ExpectedResult = "Short st...")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 9, "\u2026", ExpectedResult = "This is a\u2026")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 48, "\u2026", ExpectedResult = "This is a super-duper very long string, my frien\u2026")]
+		public string Truncate_LongerThanMaxPlusEllipsesLength_Truncated(string input, int truncateAt, string ellipses)
+		{
+			return input.Truncate(truncateAt, ellipses);
+		}
+
+		[TestCase("This is a super-duper very long string, my friend.     ", 49, "\u2026")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 49, "...")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 50, "\u2026")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 51, "\u2026")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 52, "\u2026")]
+		[TestCase("This is a super-duper very long string, my friend.     ", 53, "\u2026")]
+		public void Truncate_TrailingWhitespaceMakesItLongerThanMaxPlusEllipsesLength_Trimmed(string input, int truncateAt, string ellipses)
+		{
+			Assert.AreEqual("This is a super-duper very long string, my friend.", input.Truncate(truncateAt, ellipses));
+		}
+	}
+}

--- a/GlyssenEngineTests/packages.config
+++ b/GlyssenEngineTests/packages.config
@@ -24,10 +24,10 @@
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net472" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net461" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.DblBundle.Tests" version="8.0.0-beta0037" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.TestUtilities" version="8.0.0-beta0071" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />

--- a/GlyssenShared/GlyssenShared.csproj
+++ b/GlyssenShared/GlyssenShared.csproj
@@ -24,9 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SIL.Core" Version="8.0.0-beta0077" />
+    <PackageReference Include="SIL.Core" Version="8.0.0-beta0091" />
     <PackageReference Include="SIL.DblBundle" Version="8.0.0-beta0037" />
-    <PackageReference Include="SIL.Scripture" Version="8.0.0-beta0037" />
+    <PackageReference Include="SIL.Scripture" Version="8.0.0-beta0091" />
   </ItemGroup>
 
 </Project>

--- a/GlyssenSharedTests/GlyssenSharedTests.csproj
+++ b/GlyssenSharedTests/GlyssenSharedTests.csproj
@@ -79,7 +79,7 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.DblBundle, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.DblBundle.8.0.0-beta0037\lib\net461\SIL.DblBundle.dll</HintPath>
@@ -88,7 +88,7 @@
       <HintPath>..\packages\SIL.DblBundle.Tests.8.0.0-beta0037\lib\net461\SIL.DblBundle.Tests.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.TestUtilities, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.TestUtilities.8.0.0-beta0071\lib\net461\SIL.TestUtilities.dll</HintPath>

--- a/GlyssenSharedTests/packages.config
+++ b/GlyssenSharedTests/packages.config
@@ -14,10 +14,10 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net461" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.DblBundle.Tests" version="8.0.0-beta0037" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.TestUtilities" version="8.0.0-beta0071" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -147,7 +147,7 @@
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core.Desktop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.Desktop.8.0.0-beta0077\lib\net461\SIL.Core.Desktop.dll</HintPath>
@@ -159,7 +159,7 @@
       <HintPath>..\packages\SIL.DblBundle.Tests.8.0.0-beta0037\lib\net461\SIL.DblBundle.Tests.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.TestUtilities, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.TestUtilities.8.0.0-beta0071\lib\net461\SIL.TestUtilities.dll</HintPath>

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -37,12 +37,12 @@
   <package id="PangoSharp" version="3.22.24.37" targetFramework="net472" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Core.Desktop" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.DblBundle.Tests" version="8.0.0-beta0037" targetFramework="net472" />
   <package id="SIL.ReleaseTasks" version="2.2.0" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.TestUtilities" version="8.0.0-beta0071" targetFramework="net472" />
   <package id="SIL.Windows.Forms" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.Windows.Forms.DblBundle" version="8.0.0-beta0033" targetFramework="net472" />

--- a/RefTextDevUtilities/RefTextDevUtilities.csproj
+++ b/RefTextDevUtilities/RefTextDevUtilities.csproj
@@ -93,10 +93,10 @@
       <HintPath>..\packages\ParatextData.9.1.1-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.WritingSystems.8.0.0-beta0077\lib\net461\SIL.WritingSystems.dll</HintPath>

--- a/RefTextDevUtilities/packages.config
+++ b/RefTextDevUtilities/packages.config
@@ -14,8 +14,8 @@
   <package id="Microsoft.Windows.Compatibility" version="3.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="ParatextData" version="9.1.1-beta" targetFramework="net472" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />
   <package id="System.CodeDom" version="4.7.0" targetFramework="net472" />

--- a/Reference Text Utility/Reference Text Utility.csproj
+++ b/Reference Text Utility/Reference Text Utility.csproj
@@ -110,7 +110,7 @@
       <HintPath>..\packages\PangoSharp.3.22.24.37\lib\netstandard2.0\PangoSharp.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Core.8.0.0-beta0077\lib\net461\SIL.Core.dll</HintPath>
+      <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core.Desktop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.Desktop.8.0.0-beta0077\lib\net461\SIL.Core.Desktop.dll</HintPath>
@@ -119,7 +119,7 @@
       <HintPath>..\packages\SIL.DblBundle.8.0.0-beta0037\lib\net461\SIL.DblBundle.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Scripture, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0037\lib\net461\SIL.Scripture.dll</HintPath>
+      <HintPath>..\packages\SIL.Scripture.8.0.0-beta0091\lib\net461\SIL.Scripture.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Windows.Forms.8.0.0-beta0077\lib\net461\SIL.Windows.Forms.dll</HintPath>

--- a/Reference Text Utility/packages.config
+++ b/Reference Text Utility/packages.config
@@ -17,10 +17,10 @@
   <package id="NDesk.DBus" version="0.15.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="PangoSharp" version="3.22.24.37" targetFramework="net472" />
-  <package id="SIL.Core" version="8.0.0-beta0077" targetFramework="net472" />
+  <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Core.Desktop" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0037" targetFramework="net472" />
-  <package id="SIL.Scripture" version="8.0.0-beta0037" targetFramework="net472" />
+  <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Windows.Forms" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0077" targetFramework="net472" />
   <package id="Spart" version="1.0.0" targetFramework="net472" />


### PR DESCRIPTION
Previous behavior (accidentally, because of a change in SIL.Scripture) suppressed the error reporting and used the resulting versification, which might be bogus. Now we alert the user as appropriate.

Note: this is a pre-requisite to completion of https://github.com/sillsdev/Glyssen/pull/659

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/660)
<!-- Reviewable:end -->
