### PR TITLE
PG-1386: Handle case a versification mapping splits a verse across a chapter break…

### DIFF
--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -423,7 +423,8 @@ namespace GlyssenEngine
 						iRefBlock--;
 						continue;
 					default:
-						if (refInitStartVerse > vernInitStartVerse || currentVernBlock.MatchesReferenceText)
+						if ((refInitStartVerse > vernInitStartVerse && refInitStartVerse > currentVernBlock.EndRef(bookNum, vernacularVersification)) ||
+							currentVernBlock.MatchesReferenceText)
 						{
 							iRefBlock--;
 							continue;
@@ -473,9 +474,19 @@ namespace GlyssenEngine
 					}
 
 					// Since there's only one vernacular block for this verse (or verse bridge), just combine all
-					// ref blocks into one and call it a match.
-					vernBlockList[indexOfVernVerseStart].SetMatchedReferenceBlock(bookNum, vernacularVersification, this,
-						refBlockList.Skip(indexOfRefVerseStart).Take(numberOfRefBlocksInVerseChunk).ToList());
+					// ref blocks into one and call it a match unless the start verses don't match (in which case
+					// we're probably dealing with a mapping that involved a verse split).
+					var correspondingReferenceBlocks = refBlockList.Skip(indexOfRefVerseStart).Take(numberOfRefBlocksInVerseChunk).ToList();
+					if (refInitStartVerse.CompareTo(vernInitStartVerse) == 0)
+					{
+						currentVernBlock.SetMatchedReferenceBlock(bookNum, vernacularVersification, this,
+							correspondingReferenceBlocks);
+					}
+					else
+					{
+						currentVernBlock.SetUnmatchedReferenceBlocks(correspondingReferenceBlocks);
+					}
+
 					continue;
 				}
 

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -432,15 +432,12 @@ namespace GlyssenEngine
 						break;
 				}
 
-				var refLastVerse = currentRefBlock.EndRef(bookNum, Versification);
-
-				while (CharacterVerseData.IsCharacterExtraBiblical(currentRefBlock.CharacterId) || vernInitStartVerse > refLastVerse)
+				while (CharacterVerseData.IsCharacterExtraBiblical(currentRefBlock.CharacterId) || vernInitStartVerse > currentRefBlock.EndRef(bookNum, Versification))
 				{
 					iRefBlock++;
 					if (iRefBlock == refBlockList.Count)
 						return; // couldn't find a ref block to use at all.
 					currentRefBlock = refBlockList[iRefBlock];
-					refLastVerse = currentRefBlock.EndRef(bookNum, Versification);
 				}
 
 				var indexOfVernVerseStart = iVernBlock;
@@ -477,7 +474,7 @@ namespace GlyssenEngine
 					// ref blocks into one and call it a match unless the start verses don't match (in which case
 					// we're probably dealing with a mapping that involved a verse split).
 					var correspondingReferenceBlocks = refBlockList.Skip(indexOfRefVerseStart).Take(numberOfRefBlocksInVerseChunk).ToList();
-					if (refInitStartVerse.CompareTo(vernInitStartVerse) == 0)
+					if (correspondingReferenceBlocks.First().StartRef(bookNum, Versification).CompareTo(vernInitStartVerse) == 0)
 					{
 						currentVernBlock.SetMatchedReferenceBlock(bookNum, vernacularVersification, this,
 							correspondingReferenceBlocks);

--- a/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
+++ b/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
@@ -201,15 +201,27 @@ namespace GlyssenEngine.ViewModels
 		protected override void RelevantBlocksAdded(BookBlockIndices blocksAdded)
 		{
 			Debug.Assert(blocksAdded.BookIndex == BlockAccessor.GetIndices().BookIndex);
-			for (var i = blocksAdded.BlockIndex; i <= blocksAdded.EffectiveFinalBlockIndex; i++)
+			var completed = IsCurrentBookSingleVoice;
+			if (!completed)
 			{
-				var block = CurrentBook.GetScriptBlocks()[i];
-				if (block.UserConfirmed || IsCurrentBookSingleVoice)
+				for (var i = blocksAdded.BlockIndex; i <= blocksAdded.EffectiveFinalBlockIndex; i++)
 				{
-					CompletedBlockCount++;
-					Debug.Assert(CompletedBlockCount <= RelevantBlockCount);
-					return;
+					var block = CurrentBook.GetScriptBlocks()[i];
+					if (block.UserConfirmed)
+						completed = true;
+					else if (block.CharacterIsUnclear)
+					{
+						// This is not common, but it's possible for one or more blocks in matchup
+						// to be user-confirmed, while others are not. Probably because the user
+						// did some work in non-rainbow mode.
+						return;
+					}
 				}
+			}
+			if (completed)
+			{
+				CompletedBlockCount++;
+				Debug.Assert(CompletedBlockCount <= RelevantBlockCount);
 			}
 		}
 


### PR DESCRIPTION
…where the reference text has the first two verses in the chapter in a single block.

Also, tweaked code that counts the number of completed "relevant" blocks so that a matchup group does not get counted as completed if it contains any blocks that do not have a valid character set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/704)
<!-- Reviewable:end -->
