### PR TITLE
PG-1376: Made display of English version of reference text update

### DIFF
--- a/DistFiles/reference_texts/Russian/russian.glyssen
+++ b/DistFiles/reference_texts/Russian/russian.glyssen
@@ -14,10 +14,8 @@
   <identification>
     <name>Synodal Translation (1876)</name>
     <nameLocal />
-    <systemId type="gbc" />
-    <systemId type="tms" />
-    <systemId type="reap" />
-    <systemId type="biblica" />
+    <systemId type="fcbhOT"></systemId>
+    <systemId type="fcbhNT">99</systemId>
   </identification>
   <copyright>
     <statement contentType="xhtml">

--- a/Glyssen/Dialogs/ProjectSettingsDlg.cs
+++ b/Glyssen/Dialogs/ProjectSettingsDlg.cs
@@ -149,9 +149,7 @@ namespace Glyssen.Dialogs
 
 		private void LoadReferenceTextOptions()
 		{
-			m_labelOTVersion.Text = ReferenceText.EnglishOTVersion;
-			m_labelNTVersion.Text = ReferenceText.EnglishNTVersion;
-
+			var currentSelection = SelectedReferenceText;
 			var dataSource = new Dictionary<string, ReferenceTextProxy>();
 			foreach (var refTextId in ReferenceTextProxy.AllAvailable)
 			{
@@ -173,6 +171,8 @@ namespace Glyssen.Dialogs
 			m_ReferenceText.DataSource = new BindingSource(dataSource, null);
 			m_ReferenceText.ValueMember = "Value";
 			m_ReferenceText.DisplayMember = "Key";
+
+			SelectCurrentReferenceText(currentSelection ?? m_model.Project.ReferenceTextProxy);
 		}
 
 		private void ProjectSettingsDlg_Load(object sender, EventArgs e)
@@ -241,18 +241,23 @@ namespace Glyssen.Dialogs
 			m_chkChapterOneAnnouncements.Checked = !m_model.SkipChapterAnnouncementForFirstChapter;
 			m_chkAnnounceChaptersForSingleChapterBooks.Checked = !m_model.SkipChapterAnnouncementForSingleChapterBooks;
 
+			SelectCurrentReferenceText(m_model.Project.ReferenceTextProxy);
+
+			m_bookIntro.SelectedValue = m_model.Project.DramatizationPreferences.BookIntroductionsDramatization;
+			m_sectionHeadings.SelectedValue = m_model.Project.DramatizationPreferences.SectionHeadDramatization;
+			m_titleChapters.SelectedValue = m_model.Project.DramatizationPreferences.BookTitleAndChapterDramatization;
+		}
+
+		private void SelectCurrentReferenceText(ReferenceTextProxy currentReferenceText)
+		{
 			foreach (KeyValuePair<string, ReferenceTextProxy> kvp in m_ReferenceText.Items)
 			{
-				if (kvp.Value == m_model.Project.ReferenceTextProxy)
+				if (kvp.Value == currentReferenceText)
 				{
 					m_ReferenceText.SelectedItem = kvp;
 					break;
 				}
 			}
-
-			m_bookIntro.SelectedValue = m_model.Project.DramatizationPreferences.BookIntroductionsDramatization;
-			m_sectionHeadings.SelectedValue = m_model.Project.DramatizationPreferences.SectionHeadDramatization;
-			m_titleChapters.SelectedValue = m_model.Project.DramatizationPreferences.BookTitleAndChapterDramatization;
 		}
 
 		private string RecordingProjectName
@@ -378,7 +383,7 @@ namespace Glyssen.Dialogs
             m_model.AudioStockNumber = AudioStockNumber;
 			m_model.ChapterAnnouncementStyle = ChapterAnnouncementStyle;
 			m_model.SkipChapterAnnouncementForFirstChapter = !m_chkChapterOneAnnouncements.Checked;
-			m_model.Project.ReferenceTextProxy = ((KeyValuePair<string, ReferenceTextProxy>)m_ReferenceText.SelectedItem).Value;
+			m_model.Project.ReferenceTextProxy = SelectedReferenceText;
 
 			m_model.Project.DramatizationPreferences.BookIntroductionsDramatization = (ExtraBiblicalMaterialSpeakerOption)m_bookIntro.SelectedValue;
 			m_model.Project.DramatizationPreferences.SectionHeadDramatization = (ExtraBiblicalMaterialSpeakerOption)m_sectionHeadings.SelectedValue;
@@ -388,6 +393,8 @@ namespace Glyssen.Dialogs
 			DialogResult = DialogResult.OK;
 			Close();
 		}
+
+		private ReferenceTextProxy SelectedReferenceText => ((KeyValuePair<string, ReferenceTextProxy>?)m_ReferenceText.SelectedItem)?.Value;
 
 		private void HandleCancelButtonClick(object sender, EventArgs e)
 		{
@@ -627,6 +634,9 @@ namespace Glyssen.Dialogs
 				m_labelWarningReferenceTextDoesNotCoverAllBooks.Visible =
 					!m_model.Project.AvailableBooks.Select(b => b.Code).All(bookId =>
 						referenceText.HasContentForBook(bookId));
+
+				m_labelOTVersion.Text = referenceText.EnglishOTVersion;
+				m_labelNTVersion.Text = referenceText.EnglishNTVersion;
 			}
 		}
 

--- a/Glyssen/Dialogs/ProjectSettingsDlg.cs
+++ b/Glyssen/Dialogs/ProjectSettingsDlg.cs
@@ -149,6 +149,11 @@ namespace Glyssen.Dialogs
 
 		private void LoadReferenceTextOptions()
 		{
+			// Saving the selection (if any) here is required to deal with the (rare) case where
+			// the user does on-the-fly localization. When there is an existing selection that
+			// differs from the one that was set when we came into this dialog and we reset the
+			// data source, the selection gets lost. So we need to remember which one was selected
+			// and restore it below.
 			var currentSelection = SelectedReferenceText;
 			var dataSource = new Dictionary<string, ReferenceTextProxy>();
 			foreach (var refTextId in ReferenceTextProxy.AllAvailable)

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -65,15 +65,14 @@ namespace GlyssenEngine
 			NT
 		}
 
-		private static string GetEnglishVersion(FcbhTestament testament)
+		private string GetEnglishVersion(FcbhTestament testament)
 		{
 			var type = "fcbh" + testament;
-			return GetStandardReferenceText(ReferenceTextType.English).m_metadata
-				.Identification.SystemIds.FirstOrDefault(sysId => sysId.Type == type)?.Id;
+			return m_metadata?.Identification?.SystemIds?.FirstOrDefault(sysId => sysId.Type == type)?.Id;
 		}
 
-		public static string EnglishOTVersion => GetEnglishVersion(FcbhTestament.OT);
-		public static string EnglishNTVersion => GetEnglishVersion(FcbhTestament.NT);
+		public string EnglishOTVersion => GetEnglishVersion(FcbhTestament.OT);
+		public string EnglishNTVersion => GetEnglishVersion(FcbhTestament.NT);
 
 		public ReferenceTextType Type => m_referenceTextType;
 		


### PR DESCRIPTION
 based on selected reference text, since it may be out of sync with latest English version.
Also fixed logic that selects the current reference text so that if user localizes on the fly, the same one is re-selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/687)
<!-- Reviewable:end -->
