### PR TITLE
Prevent creation of release packages on nuget whenever a PR is merged into master

### DIFF
--- a/GlyssenEngine/GitVersion.yml
+++ b/GlyssenEngine/GitVersion.yml
@@ -1,2 +1,7 @@
 # This overrides the assembly versioning scheme 
 assembly-versioning-scheme: MajorMinor
+# This makes untagged commits on master produce a beta, rather than a release
+branches:
+  master:
+    tag: beta
+    regex: (origin/)?master

--- a/GlyssenShared/GitVersion.yml
+++ b/GlyssenShared/GitVersion.yml
@@ -1,2 +1,7 @@
 # This overrides the assembly versioning scheme 
 assembly-versioning-scheme: MajorMinor
+# This makes untagged commits on master produce a beta, rather than a release
+branches:
+  master:
+    tag: beta
+    regex: (origin/)?master


### PR DESCRIPTION
We only want releases to be created when a commit is tagged with a version number. All others shoud be beta.
This approach might not be correct since gitversion CLI returns a warning about ambiguity between the base gitversion.yml file (in the solution dir) and the ones in the project folders. But it appears that (at least on Appveyor) the yml file in the project folder is the one that wins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/695)
<!-- Reviewable:end -->
