### PR TITLE
PG-1329: Recognize "he said" text and automatically apply to other blocks

### DIFF
--- a/GlyssenEngine/Bundle/GlyssenDblTextMetadata.cs
+++ b/GlyssenEngine/Bundle/GlyssenDblTextMetadata.cs
@@ -230,7 +230,7 @@ namespace GlyssenEngine.Bundle
 		}
 
 		/// <summary>
-		/// This is not part of the original DBL metadata. This data is now stored as part of the "langauge" data.
+		/// This is not part of the original DBL metadata. This data is now stored as part of the "language" data.
 		/// </summary>
 		[XmlElement("fontSizeInPoints")]
 		[DefaultValue(default(int))]

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -526,6 +526,20 @@ namespace GlyssenEngine
 			return itemToRemove != null && ProjectCharacterDetail.Remove(itemToRemove);
 		}
 
+		public IReadOnlyList<string> ReportingClauses => m_metadata.Language.ReportingClauses;
+
+		public bool AddNewReportingClauses(IEnumerable<string> reportingClauses)
+		{
+			var newAdditions = reportingClauses.Where(c => !m_metadata.Language.ReportingClauses.Contains(c)).ToList();
+			if (newAdditions.Any())
+			{
+				m_metadata.Language.ReportingClauses.AddRange(newAdditions);
+				return true;
+			}
+
+			return false;
+		}
+
 		public void UpdateSettings(ProjectSettingsViewModel model, string defaultFontFamily, int defaultFontSizeInPoints, bool rightToLeftScript)
 		{
 			Debug.Assert(!IsNullOrEmpty(model.RecordingProjectName));
@@ -1384,7 +1398,7 @@ namespace GlyssenEngine
 				var sourceBookScript = sourceProject.m_books.SingleOrDefault(b => b.BookId == targetBookScript.BookId);
 				if (sourceBookScript != null)
 				{
-					targetBookScript.ApplyUserDecisions(sourceBookScript, ReferenceText);
+					targetBookScript.ApplyUserDecisions(sourceBookScript, ReferenceText, ReportingClauses);
 				}
 			}
 			Analyze();

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -530,14 +530,10 @@ namespace GlyssenEngine
 
 		public bool AddNewReportingClauses(IEnumerable<string> reportingClauses)
 		{
-			var newAdditions = reportingClauses.Where(c => !m_metadata.Language.ReportingClauses.Contains(c)).ToList();
-			if (newAdditions.Any())
-			{
-				m_metadata.Language.ReportingClauses.AddRange(newAdditions);
-				return true;
-			}
-
-			return false;
+			var retVal = false;
+			foreach (var reportingClause in reportingClauses)
+				retVal |= m_metadata.Language.ReportingClauses.Add(reportingClause);
+			return retVal;
 		}
 
 		public void UpdateSettings(ProjectSettingsViewModel model, string defaultFontFamily, int defaultFontSizeInPoints, bool rightToLeftScript)

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -526,7 +526,7 @@ namespace GlyssenEngine
 			return itemToRemove != null && ProjectCharacterDetail.Remove(itemToRemove);
 		}
 
-		public IReadOnlyList<string> ReportingClauses => m_metadata.Language.ReportingClauses;
+		public IReadOnlyCollection<string> ReportingClauses => m_metadata.Language.ReportingClauses;
 
 		public bool AddNewReportingClauses(IEnumerable<string> reportingClauses)
 		{

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -215,7 +215,7 @@ namespace GlyssenEngine
 		/// <param name="allowSplitting">Flag indicating whether existing reference text blocks can be split (at verse breaks) to
 		/// achieve better correspondence to the vernacular blocks.</param>
 		public BlockMatchup GetBlocksForVerseMatchedToReferenceText(BookScript vernacularBook, int iBlock,
-			IReadOnlyList<string> reportingClauses = null, uint predeterminedBlockCount = 0, bool allowSplitting = true)
+			IReadOnlyCollection<string> reportingClauses = null, uint predeterminedBlockCount = 0, bool allowSplitting = true)
 		{
 			if (iBlock < 0 || iBlock >= vernacularBook.GetScriptBlocks().Count)
 				throw new ArgumentOutOfRangeException("iBlock");

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -122,37 +122,17 @@ namespace GlyssenEngine
 			}
 		}
 
-		public bool HasSecondaryReferenceText
-		{
-			get { return m_referenceTextType != ReferenceTextType.English; }
-		}
+		public bool HasSecondaryReferenceText => m_referenceTextType != ReferenceTextType.English;
 
-		public string SecondaryReferenceTextLanguageName
-		{
-			get { return HasSecondaryReferenceText ? "English" : null; }
-		}
+		public ReferenceText SecondaryReferenceText => GetStandardReferenceText(ReferenceTextType.English);
 
-		public ReferenceText SecondaryReferenceText
-		{
-			get { return GetStandardReferenceText(ReferenceTextType.English); }
-		}
+		public IReferenceLanguageInfo BackingReferenceLanguage => SecondaryReferenceText;
 
