### PR TITLE
v1.3.13 Final changes for release

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -111,6 +111,7 @@
 				try {
 					OutputFilename = Path.GetFullPath(OutputFilename);
 
+					ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 					Log.LogMessage("Downloading latest version of NuGet.exe...");
 					WebClient webClient = new WebClient();
 					webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFilename);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
+## [1.3.13] - 2020-06-15
+
+### Changed
+
+- Switch localization to use XLIFF format instead of TMX. More (albeit minimal) UI languages available. Translations can be done via crowdin.com.
+
 ## [1.3.11] - 2020-05-27
 
 ### Added

--- a/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
+++ b/ControlDataIntegrityTests/ControlDataIntegrityTests.csproj
@@ -70,14 +70,14 @@
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Paratext.LexicalContracts, Version=9.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
+    <Reference Include="Paratext.LexicalContracts, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>

--- a/ControlDataIntegrityTests/packages.config
+++ b/ControlDataIntegrityTests/packages.config
@@ -20,7 +20,7 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net461" />
-  <package id="ParatextData" version="9.1.5-beta" targetFramework="net472" />
+  <package id="ParatextData" version="9.1.7-beta" targetFramework="net472" />
   <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0085" targetFramework="net472" />

--- a/DevTools/DevTools.csproj
+++ b/DevTools/DevTools.csproj
@@ -64,14 +64,14 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Paratext.LexicalContracts, Version=9.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
+    <Reference Include="Paratext.LexicalContracts, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>

--- a/DevTools/packages.config
+++ b/DevTools/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Win32.SystemEvents" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Windows.Compatibility" version="3.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-  <package id="ParatextData" version="9.1.5-beta" targetFramework="net472" />
+  <package id="ParatextData" version="9.1.7-beta" targetFramework="net472" />
   <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0085" targetFramework="net472" />
   <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -603,7 +603,7 @@
       <Version>3.22.24.37</Version>
     </PackageReference>
     <PackageReference Include="ParatextData">
-      <Version>9.1.5-beta</Version>
+      <Version>9.1.7-beta</Version>
     </PackageReference>
     <PackageReference Include="SIL.Core">
       <Version>8.0.0-beta0091</Version>

--- a/GlyssenEngine/GlyssenEngine.csproj
+++ b/GlyssenEngine/GlyssenEngine.csproj
@@ -70,7 +70,7 @@ See full changelog at https://github.com/sillsdev/Glyssen/blob/master/CHANGELOG.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="ParatextData" Version="9.1.5-beta" />
+    <PackageReference Include="ParatextData" Version="9.1.7-beta" />
     <PackageReference Include="SIL.Core" Version="8.0.0-beta0091" />
     <PackageReference Include="SIL.DblBundle" Version="8.0.0-beta0085" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.2.0" />

--- a/GlyssenEngineTests/GlyssenEngineTests.csproj
+++ b/GlyssenEngineTests/GlyssenEngineTests.csproj
@@ -70,14 +70,14 @@
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Paratext.LexicalContracts, Version=9.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
+    <Reference Include="Paratext.LexicalContracts, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/GlyssenEngineTests/packages.config
+++ b/GlyssenEngineTests/packages.config
@@ -22,7 +22,7 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net472" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net472" />
-  <package id="ParatextData" version="9.1.5-beta" targetFramework="net472" />
+  <package id="ParatextData" version="9.1.7-beta" targetFramework="net472" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net461" />
   <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.DblBundle" version="8.0.0-beta0085" targetFramework="net472" />

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -121,14 +121,14 @@
     <Reference Include="PangoSharp, Version=3.22.24.37, Culture=neutral, PublicKeyToken=313398f2149d753f, processorArchitecture=MSIL">
       <HintPath>..\packages\PangoSharp-signed.3.22.24.37\lib\netstandard2.0\PangoSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Paratext.LexicalContracts, Version=9.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
+    <Reference Include="Paratext.LexicalContracts, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -35,7 +35,7 @@
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net472" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.8.0" targetFramework="net461" />
   <package id="PangoSharp-signed" version="3.22.24.37" targetFramework="net472" />
-  <package id="ParatextData" version="9.1.5-beta" targetFramework="net472" />
+  <package id="ParatextData" version="9.1.7-beta" targetFramework="net472" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Core.Desktop" version="8.0.0-beta0085" targetFramework="net472" />

--- a/RefTextDevUtilities/RefTextDevUtilities.csproj
+++ b/RefTextDevUtilities/RefTextDevUtilities.csproj
@@ -65,14 +65,14 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Paratext.LexicalContracts, Version=9.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
+    <Reference Include="Paratext.LexicalContracts, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\Paratext.LexicalContracts.dll</HintPath>
     </Reference>
-    <Reference Include="ParatextData, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
+    <Reference Include="ParatextData, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\ParatextData.dll</HintPath>
     </Reference>
-    <Reference Include="PtxUtils, Version=9.1.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\ParatextData.9.1.5-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
+    <Reference Include="PtxUtils, Version=9.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ParatextData.9.1.7-beta\lib\netstandard2.0\PtxUtils.dll</HintPath>
     </Reference>
     <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
       <HintPath>..\packages\SIL.Core.8.0.0-beta0091\lib\net461\SIL.Core.dll</HintPath>

--- a/RefTextDevUtilities/packages.config
+++ b/RefTextDevUtilities/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Win32.SystemEvents" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Windows.Compatibility" version="3.1.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-  <package id="ParatextData" version="9.1.5-beta" targetFramework="net472" />
+  <package id="ParatextData" version="9.1.7-beta" targetFramework="net472" />
   <package id="SIL.Core" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.Scripture" version="8.0.0-beta0091" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="8.0.0-beta0085" targetFramework="net472" />


### PR DESCRIPTION
This change includes the CHANGELOG update and an upgrade to PartextDat 9.1.7-beta to resolve an issue with the Installer when upgrading from a previous version of Glyssen.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/688)
<!-- Reviewable:end -->
