### PR TITLE
PG-1352: Prevented crash when Paratext project has book names defined for unavailable books

### DIFF
--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -1312,17 +1312,19 @@ namespace GlyssenEngine
 		private void AddMissingAvailableBooks()
 		{
 			BookNames nameInfo = null;
-			for (var i = 0; i < m_books.Count; i++)
+
+			int Compare(Book book, BookScript bookScript) => BCVRef.BookToNumber(book.Code).CompareTo(bookScript.BookNumber);
+			Book GetBook(BookScript bookScript)
 			{
-				if (m_projectMetadata.AvailableBooks[i].Code != m_books[i].BookId)
-				{
-					if (!IsLiveParatextProject)
-						throw new InvalidOperationException($"Book {m_books[i].BookId} parsed and added to project but not in AvailableBooks in metadata!");
-					if (nameInfo == null)
-						nameInfo = GetSourceParatextProject().BookNames;
-					m_projectMetadata.AvailableBooks.Insert(i, ParatextScrTextWrapper.GetBook(nameInfo, m_books[i].BookNumber, true));
-				}
+				if (!IsLiveParatextProject)
+					throw new InvalidOperationException($"Book {bookScript.BookId} parsed and added to project but not in AvailableBooks in metadata!");
+				if (nameInfo == null)
+					nameInfo = GetSourceParatextProject().BookNames;
+				return ParatextScrTextWrapper.GetBook(nameInfo, bookScript.BookNumber, true);
 			}
+
+			// Merge m_books into m_projectMetadata.AvailableBooks
+			m_projectMetadata.AvailableBooks.MergeOrderedList(m_books, Compare, GetBook);
 		}
 
 		protected override void SetVersification(ScrVers versification)

--- a/GlyssenEngine/Utilities/ListExtensions.cs
+++ b/GlyssenEngine/Utilities/ListExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GlyssenEngine.Utilities
+{
+	public static class ListExtensions
+	{
+		/// <summary>
+		/// Merges two sorted lists containing potentially different types of objects, resulting in a single
+		/// sorted list of objects of type T with no duplicates.
+		/// </summary>
+		public static void MergeOrderedList<TMe, TOther>(this List<TMe> me, IReadOnlyList<TOther> other, Func<TMe, TOther, int> compare = null, Func<TOther, TMe> selectT = null)
+		{
+			if (other == null)
+				throw new ArgumentNullException(nameof(other));
+			if (compare == null)
+			{
+				if (typeof(TMe).GetInterfaces().Any(i => i == typeof(IComparable<TOther>)))
+				{
+					compare = (a, b) => ((IComparable<TOther>)a).CompareTo(b);
+				}
+				else
+				{
+					throw new ArgumentNullException(nameof(compare),
+						"A comparison method must be supplied if no default comparison exists.");
+				}
+			}
+
+			if (selectT == null)
+				if (typeof(TMe).IsAssignableFrom(typeof(TOther)))
+				{
+					selectT = o => (TMe)(o as object);
+				}
+				else
+				{
+					throw new ArgumentNullException(nameof(selectT),
+						$"A selection method must be supplied if the items in the other list cannot be assigned to the type of the items in \"{nameof(me)}\"");
+				}
+
+			if (me.Count == 0)
+			{
+				me.AddRange(other.Select(selectT));
+				return;
+			}
+
+			for (int o = 0, m = 0; o < other.Count; o++)
+			{
+				var currentOther = other[o];
+				while (compare(me[m], currentOther) < 0 && ++m < me.Count) {}
+
+				if (m == me.Count)
+				{
+					me.AddRange(other.Skip(o).Select(selectT));
+					break;
+				}
+
+				if (compare(me[m], currentOther) != 0)
+					me.Insert(m, selectT(currentOther));
+			}
+		}
+	}
+}

--- a/GlyssenEngineTests/GlyssenEngineTests.csproj
+++ b/GlyssenEngineTests/GlyssenEngineTests.csproj
@@ -302,6 +302,7 @@
     <Compile Include="UndoActionsTests\UndoStackTests.cs" />
     <Compile Include="Casting\VoiceActorListTests.cs" />
     <Compile Include="Casting\VoiceActorTests.cs" />
+    <Compile Include="Utilities\ListExtensionsTests.cs" />
     <Compile Include="Utilities\StringExtensionsTests.cs" />
     <Compile Include="Utilities\VerseBridge.cs" />
     <Compile Include="ViewModelTests\AddCharactersToGroupViewModelTests.cs" />