-		public IReferenceLanguageInfo BackingReferenceLanguage
-		{
-			get { return SecondaryReferenceText; }
-		}
+		// ENHANCE: When we support custom reference texts in languages that do not use a simple space character, this will
+		// need to be overridable in m_metadata.Language.
+		public string WordSeparator => " ";
 
-		public string WordSeparator
-		{
-			// ENHANCE: When we support custom reference texts in languages that do not use a simple space character, this will
-			// need to be overridable in m_metadata.Language.
-			get { return " "; }
-		}
-
-		public string HeSaidText
-		{
-			get { return m_metadata.Language.HeSaidText ?? "he said."; }
-		}
+		public string HeSaidText => m_metadata.Language.HeSaidText ?? "he said.";
 
 		/// <summary>
 		/// This gets the included books from the project. As needed, blocks are broken up and matched to
@@ -229,12 +209,13 @@ namespace GlyssenEngine
 		/// </summary>
 		/// <param name="vernacularBook">The book</param>
 		/// <param name="iBlock">Index of the "anchor" block for the matchup</param>
+		/// <param name="reportingClauses">vernacular strings that can be automatically matched to "he said"</param>
 		/// <param name="predeterminedBlockCount">Used to get a fast result if the caller knows the exact extent of the desired
 		/// matchup (typically based on a previous call to this method).</param>
 		/// <param name="allowSplitting">Flag indicating whether existing reference text blocks can be split (at verse breaks) to
 		/// achieve better correspondence to the vernacular blocks.</param>
 		public BlockMatchup GetBlocksForVerseMatchedToReferenceText(BookScript vernacularBook, int iBlock,
-			uint predeterminedBlockCount = 0, bool allowSplitting = true)
+			IReadOnlyList<string> reportingClauses = null, uint predeterminedBlockCount = 0, bool allowSplitting = true)
 		{
 			if (iBlock < 0 || iBlock >= vernacularBook.GetScriptBlocks().Count)
 				throw new ArgumentOutOfRangeException("iBlock");
@@ -253,6 +234,8 @@ namespace GlyssenEngine
 			var matchup = new BlockMatchup(vernacularBook, iBlock, splitBlocks,
 				block => IsOkayToSplitBeforeBlock(vernacularBook, block, verseSplitLocationsBasedOnRef),
 				this, predeterminedBlockCount);
+
+			matchup.MatchHeSaidBlocks(reportingClauses);
 
 			if (!matchup.AllScriptureBlocksMatch)
 			{

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -241,7 +241,7 @@ namespace GlyssenEngine.Script
 			// ReportingClauses in the reference language. For now, we really only expect there to
 			// be one, and that is the only one we can insert. Even if we were to add others (e.g.,
 			// "they said") to English (or other known reference text languages), it would be
-			// pretty unlikely that we would get matches very often. And it's not 1005 clear that
+			// pretty unlikely that we would get matches very often. And it's not 100% clear that
 			// we would want to return them if we did.
 			b.GetPrimaryReferenceText(true)?.Trim() == m_referenceLanguageInfo.HeSaidText);
 

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -477,7 +477,7 @@ namespace GlyssenEngine.Script
 			return !blockIndices.Any(i => CorrelatedBlocks[i].CharacterIsStandard);
 		}
 
-		public void MatchHeSaidBlocks(IReadOnlyList<string> reportingClauses)
+		public void MatchHeSaidBlocks(IReadOnlyCollection<string> reportingClauses)
 		{
 			if (reportingClauses == null || !reportingClauses.Any())
 				return;

--- a/GlyssenEngine/Script/BookScript.cs
+++ b/GlyssenEngine/Script/BookScript.cs
@@ -553,7 +553,7 @@ namespace GlyssenEngine.Script
 				AddOverrideInfo(info);
 		}
 
-		public void ApplyUserDecisions(BookScript sourceBookScript, ReferenceText referenceTextToReapply = null, IReadOnlyList<string> reportingClauses = null)
+		public void ApplyUserDecisions(BookScript sourceBookScript, ReferenceText referenceTextToReapply = null, IReadOnlyCollection<string> reportingClauses = null)
 		{
 			var blockComparer = new SplitBlockComparer();
 
@@ -571,7 +571,7 @@ namespace GlyssenEngine.Script
 		}
 
 		private void ApplyReferenceBlockMatches(BookScript sourceBookScript, ReferenceText referenceTextToReapply,
-			IReadOnlyList<string> reportingClauses, SplitBlockComparer blockComparer)
+			IReadOnlyCollection<string> reportingClauses, SplitBlockComparer blockComparer)
 		{
 			var sourceBlocks = sourceBookScript.GetScriptBlocks();
 			for (int iSrc = 0; iSrc < sourceBlocks.Count; iSrc++)

--- a/GlyssenEngine/Script/BookScript.cs
+++ b/GlyssenEngine/Script/BookScript.cs
@@ -553,7 +553,7 @@ namespace GlyssenEngine.Script
 				AddOverrideInfo(info);
 		}
 
