### PR TITLE
PG-1366: When getting a TextReader, open file with read-only access.

### DIFF
--- a/GlyssenFileBasedPersistence/PersistenceImplementation.cs
+++ b/GlyssenFileBasedPersistence/PersistenceImplementation.cs
@@ -391,7 +391,7 @@ namespace GlyssenFileBasedPersistence
 		}
 
 		private TextReader GetReader(string fullPath) =>
-			RobustFile.Exists(fullPath) ? new StreamReader(new FileStream(fullPath, FileMode.Open)) : null;
+			RobustFile.Exists(fullPath) ? new StreamReader(new FileStream(fullPath, FileMode.Open, FileAccess.Read)) : null;
 
 		#endregion
 		


### PR DESCRIPTION
This should prevent UnauthorizedAccessException: Access to the path 'C:\Program Files\Glyssen\reference_texts\English\english.glyssen' is denied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/675)
<!-- Reviewable:end -->
