### PR TITLE
For Vessel: Ignore Hypothetical quotes types when reference text = null

### DIFF
--- a/GlyssenEngineTests/GlyssenEngineTests.csproj
+++ b/GlyssenEngineTests/GlyssenEngineTests.csproj
@@ -276,6 +276,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Quote\NewTestamentBooksFirstComparerTests.cs" />
+    <Compile Include="Quote\ParserCharacterRepositoryTests.cs" />
     <Compile Include="Quote\QuoteParserTests.cs" />
     <Compile Include="Quote\QuoteSystemGuesserTests.cs" />
     <Compile Include="Quote\QuoteSystemTests.cs" />

--- a/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
+++ b/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
@@ -9,6 +9,13 @@ namespace GlyssenEngineTests.Quote
 	[TestFixture]
 	public class ParserCharacterRepositoryTests
 	{
+		[OneTimeSetUp]
+		public void OneTimeSetUp()
+		{
+			// Use a test version of the file so the tests won't break every time we fix a problem in the production control file.
+			ControlCharacterVerseData.TabDelimitedCharacterVerseData = Properties.Resources.TestCharacterVerseOct2015;
+		}
+
 		[TestCase(19, 10, "6", "man, wicked")]
 		[TestCase(40, 7, "8", "Jesus")]
 		public void ParserCharacterRepository_ReferenceTextIsNull_ReturnsSingleCharacterForVerse(int book, int chapter, string verse, string expectedCharacter)
@@ -25,11 +32,11 @@ namespace GlyssenEngineTests.Quote
 		{
 			var cvRepo = new ParserCharacterRepository(ControlCharacterVerseData.Singleton, null);
 
-			var characters = cvRepo.GetCharacters(45, 2, new Verse("17"));
+			var characters = cvRepo.GetCharacters(44, 8, new Verse("37"));
 
 			Assert.True(characters.Count == 2);
-			Assert.That(characters.Any(i => i.Character == "narrator-ROM"));
-			Assert.That(characters.Any(i => i.Character == "you (hypothetical)"));
+			Assert.That(characters.Any(i => i.Character == "Ethiopian officer of Queen Candace"));
+			Assert.That(characters.Any(i => i.Character == "Philip the evangelist"));
 		}
 	}
 }

--- a/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
+++ b/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
@@ -28,12 +28,8 @@ namespace GlyssenEngineTests.Quote
 			var characters = cvRepo.GetCharacters(45, 2, new Verse("17"));
 
 			Assert.True(characters.Count == 2);
-			var firstCharacter = characters.First().ToString();
-			var lastCharacter = characters.Last().ToString();
-
-			Assert.True(firstCharacter != lastCharacter);
-			Assert.True(firstCharacter == "narrator-ROM" || lastCharacter == "narrator-ROM");
-			Assert.True(firstCharacter == "you (hypothetical)" || lastCharacter == "you (hypothetical)");
+			Assert.That(characters.Any(i => i.Character == "narrator-ROM"));
+			Assert.That(characters.Any(i => i.Character == "you (hypothetical)"));
 		}
 	}
 }

--- a/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
+++ b/GlyssenEngineTests/Quote/ParserCharacterRepositoryTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using Glyssen.Shared;
+using GlyssenEngine.Character;
+using GlyssenEngine.Quote;
+using NUnit.Framework;
+
+namespace GlyssenEngineTests.Quote
+{
+	[TestFixture]
+	public class ParserCharacterRepositoryTests
+	{
+		[TestCase(19, 10, "6", "man, wicked")]
+		[TestCase(40, 7, "8", "Jesus")]
+		public void ParserCharacterRepository_ReferenceTextIsNull_ReturnsSingleCharacterForVerse(int book, int chapter, string verse, string expectedCharacter)
+		{
+			var cvRepo = new ParserCharacterRepository(ControlCharacterVerseData.Singleton, null);
+
+			var characters = cvRepo.GetCharacters(book, chapter, new Verse(verse));
+
+			Assert.AreEqual(expectedCharacter, characters.Single().ToString());
+		}
+
+		[Test]
+		public void ParserCharacterRepository_ReferenceTextIsNull_ReturnsMultipleCharactersForVerse()
+		{
+			var cvRepo = new ParserCharacterRepository(ControlCharacterVerseData.Singleton, null);
+
+			var characters = cvRepo.GetCharacters(45, 2, new Verse("17"));
+
+			Assert.True(characters.Count == 2);
+			var firstCharacter = characters.First().ToString();
+			var lastCharacter = characters.Last().ToString();
+
+			Assert.True(firstCharacter != lastCharacter);
+			Assert.True(firstCharacter == "narrator-ROM" || lastCharacter == "narrator-ROM");
+			Assert.True(firstCharacter == "you (hypothetical)" || lastCharacter == "you (hypothetical)");
+		}
+	}
+}


### PR DESCRIPTION
Ignore Hypothetical quotes types when the reference text is unavailable. This was done because Vessel does not assign a reference text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/716)
<!-- Reviewable:end -->