-		public void ApplyUserDecisions(BookScript sourceBookScript, ReferenceText referenceTextToReapply = null)
+		public void ApplyUserDecisions(BookScript sourceBookScript, ReferenceText referenceTextToReapply = null, IReadOnlyList<string> reportingClauses = null)
 		{
 			var blockComparer = new SplitBlockComparer();
 
@@ -565,13 +565,13 @@ namespace GlyssenEngine.Script
 
 			ApplyUserSplits(sourceBookScript, blockComparer);
 			if (referenceTextToReapply != null)
-				ApplyReferenceBlockMatches(sourceBookScript, referenceTextToReapply, blockComparer);
+				ApplyReferenceBlockMatches(sourceBookScript, referenceTextToReapply, reportingClauses, blockComparer);
 			ApplyUserAssignments(sourceBookScript);
 			CleanUpMultiBlockQuotes();
 		}
 
 		private void ApplyReferenceBlockMatches(BookScript sourceBookScript, ReferenceText referenceTextToReapply,
-			SplitBlockComparer blockComparer)
+			IReadOnlyList<string> reportingClauses, SplitBlockComparer blockComparer)
 		{
 			var sourceBlocks = sourceBookScript.GetScriptBlocks();
 			for (int iSrc = 0; iSrc < sourceBlocks.Count; iSrc++)
@@ -623,7 +623,7 @@ namespace GlyssenEngine.Script
 				}
 				else if (!sourceBlocks.Skip(iSrc).Take(targetMatchup.CorrelatedBlocks.Count).SequenceEqual(targetMatchup.CorrelatedBlocks, blockComparer))
 					continue;
-				var sourceMatchup = referenceTextToReapply.GetBlocksForVerseMatchedToReferenceText(sourceBookScript, iSrc,
+				var sourceMatchup = referenceTextToReapply.GetBlocksForVerseMatchedToReferenceText(sourceBookScript, iSrc, reportingClauses,
 					(uint)targetMatchup.CorrelatedBlocks.Count, false);
 				if (sourceMatchup.CountOfBlocksAddedBySplitting != 0)
 				{

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -835,7 +835,7 @@ namespace GlyssenEngine.ViewModels
 				$"{CurrentBook.BookId} {CurrentBlock.ChapterNumber}:{CurrentBlock.InitialStartVerseNumber}");
 
 			m_currentRefBlockMatchups = m_project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(CurrentBook,
-				currentIndices.BlockIndex, currentIndices.MultiBlockCount);
+				currentIndices.BlockIndex, m_project.ReportingClauses, currentIndices.MultiBlockCount);
 			if (m_currentRefBlockMatchups != null)
 			{
 				m_currentRefBlockMatchups.MatchAllBlocks();
@@ -937,6 +937,16 @@ namespace GlyssenEngine.ViewModels
 				for (int i = startIndex; i < RelevantBlockCount && m_relevantBookBlockIndices[i].BookIndex == currentBookIndex; i++)
 					m_relevantBookBlockIndices[i].BlockIndex += insertions;
 			}
+
+			ProcessNewHeSaidRenderings();
+		}
+
+		private void ProcessNewHeSaidRenderings()
+		{
+			if (m_project.AddNewReportingClauses(m_currentRefBlockMatchups.HeSaidBlocks.Select(b => b.GetText(false).Trim()).Distinct()))
+			{
+				// TODO: re-check existing matchups to pare down list of relevant matchups.
+			}
 		}
 
 		protected virtual void HandleCurrentBlockChanged()
@@ -1004,7 +1014,7 @@ namespace GlyssenEngine.ViewModels
 
 					BlockMatchup matchup;
 					if (AttemptRefBlockMatchup &&
-						(matchup = m_project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(CurrentBook, indices.BlockIndex)) != null)
+						(matchup = m_project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(CurrentBook, indices.BlockIndex, m_project.ReportingClauses)) != null)
 					{
 						if (indices.ExtendForMatchup(matchup))
 							m_navigator.SetIndices(indices); // The call to GetIndices (above) gets a copy, so we need to set the state to reflect the updated Multi-block count

--- a/GlyssenEngineTests/ProjectTests.cs
+++ b/GlyssenEngineTests/ProjectTests.cs
@@ -506,8 +506,8 @@ namespace GlyssenEngineTests
 
 				i += matchup.OriginalBlockCount;
 			}
-			Assert.IsTrue(heSaidRenderings.Count > 0, "Setup conditions note met");
-			Assert.IsTrue(matchupIndices.Count > 0, "Setup conditions note met");
+			Assert.IsTrue(heSaidRenderings.Count > 0, "Setup conditions not met");
+			Assert.IsTrue(matchupIndices.Count > 0, "Setup conditions not met");
 
 			// SUT
 			Assert.IsTrue(project.AddNewReportingClauses(heSaidRenderings));