--- a/GlyssenEngineTests/Utilities/ListExtensionsTests.cs
+++ b/GlyssenEngineTests/Utilities/ListExtensionsTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GlyssenEngine.Utilities;
+using NUnit.Framework;
+
+namespace GlyssenEngineTests.Utilities
+{
+	[TestFixture]
+	public class ListExtensionsTests
+	{
+		[Test]
+		public void MergeOrderedList_NullOther_ThrowsArgumentNullException()
+		{
+			var me = new List<int>( new [] {1, 2, 3});
+			List<char> other = null;
+			Assert.Throws<ArgumentNullException>(() => me.MergeOrderedList(other, null, null));
+		}
+
+		[Test]
+		public void MergeOrderedList_NullCompareMethodWithDifferentTypes_ThrowsArgumentNullException()
+		{
+			var me = new List<int>( new [] {1, 2, 3});
+			var other = new List<char>( new [] {'a', 'b', 'c'});
+			Assert.Throws<ArgumentNullException>(() => me.MergeOrderedList(other, null));
+		}
+
+		[Test]
+		public void MergeOrderedList_NullSelectMethodWithDifferentTypes_ThrowsArgumentNullException()
+		{
+			var me = new List<int>( new [] {1, 2, 3});
+			var other = new List<char>( new [] {'a', 'b', 'c'});
+			Assert.Throws<ArgumentNullException>(() => me.MergeOrderedList(other, (a, b) => a.CompareTo(b), null));
+		}
+
+		[Test]
+		public void MergeOrderedList_NullCompareAndSelectMethodWithSameTypes_ListsMerged()
+		{
+			var me = new List<int>( new [] {1, 2, 3});
+			var other = new List<int>( new [] {1, 3, 4});
+			me.MergeOrderedList(other, null, null);
+			Assert.That(me.SequenceEqual(new [] {1, 2, 3, 4}));
+		}
+
+		[Test]
+		public void MergeOrderedList_EmptyMe_MeFilledWithItemsFromOther()
+		{
+			var me = new List<char>();
+			var other = new List<int>( new [] {1, 2, 4});
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd'}));
+		}
+
+		[Test]
+		public void MergeOrderedList_EmptyOther_MeUnchanged()
+		{
+			var me = new List<char>(new [] {'a', 'b', 'd'});
+			me.MergeOrderedList(new List<int>(), Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd'}));
+		}
+
+		[Test]
+		public void MergeOrderedList_OtherContainsOnlyDuplicates_MeUnchanged()
+		{
+			var me = new List<char>(new [] {'a', 'b', 'd'});
+			var other = new List<int>( new [] {1, 2, 4});
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd'}));
+			
+			other.RemoveAt(2);
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd'}));
+			
+			other.RemoveAt(0);
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd'}));
+		}
+
+		[Test]
+		public void MergeOrderedList_OtherContainsNewItemsBeforeAnyItemInMe_NewItemsPrependedToMe()
+		{
+			var me = new List<char>(new [] {'d', 'g', 'm'});
+			var other = new List<int>( new [] {3});
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'c', 'd', 'g', 'm'}));
+			
+			other.Insert(0, 2);
+			other.Insert(0, 1);
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'c', 'd', 'g', 'm'}));
+		}
+
+		[Test]
+		public void MergeOrderedList_OtherContainsNewItemsAfterAnyItemInMe_NewItemsAppendedToMe()
+		{
+			var me = new List<char>(new [] {'d', 'e', 'f'});
+			var other = new List<int>( new [] {7});
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'d', 'e', 'f', 'g'}));
+			
+			other.Add(9);
+			other.Add(26);
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'d', 'e', 'f', 'g', 'i', 'z'}));
+		}
+
+		[Test]
+		public void MergeOrderedList_OtherContainsNewItemsIntermingledWithMe_MergedInOrderWithNoDuplicates()
+		{
+			var me = new List<char>(new [] {'d', 'f', 'm'});
+			var other = new List<int>( new [] {1, 2, 5, 8, 26});
+			me.MergeOrderedList(other, Compare, IntToChar);
+			Assert.That(me.SequenceEqual(new [] {'a', 'b', 'd', 'e', 'f', 'h', 'm', 'z'}));
+		}
+
+		private int Compare(char c, int i) => c.CompareTo((char)(i + 'a' - 1));
+
+		private char IntToChar(int i) => (char)(i + 'a' - 1);
+	}
+}


### PR DESCRIPTION
AddMissingAvailableBooks was incorrectly assuming that m_books would not have "holes." I write a really cool general-purpose merge method to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/667)
<!-- Reviewable:end -->