--- a/GlyssenEngineTests/ProjectTests.cs
+++ b/GlyssenEngineTests/ProjectTests.cs
@@ -456,6 +456,71 @@ namespace GlyssenEngineTests
 			WaitForParsingToComplete();
 		}
 
+		[Test]
+		public void AddNewReportingClauses_EmptyCollection_NoChange()
+		{
+			var project = TestProject.CreateBasicTestProject();
+			project.Metadata.Language.ReportingClauses.Add("dijo");
+			Assert.IsFalse(project.AddNewReportingClauses(new String[0]));
+			Assert.AreEqual("dijo", project.ReportingClauses.Single());
+		}
+
+		[Test]
+		public void AddNewReportingClauses_Existing_NoChange()
+		{
+			var project = TestProject.CreateBasicTestProject();
+			project.Metadata.Language.ReportingClauses.Add("dijo");
+			Assert.IsFalse(project.AddNewReportingClauses(new []{"dijo"}));
+			Assert.AreEqual("dijo", project.ReportingClauses.Single());
+		}
+
+		[Test]
+		public void AddNewReportingClauses_NewOnes_AddedAndDataUpdated()
+		{
+			// TODO: Much of this test probably belongs elsewhere. Project is now only responsible for updating the list and returning whether anything was added.
+			// SETUP
+			var project = TestProject.CreateTestProject(TestProject.TestBook.MRK);
+			var book = project.IncludedBooks.First();
+			Assert.IsFalse(book.Blocks.Any(b => b.MatchesReferenceText));
+			var narrator = CharacterVerseData.GetStandardCharacterId(book.BookId, CharacterVerseData.StandardCharacter.Narrator);
+			var heSaidRenderings = new HashSet<string>();
+			var matchupIndices = new List<Tuple<int, uint>>();
+			for(var i = 0; i < book.Blocks.Count;)
+			{
+				var block = book.Blocks[i];
+				if (!block.IsScripture)
+				{
+					i++;
+					continue;
+				}
+
+				var matchup = project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(book, i);
+				if (!matchup.AllScriptureBlocksMatch && matchup.CorrelatedBlocks.Where(b => !b.MatchesReferenceText)
+					.All(ub => ub.CharacterId == narrator && !ub.CoversMoreThanOneVerse &&
+						ub.BlockElements.OfType<ScriptText>().Single().Content.Length < 75))
+				{
+					heSaidRenderings.AddRange(matchup.CorrelatedBlocks.Where(b => !b.MatchesReferenceText)
+						.Select(b => b.BlockElements.OfType<ScriptText>().Single().Content.Trim()));
+					matchupIndices.Add(new Tuple<int, uint>(i, (uint)matchup.OriginalBlockCount));
+				}
+
+				i += matchup.OriginalBlockCount;
+			}
+			Assert.IsTrue(heSaidRenderings.Count > 0, "Setup conditions note met");
+			Assert.IsTrue(matchupIndices.Count > 0, "Setup conditions note met");
+
+			// SUT
+			Assert.IsTrue(project.AddNewReportingClauses(heSaidRenderings));
+			
+			// VERIFY
+			Assert.IsTrue(heSaidRenderings.SetEquals(project.Metadata.Language.ReportingClauses));
+			foreach (var m in matchupIndices)
+			{
+				var matchup = project.ReferenceText.GetBlocksForVerseMatchedToReferenceText(book, m.Item1, project.ReportingClauses, m.Item2);
+				Assert.IsTrue(matchup.AllScriptureBlocksMatch);
+			}
+		}
+
 		[TestCase("Boaz")]
 		[TestCase("Mr. Rogers")]
 		public void UpdateProjectFromBundleData_ProjectHasCustomCharacterVerseDecisions_UserDecisionsReapplied(string character)

--- a/GlyssenEngineTests/Script/BlockMatchupTests.cs
+++ b/GlyssenEngineTests/Script/BlockMatchupTests.cs
@@ -1735,7 +1735,7 @@ namespace GlyssenEngineTests.Script
 				"Luego sucedió la próxima cosa.").CharacterId;
 
 			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
-			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);//TestReferenceText.CreateCustomReferenceText(TestReferenceText.TestReferenceTextResource.SpanishMAT);
+			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
 			vernacularBlocks[0].SetMatchedReferenceBlock("After these things, Jesus taught them, saying: ");
 			vernacularBlocks[1].SetMatchedReferenceBlock("“Uncle, you are verse two,” ");
 			vernacularBlocks.Last().SetMatchedReferenceBlock("Then it came about that the next thing happened.");
@@ -1766,6 +1766,107 @@ namespace GlyssenEngineTests.Script
 			Assert.AreEqual("", matchup.CorrelatedBlocks[4].GetPrimaryReferenceText());
 			Assert.AreEqual(narrator, matchup.CorrelatedBlocks[4].CharacterId);
 			Assert.AreEqual(MultiBlockQuote.None, matchup.CorrelatedBlocks[4].MultiBlockQuote);
+		}
+
+		[Test]
+		public void HeSaidBlocks_NoBlocksCorrespondToHeSaid_Empty()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Después de estas cosas, Jesús les enseño, diciendo: ", true));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“Tio estas verso du,” "));
+			var vernJesusSaidBlock = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, "diris Jesuo. Etcetera. ");
+			vernJesusSaidBlock.MultiBlockQuote = MultiBlockQuote.Start;
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnexpectedCharacter, 3, "This is actually spoken by the narrator but was originally parsed as quoted speech. "));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnexpectedCharacter, 4, "And this is the rest of the narrator's mumblings."));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks, "Luego sucedió la próxima cosa.");
+
+			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
+			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, rt, (uint)vernacularBlocks.Count);
+			matchup.MatchAllBlocks();
+
+			Assert.IsFalse(matchup.HeSaidBlocks.Any());
+		}
+
+		[Test]
+		public void HeSaidBlocks_BlockIsMatchedToHeSaidButNotApplied_Empty()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Después de estas cosas, Jesús les enseño, diciendo: ", true));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“Tio estas verso du,” "));
+			var vernJesusSaidBlock = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, "diris Jesuo. Etcetera. ");
+			vernJesusSaidBlock.MultiBlockQuote = MultiBlockQuote.Start;
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnexpectedCharacter, 3, "This is actually spoken by the narrator but was originally parsed as quoted speech. "));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kUnexpectedCharacter, 4, "And this is the rest of the narrator's mumblings."));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks, "Luego sucedió la próxima cosa.");
+
+			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
+			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, rt, (uint)vernacularBlocks.Count);
+			matchup.MatchAllBlocks();
+			matchup.SetReferenceText(2, rt.HeSaidText);
+
+			Assert.IsFalse(matchup.HeSaidBlocks.Any());
+		}
+
+		[Test]
+		public void HeSaidBlocks_BlockIsMatchedToHeSaidAndApplied_ReturnsHeSaidBlock()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Después de estas cosas, Jesús les enseño, diciendo: ", true));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“Tio estas verso du,” "));
+			var vernJesusSaidBlock = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, "diris Jesuo. Etcetera. ");
+			vernJesusSaidBlock.MultiBlockQuote = MultiBlockQuote.Start;
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(3, "This is actually spoken by the narrator but was originally parsed as quoted speech. "));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(4, "And this is the rest of the narrator's mumblings."));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			var narrator = ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks, "Luego sucedió la próxima cosa.").CharacterId;
+
+			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
+			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, rt, (uint)vernacularBlocks.Count);
+			matchup.MatchAllBlocks();
+			matchup.SetReferenceText(2, rt.HeSaidText);
+			matchup.CorrelatedBlocks[2].CharacterId = narrator;
+			matchup.Apply();
+
+			Assert.AreEqual("diris Jesuo. Etcetera. ", matchup.HeSaidBlocks.Single().GetText(true));
+		}
+
+		[Test]
+		public void HeSaidBlocks_TwoBlocksMatchHeSaidButOnlyOneIsAssignedToNarrator_ReturnsOnlyTheHeSaidBlockSpokenByTheNarrator()
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Jesús les contó lo que dijo aquel hombre: ", true));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“\u2014Ya no quiero seguir en cuarentena, "));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Start;
+			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, "dijo.", "qm");
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 3, "“Sin embargo, la cuarentena seguía,”"));
+			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
+			ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks, "recounted Jesus.");
+			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(4, "Luego sucedió la próxima cosa."));
+
+			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
+			ReferenceText rt = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+
+			var matchup = new BlockMatchup(vernBook, 0, null, i => true, rt, (uint)vernacularBlocks.Count);
+			matchup.MatchAllBlocks();
+			matchup.SetReferenceText(2, rt.HeSaidText);
+			matchup.CorrelatedBlocks[2].CharacterId = "Jesus";
+			matchup.InsertHeSaidText(4, (i, i1, arg3) => { });
+			
+			matchup.Apply();
+
+			Assert.AreEqual("recounted Jesus.", matchup.HeSaidBlocks.Single().GetText(true));
 		}
 
 		[TestCase(1)]

--- a/GlyssenEngineTests/ViewModelTests/AssignCharacterViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/AssignCharacterViewModelTests.cs
@@ -894,7 +894,7 @@ namespace GlyssenEngineTests.ViewModelTests
 			m_fullProjectRefreshRequired = true;
 
 			// Find some place where we have a long run of continuation blocks, where the first two are in the
-			// same vere but the next one starts a new verse.
+			// same verse but the next one starts a new verse.
 			int i = 0;
 			for (; i < m_testProject.Books[0].Blocks.Count - 4; i++)
 			{

--- a/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using SIL.Extensions;
 using SIL.Reflection;
 using SIL.Scripture;
+using static System.String;
 using BlockNavigatorViewModel = GlyssenEngine.ViewModels.BlockNavigatorViewModel<Rhino.Mocks.Interfaces.IMockedObject>;
 
 namespace GlyssenEngineTests.ViewModelTests
@@ -1362,7 +1363,7 @@ namespace GlyssenEngineTests.ViewModelTests
 		[Test]
 		public void CanNavigateToPreviousRelevantBlock_OnBlockWhoseRainbowGroupCoversFirstBlock_ReturnsFalse()
 		{
-			m_model.SetMode(m_model.Mode, false);
+			m_model.SetMode(BlocksToDisplay.Ambiguous, false);
 			while (m_model.CanNavigateToPreviousRelevantBlock)
 				m_model.LoadPreviousRelevantBlock();
 			m_model.LoadNextRelevantBlock();
@@ -1376,6 +1377,100 @@ namespace GlyssenEngineTests.ViewModelTests
 			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.OriginalBlocks.Contains(origCurrentBlock));
 			Assert.AreEqual(1, m_model.CurrentDisplayIndex, "Note: Setting AttemptRefBlockMatchup = true should cause the filter to be" +
 				"reset and the \"block\" display index");
+		}
+
+		
+		[Test]
+		public void ApplyCurrentReferenceTextMatchup_HeSaid_SetsReferenceTextsForBlocksInGroupAndUpdatesState()
+		{
+			// SETUP
+			var markNarrator = CharacterVerseData.GetStandardCharacterId("MRK", CharacterVerseData.StandardCharacter.Narrator);
+			AddHeSaidAfterQuoteAtEndOfVerseInMark(1, 8, markNarrator);
+			var addedHeSaidBlockToMatchExplicitly = AddHeSaidAfterQuoteAtEndOfVerseInMark(1, 11, markNarrator);
+			AddHeSaidAfterQuoteAtEndOfVerseInMark(1, 15, markNarrator);
+			AddHeSaidAfterQuoteAtEndOfVerseInMark(1, 17, markNarrator);
+
+			m_model.SetMode(BlocksToDisplay.NotAlignedToReferenceText, true);
+			while (m_model.CanNavigateToPreviousRelevantBlock)
+				m_model.LoadPreviousRelevantBlock();
+
+			BlockNavigatorViewModelTests.FindRefInMark(m_model, 1, 8);
+			Assert.IsTrue(m_model.IsCurrentLocationRelevant);
+			m_model.LoadNextRelevantBlock();
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.First().InitialStartVerseNumber <= 11);
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Last().LastVerseNum == 11);
+			const string separator = "***";
+			var Mark1V11MatchupBlocks = Join(separator, m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Select(b => b.GetText(true)));
+			m_model.LoadNextRelevantBlock();
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.First().InitialStartVerseNumber <= 15);
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Last().LastVerseNum == 15);
+			m_model.LoadNextRelevantBlock();
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.First().InitialStartVerseNumber <= 17);
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Last().LastVerseNum == 17);
+			Assert.IsTrue(m_model.CanNavigateToNextRelevantBlock, "Setup condition not met");
+			m_model.LoadNextRelevantBlock();
+			var firstRelevantMatchupPastMark1V17Blocks = Join(separator, m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Select(b => b.GetText(true)));
+			m_model.LoadPreviousRelevantBlock();
+			m_model.LoadPreviousRelevantBlock();
+			m_model.LoadPreviousRelevantBlock();
+			var matchup = m_model.CurrentReferenceTextMatchup;
+			Assert.AreEqual(Mark1V11MatchupBlocks, Join(separator, matchup.CorrelatedBlocks.Select(b => b.GetText(true))));
+			Assert.AreEqual(addedHeSaidBlockToMatchExplicitly, matchup.OriginalBlocks.Last());
+			bool callbackCalled = false;
+			var iHeSaidRow = matchup.CorrelatedBlocks.Count - 1;
+			matchup.InsertHeSaidText(iHeSaidRow, (iRow, level, text) =>
+			{
+				Assert.AreEqual(iHeSaidRow, iRow);
+				Assert.AreEqual(0, level);
+				Assert.AreEqual("he said.", text);
+				Assert.IsFalse(callbackCalled);
+				callbackCalled = true;
+			});
+			Assert.IsTrue(callbackCalled);
+
+			var origRelevantBlock = m_model.RelevantBlockCount;
+			var origBlockDisplayIndex = m_model.CurrentDisplayIndex;
+
+			// SUT
+			m_model.ApplyCurrentReferenceTextMatchup();
+
+			// VERIFY
+			Assert.AreEqual(matchup, m_model.CurrentReferenceTextMatchup);
+			Assert.IsTrue(m_model.IsCurrentLocationRelevant,
+				"We leave the matchup that was explicitly applied in the collection so the user can use \"Prev\" to get back to it");
+
+			Assert.AreEqual(origBlockDisplayIndex - 1, m_model.CurrentDisplayIndex,
+				"One of the previous matchups (for Mark 1:8) is no longer relevant.");
+			Assert.AreEqual(origRelevantBlock - 3, m_model.RelevantBlockCount,
+				"The three other matchups with the \"he said\" text should no longer be considered relevant.");
+			Assert.IsTrue(m_model.CanNavigateToNextRelevantBlock);
+			m_model.LoadNextRelevantBlock();
+			Assert.AreEqual(firstRelevantMatchupPastMark1V17Blocks,
+				Join(separator, m_model.CurrentReferenceTextMatchup.CorrelatedBlocks.Select(b => b.GetText(true))));
+		}
+
+		private Block AddHeSaidAfterQuoteAtEndOfVerseInMark(int chapterNum, int verseNum, string markNarrator)
+		{
+			var mark = m_testProject.IncludedBooks.Single(b => b.BookId == "MRK");
+			var markBlocks = mark.GetScriptBlocks();
+			var iBlock = markBlocks.TakeWhile(b => b.ChapterNumber <= chapterNum)
+				.IndexOf(b => b.LastVerseNum == verseNum);
+			Assert.IsTrue(iBlock > 0, "Setup condition not met.");
+			while (iBlock + 1 < markBlocks.Count && markBlocks[iBlock + 1].IsScripture && markBlocks[iBlock + 1].LastVerseNum == verseNum)
+				iBlock++;
+			var block = markBlocks[iBlock];
+			var lastScriptText = (ScriptText)block.BlockElements.Last();
+			var lastTextContent = lastScriptText.Content;
+			if (lastTextContent.Last() != ' ')
+				lastTextContent = lastScriptText.Content += " ";
+			Assert.IsTrue(lastTextContent.EndsWith("” "), "Setup condition not met.");
+
+			var characterToReapply = block.CharacterId;
+			lastScriptText.Content += "wacci kum.";
+			var newBlock = mark.SplitBlock(block, verseNum.ToString(), lastTextContent.Length, false);
+			block.CharacterId = characterToReapply;
+			newBlock.CharacterId = markNarrator;
+			return newBlock;
 		}
 	}
 

--- a/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
+++ b/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
@@ -37,7 +37,7 @@ namespace Glyssen.Shared.Bundle
 		public int FontSizeUiAdjustment { get; set; }
 
 		/// <summary>
-		/// Historically, the "heSaidText" element held the (on-and-only) rendering of "he said" in
+		/// Historically, the "heSaidText" element held the (one-and-only) rendering of "he said" in
 		/// the language. This was needed only for reference texts and was not exposed via the UI.
 		/// However, now that we are detecting and applying reporting clauses, there is the
 		/// possibility of multiple ones. We don't actually care what the specific meaning of each

--- a/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
+++ b/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
@@ -14,7 +14,7 @@ namespace Glyssen.Shared.Bundle
 	public class GlyssenDblMetadataLanguage : DblMetadataLanguage
 	{
 		private int m_fontSizeInPoints;
-		private string m_heSaidTextTemp;
+		private string m_heSaidText;
 
 		/// <summary>
 		/// This is pulled in from the stylesheet or set via the ProjectSettingsDlg.
@@ -37,55 +37,31 @@ namespace Glyssen.Shared.Bundle
 		public int FontSizeUiAdjustment { get; set; }
 
 		/// <summary>
-		/// Historically, the "heSaidText" element held the (one-and-only) rendering of "he said" in
-		/// the language. This was needed only for reference texts and was not exposed via the UI.
-		/// However, now that we are detecting and applying reporting clauses, there is the
-		/// possibility of multiple ones. We don't actually care what the specific meaning of each
-		/// one is. For data migration purposes, we don't ever expect to have both the "heSaidText"
-		/// element and a list of reporting clauses, but the set code should handle it correctly if
-		/// it ever happened. For most reference texts, the list of reporting clauses will just
-		/// contain a single entry (which used to be the "heSaidText"). 
+		/// Translation equivalent for "he said." in this language.
+		/// This is needed only for reference texts and is not exposed via the UI.
 		/// </summary>
 		[XmlElement("heSaidText")]
 		[DefaultValue(null)]
-		public string HeSaidText_DeprecatedXml
-		{
-			get => null;
-			set => HeSaidText = value;
-
-		}
-
-		/// <summary>
-		/// Translation equivalent for "he said." in this language.
-		/// </summary>
 		public string HeSaidText
 		{
-			get => ReportingClauses?.FirstOrDefault();
+			get => m_heSaidText;
 			set
 			{
-				m_heSaidTextTemp = value;
-				if (ReportingClauses == null)
-					ReportingClauses = new List<string>(new [] { value });
-				else if (ReportingClauses.Count == 0)
+				m_heSaidText = value;
+				if (ReportingClauses != null && !ReportingClauses.Contains(value))
 					ReportingClauses.Add(value);
-				else if (ReportingClauses[0] != value)
-				{
-					if (ReportingClauses.Contains(value))
-						ReportingClauses.Remove(value);
-					ReportingClauses.Insert(0, value);
-				}
 			}
 		}
 
 		/// <summary>
 		/// Translation equivalent for "he said", "they said", "she says", "you will say", etc. in
-		/// this language. The first one will be treated as the default "he said" text. (The
-		/// current UI doesn't actually give the user a way to order them to ensure this, so if we
-		/// ever implement the ability to create a custom reference text from a Glyssen project,
-		/// they will need a way to re-order them so that the desired "he said" is first.)
+		/// this language.
 		/// </summary>
+		/// <remarks>If we ever implement the ability to create a custom reference text from a
+		/// Glyssen project, there will need a way to select the desired "he said" from this list
+		/// to set <see cref="HeSaidText"/>.</remarks>
 		[XmlElement("reportingClause")]
-		public List<string> ReportingClauses { get; set; }
+		public HashSet<string> ReportingClauses { get; set; }
 
 		public GlyssenDblMetadataLanguage Clone()
 		{

--- a/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
+++ b/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Xml.Serialization;
 using SIL.DblBundle.Text;
 
@@ -12,6 +14,7 @@ namespace Glyssen.Shared.Bundle
 	public class GlyssenDblMetadataLanguage : DblMetadataLanguage
 	{
 		private int m_fontSizeInPoints;
+		private string m_heSaidTextTemp;
 
 		/// <summary>
 		/// This is pulled in from the stylesheet or set via the ProjectSettingsDlg.
@@ -34,12 +37,55 @@ namespace Glyssen.Shared.Bundle
 		public int FontSizeUiAdjustment { get; set; }
 
 		/// <summary>
-		/// Translation equivalent for "he said." in this language. (Only needed for reference texts - currently
-		/// not exposed via the UI.)
+		/// Historically, the "heSaidText" element held the (on-and-only) rendering of "he said" in
+		/// the language. This was needed only for reference texts and was not exposed via the UI.
+		/// However, now that we are detecting and applying reporting clauses, there is the
+		/// possibility of multiple ones. We don't actually care what the specific meaning of each
+		/// one is. For data migration purposes, we don't ever expect to have both the "heSaidText"
+		/// element and a list of reporting clauses, but the set code should handle it correctly if
+		/// it ever happened. For most reference texts, the list of reporting clauses will just
+		/// contain a single entry (which used to be the "heSaidText"). 
 		/// </summary>
 		[XmlElement("heSaidText")]
 		[DefaultValue(null)]
-		public string HeSaidText { get; set; }
+		public string HeSaidText_DeprecatedXml
+		{
+			get => null;
+			set => HeSaidText = value;
+
+		}
+
+		/// <summary>
+		/// Translation equivalent for "he said." in this language.
+		/// </summary>
+		public string HeSaidText
+		{
+			get => ReportingClauses?.FirstOrDefault();
+			set
+			{
+				m_heSaidTextTemp = value;
+				if (ReportingClauses == null)
+					ReportingClauses = new List<string>(new [] { value });
+				else if (ReportingClauses.Count == 0)
+					ReportingClauses.Add(value);
+				else if (ReportingClauses[0] != value)
+				{
+					if (ReportingClauses.Contains(value))
+						ReportingClauses.Remove(value);
+					ReportingClauses.Insert(0, value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Translation equivalent for "he said", "they said", "she says", "you will say", etc. in
+		/// this language. The first one will be treated as the default "he said" text. (The
+		/// current UI doesn't actually give the user a way to order them to ensure this, so if we
+		/// ever implement the ability to create a custom reference text from a Glyssen project,
+		/// they will need a way to re-order them so that the desired "he said" is first.)
+		/// </summary>
+		[XmlElement("reportingClause")]
+		public List<string> ReportingClauses { get; set; }
 
 		public GlyssenDblMetadataLanguage Clone()
 		{

--- a/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
+++ b/GlyssenShared/Bundle/GlyssenDblMetadataLanguage.cs
@@ -48,8 +48,11 @@ namespace Glyssen.Shared.Bundle
 			set
 			{
 				m_heSaidText = value;
-				if (ReportingClauses != null && !ReportingClauses.Contains(value))
-					ReportingClauses.Add(value);
+				// There is no actual purpose in doing this since currently only reference texts
+				// should have a "heSaidText" element and we never access the ReportingClauses for
+				// a reference text, but since technically the "he said" text is a reporting
+				// clause, this feels like the right thing to do. (It might matter in the future.)
+				ReportingClauses?.Add(value);
 			}
 		}
 


### PR DESCRIPTION
Initial implementation to detect and store reporting clauses and generate the corresponding "he said" reference blocks in GetBlocksForVerseMatchedToReferenceText.

This includes the migration of the "heSaid" element to "reportingClause" (now a list)
(Also fixed a few typos/misspellings)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/662)
<!-- Reviewable:end -->
