### PR TITLE
PG-1404: Prevent crash switching to Select Character mode when matchup's first block is not relevant

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -420,9 +420,8 @@ namespace Glyssen.Dialogs
 		private IEnumerable<int> GetColumnsIntoWhichHeSaidCanBeInserted(DataGridViewRow row)
 		{
 			var matchup = m_viewModel.CurrentReferenceTextMatchup;
-			if (row != null && matchup != null && (matchup.CorrelatedBlocks[row.Index].
-					CharacterIs(m_viewModel.CurrentBookId, CharacterVerseData.StandardCharacter.Narrator) ||
-				matchup.CorrelatedBlocks[row.Index].CharacterId == CharacterVerseData.kUnexpectedCharacter))
+			if (row != null && matchup != null &&
+				matchup.CorrelatedBlocks[row.Index].IsNarratorOrPotentialNarrator(m_viewModel.CurrentBookId))
 			{
 				if (Block.IsEmptyVerseReferenceText(row.Cells[colEnglish.Index].Value as string))
 					yield return colEnglish.Index;

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -380,6 +380,12 @@ namespace GlyssenEngine.Script
 			{
 				return false;
 			}
+			if (!CharacterVerseData.IsCharacterOfType(CharacterId, CharacterVerseData.StandardCharacter.Narrator))
+			{
+				if (CharacterId != CharacterVerseData.kNeedsReview)
+					return false;
+				CharacterId = CharacterVerseData.GetStandardCharacterId(BCVRef.NumberToBookCode(bookNum), CharacterVerseData.StandardCharacter.Narrator);
+			}
 
 			SetMatchedReferenceBlock(referenceText.HeSaidText);
 			var verse = BlockElements.First() as Verse;

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -808,12 +808,7 @@ namespace GlyssenEngine.Script
 
 		public bool IsNarratorOrPotentialNarrator(string bookId) =>
 			CharacterIs(bookId, CharacterVerseData.StandardCharacter.Narrator) ||
-			CharacterId == CharacterVerseData.kNeedsReview ||
-			// REVIEW: Is this is right? This came from AssignCharacterDlg.GetColumnsIntoWhichHeSaidCanBeInserted.
-			// The other (similar) version of it was in BlockMatchup.InsertHeSaidText. That version also allowed
-			// the ambiguous character. Either way, those characters don't seem like likely candidates for narrator
-			// since Glyssen thought the block was a speaking character.
-			CharacterId == CharacterVerseData.kUnexpectedCharacter;
+			CharacterId == CharacterVerseData.kNeedsReview;
 
 		public bool IsQuoteStart => IsQuote && !IsContinuationOfPreviousBlockQuote;
 

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -373,6 +373,29 @@ namespace GlyssenEngine.Script
 
 		public int CountOfSoundsWhereUserSpecifiesLocation => BlockElements.OfType<Sound>().Count(s => s.UserSpecifiesLocation);
 
+		/// <summary>
+		/// If this block is a narrator block or is marked as "Needs Review" and it has a single
+		/// text element (i.e., covers no more than one verse/bridge) and the text matches on of
+		/// the known reporting clauses for the vernacular, the block will be matched to a newly
+		/// created reference text block (including in the secondary reference language) with
+		/// appropriately corresponding verse number(s) if present in this block, shifted as
+		/// needed by the versification mapping. If this block is marked as "Needs Review", an
+		/// additional side-effect will be that the block's CharacterID is changed to narrator,
+		/// since it is nonsensical to have a reporting clause spoken by any other character.
+		/// </summary>
+		/// <param name="reportingClauses">collection of known reporting clauses (aka, "he said"s)
+		/// for the vernacular</param>
+		/// <param name="referenceText">The primary reference text in use for the project to which
+		/// this block belongs</param>
+		/// <param name="bookNum">The 1-based number of the Scripture book to which this block
+		/// belongs</param>
+		/// <param name="vernacularVersification">The versification in use for the project to which
+		/// this block belongs</param>
+		/// <returns><c>true</c> if the block was found to be a reporting clause; <c>false</c>
+		/// otherwise</returns>
+		/// <remarks>This method should probably not be called on a block that is part of the
+		/// permanent project data (i.e., is not cloned) because it can have side-effects that
+		/// that the user might actually wish to review.</remarks>
 		public bool TryMatchToReportingClause(IReadOnlyCollection<string> reportingClauses, ReferenceText referenceText, int bookNum, ScrVers vernacularVersification)
 		{
 			if (MatchesReferenceText || reportingClauses == null ||
@@ -390,7 +413,11 @@ namespace GlyssenEngine.Script
 			SetMatchedReferenceBlock(referenceText.HeSaidText);
 			var verse = BlockElements.First() as Verse;
 			string verseNumberToInsert = verse?.Number;
-			// ENHANCE: convert the vernacular verse number into the versification of the reference text(s).
+			
+			// ENHANCE: Even if no verse number is present, the reference text blocks should have
+			// their InitialStartVerseNumber and InitialEndVerseNumber fields set according to the
+			// versification. (At this time, I don't think those are ever used, so it's not a big
+			// deal.)
 			if (verse != null)
 			{
 				if (vernacularVersification != referenceText.Versification)

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -806,6 +806,15 @@ namespace GlyssenEngine.Script
 			get { return !CharacterVerseData.IsCharacterStandard(CharacterId) || UserConfirmed; }
 		}
 
+		public bool IsNarratorOrPotentialNarrator(string bookId) =>
+			CharacterIs(bookId, CharacterVerseData.StandardCharacter.Narrator) ||
+			CharacterId == CharacterVerseData.kNeedsReview ||
+			// REVIEW: Is this is right? This came from AssignCharacterDlg.GetColumnsIntoWhichHeSaidCanBeInserted.
+			// The other (similar) version of it was in BlockMatchup.InsertHeSaidText. That version also allowed
+			// the ambiguous character. Either way, those characters don't seem like likely candidates for narrator
+			// since Glyssen thought the block was a speaking character.
+			CharacterId == CharacterVerseData.kUnexpectedCharacter;
+
 		public bool IsQuoteStart => IsQuote && !IsContinuationOfPreviousBlockQuote;
 
 		/// <summary>

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -405,7 +405,7 @@ namespace GlyssenEngine.Script
 				if (existingEmptyVerseRefText != null)
 				{
 					var narrator = CharacterVerseData.GetStandardCharacterId(BookId, CharacterVerseData.StandardCharacter.Narrator);
-					if (block.CharacterIsUnclear)
+					if (block.CharacterId != narrator)
 						block.SetNonDramaticCharacterId(narrator);
 					// Deal with following blocks in quote block chain (and mark this one None).
 					if (block.MultiBlockQuote == MultiBlockQuote.Start)
@@ -419,7 +419,7 @@ namespace GlyssenEngine.Script
 							// It's probably impossible in practice, but if this block has a character other than narrator already set,
 							// let's leave it as is. And, of course, if it's already explicitly set to narrator, then there's nothing to
 							// do.
-							if (contBlock.CharacterIsUnclear)
+							if (contBlock.CharacterId == CharacterVerseData.kNeedsReview)
 							{
 								// By far the common case will be that this block will be associated with a reference
 								// block that has a real character ID. If so, we'll use that ID, even if it's not
@@ -431,7 +431,8 @@ namespace GlyssenEngine.Script
 								// we need to fire the handler to alert the client.
 								var dataChange = false;
 								var newCharacterId = contBlock.ReferenceBlocks.SingleOrDefault()?.CharacterId;
-								if (CharacterVerseData.IsCharacterUnclear(newCharacterId))
+								if (newCharacterId == CharacterVerseData.kNeedsReview ||
+									CharacterVerseData.IsCharacterUnclear(newCharacterId))
 								{
 									newCharacterId = narrator;
 									dataChange = true;

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -399,8 +399,7 @@ namespace GlyssenEngine.Script
 		private void InsertHeSaidText(IReferenceLanguageInfo referenceLanguageInfo, int i, Action<int, int, string> handleHeSaidInserted, int level = 0)
 		{
 			var block = CorrelatedBlocks[i];
-			if (block.CharacterIs(BookId, CharacterVerseData.StandardCharacter.Narrator) ||
-				block.CharacterIsUnclear)
+			if (block.IsNarratorOrPotentialNarrator(BookId))
 			{
 				var existingEmptyVerseRefText = block.GetEmptyVerseReferenceTextAtDepth(level);
 				if (existingEmptyVerseRefText != null)

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -317,9 +317,9 @@ namespace GlyssenEngine.ViewModels
 						var indices = new BookBlockIndices(m_temporarilyIncludedBookBlockIndices.BookIndex, m_temporarilyIncludedBookBlockIndices.BlockIndex);
 						for (var iBlock = 0; iBlock < m_temporarilyIncludedBookBlockIndices.MultiBlockCount; iBlock++)
 						{
-							indices.BlockIndex++;
 							if (SetAsCurrentLocationIfRelevant(indices))
 								return; // This can happen, for example if we're switching out of rainbow mode and going from a previously relevant matchup to a single relevant block within it.
+							indices.BlockIndex++;
 						}
 					}
 					if (stayOnCurrentBlock)

--- a/GlyssenEngineTests/ReferenceTextTests.cs
+++ b/GlyssenEngineTests/ReferenceTextTests.cs
@@ -4382,16 +4382,23 @@ namespace GlyssenEngineTests
 		}
 		#endregion
 
-		#region PG-1395 (modified for PG-1396)
-		[Test]
-		public void GetBlocksForVerseMatchedToReferenceText_ReportingClausesComeAfterSpeechhLinesInVerseWithMultipleSpeakers_AllBlocksMatchedWithReportingClausesMatchedToModifiedReportingClauses()
+		#region PG-1395 (modified for PG-1396 and PG-1403)
+		[TestCase(false)]
+		[TestCase(true)]
+		public void GetBlocksForVerseMatchedToReferenceText_ReportingClausesComeAfterSpeechLinesInVerseWithMultipleSpeakers_AllBlocksMatchedWithReportingClausesMatchedToModifiedReportingClauses(
+			bool blockIsNeedsReview)
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(CreateBlockForVerse("Jesus", 31, "Кьве хцикай бубадин тӀалабун ни кьилиз акъудна?» ", false, 21));
 			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kAmbiguousCharacter, "«Сад лагьайда», ");
-			AddNarratorBlockForVerseInProgress(vernacularBlocks, "– жаваб гана абуру. ");
+			var heSaidBlock = AddNarratorBlockForVerseInProgress(vernacularBlocks, "– жаваб гана абуру. ");
+			var narrator = heSaidBlock.CharacterId;
+			if (blockIsNeedsReview)
+				heSaidBlock.CharacterId = CharacterVerseData.kNeedsReview;
 			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kAmbiguousCharacter, "«За квез рикӀивай лугьузва: харж кӀватӀдайбурни ява папар Аллагьдин Пачагьлугъдиз квелай вилик акъатда», ");
-			AddNarratorBlockForVerseInProgress(vernacularBlocks, "– лагьана Исади. – ");
+			heSaidBlock = AddNarratorBlockForVerseInProgress(vernacularBlocks, "– лагьана Исади. – ");
+			if (blockIsNeedsReview)
+				heSaidBlock.CharacterId = CharacterVerseData.kNeedsReview;
 			var vernBook = new BookScript("MAT", vernacularBlocks, m_vernVersification);
 
 			var refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
@@ -4416,8 +4423,10 @@ namespace GlyssenEngineTests
 			Assert.AreEqual(refTextBlocks[0].GetText(true), textOfMatchedRefTextBlocks[0]);
 			Assert.AreEqual(refTextBlocks[2].GetText(true), textOfMatchedRefTextBlocks[1]);
 			Assert.AreEqual(refTextBlocks[1].GetText(true).ToLower().Replace(",", "."), textOfMatchedRefTextBlocks[2].ToLower());
+			Assert.AreEqual(narrator, result[2].CharacterId);
 			Assert.AreEqual(refTextBlocks[4].GetText(true), textOfMatchedRefTextBlocks[3]);
 			Assert.AreEqual(refTextBlocks[3].GetText(true).ToLower().Replace(",", "."), textOfMatchedRefTextBlocks[4].ToLower());
+			Assert.AreEqual(narrator, result[4].CharacterId);
 		}
 		#endregion
 

--- a/GlyssenEngineTests/Script/BlockMatchupTests.cs
+++ b/GlyssenEngineTests/Script/BlockMatchupTests.cs
@@ -12,7 +12,7 @@ using SIL.Scripture;
 namespace GlyssenEngineTests.Script
 {
 	[TestFixture]
-	class BlockMatchupTests
+	public class BlockMatchupTests
 	{
 		[TearDown]
 		public void Teardown()
@@ -1481,7 +1481,7 @@ namespace GlyssenEngineTests.Script
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "Este es versiculo dos y tres, ", true, 1, "p", 3));
-			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kUnexpectedCharacter, "dijo Jesus. ");
+			ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kNeedsReview, "dijo Jesus. ");
 			var vernBook = new BookScript("MAT", vernacularBlocks, ScrVers.English);
 			var matchup = new BlockMatchup(vernBook, 0, null, i => true, ReferenceText.GetStandardReferenceText(ReferenceTextType.English));
 			matchup.MatchAllBlocks();
@@ -1630,12 +1630,11 @@ namespace GlyssenEngineTests.Script
 			Assert.IsFalse(matchup.CorrelatedBlocks[2].MatchesReferenceText);
 		}
 
-		[TestCase(CharacterVerseData.kUnexpectedCharacter, null)]
-		[TestCase(CharacterVerseData.kAmbiguousCharacter, null)]
-		[TestCase(CharacterVerseData.kUnexpectedCharacter, "Andrew")]
-		[TestCase(CharacterVerseData.kAmbiguousCharacter, "Andrew")]
-		public void InsertHeSaidText_EmptyRowsAreStartOfMultiBlockQuote_HeSaidInsertedIntoEmptyRefTextsAndBlockChainBroken(string origCharacter, string refTextCharacter)
+		[TestCase(null)]
+		[TestCase("Andrew")]
+		public void InsertHeSaidText_EmptyRowsAreStartOfMultiBlockQuote_HeSaidInsertedIntoEmptyRefTextsAndBlockChainBroken(string refTextCharacter)
 		{
+			string origCharacter = CharacterVerseData.kNeedsReview;
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "After these things, Jesus taught them, saying: ", true));
 			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“Tio estas verso du,” "));
@@ -1718,18 +1717,17 @@ namespace GlyssenEngineTests.Script
 			Assert.AreEqual(MultiBlockQuote.None, matchup.CorrelatedBlocks.Last().MultiBlockQuote);
 		}
 
-		[TestCase(CharacterVerseData.kUnexpectedCharacter)]
-		[TestCase(CharacterVerseData.kAmbiguousCharacter)]
-		public void InsertHeSaidText_EmptyRowsAreStartOfMultiBlockQuote_ContBlocksNotAlignedToRefText_HeSaidInsertedIntoEmptyRefTextsAndContBlocksSetToNarrator(string origCharacter)
+		[Test]
+		public void InsertHeSaidText_EmptyRowsAreStartOfMultiBlockQuote_ContBlocksNotAlignedToRefText_HeSaidInsertedIntoEmptyRefTextsAndContBlocksSetToNarrator()
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(ReferenceTextTests.CreateNarratorBlockForVerse(1, "Después de estas cosas, Jesús les enseño, diciendo: ", true));
 			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse("Jesus", 2, "“Tio estas verso du,” "));
-			var vernJesusSaidBlock = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, origCharacter, "diris Jesuo. Etcetera. ");
+			var vernJesusSaidBlock = ReferenceTextTests.AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kNeedsReview, "diris Jesuo. Etcetera. ");
 			vernJesusSaidBlock.MultiBlockQuote = MultiBlockQuote.Start;
-			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(origCharacter, 3, "This is actually spoken by the narrator but was originally parsed as quoted speech. "));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kNeedsReview, 3, "This is actually spoken by the narrator but was originally parsed as quoted speech. "));
 			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
-			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(origCharacter, 4, "And this is the rest of the narrator's mumblings."));
+			vernacularBlocks.Add(ReferenceTextTests.CreateBlockForVerse(CharacterVerseData.kNeedsReview, 4, "And this is the rest of the narrator's mumblings."));
 			vernacularBlocks.Last().MultiBlockQuote = MultiBlockQuote.Continuation;
 			var narrator = ReferenceTextTests.AddNarratorBlockForVerseInProgress(vernacularBlocks,
 				"Luego sucedió la próxima cosa.").CharacterId;

--- a/GlyssenEngineTests/Script/BlockTests.cs
+++ b/GlyssenEngineTests/Script/BlockTests.cs
@@ -1788,6 +1788,60 @@ namespace GlyssenEngineTests.Script
 			Assert.Null(block.GetNextInterruption(interruptionFinderForQuoteSystemWithLongDashDialogueQuotes));
 		}
 
+		[TestCase(CharacterVerseData.kAmbiguousCharacter)]
+		[TestCase(CharacterVerseData.kUnexpectedCharacter)]
+		public void TryMatchToReportingClause_BlockCharacterIsUnclear_ReturnsFalse(string character)
+		{
+			var block = new Block("p", 1, 2)
+			{
+				CharacterId = character,
+				BookCode = "MAT",
+				BlockElements =
+				{
+					new Verse("2"),
+					new ScriptText("el dijo"),
+				}
+			};
+			Assert.IsFalse(block.TryMatchToReportingClause(new []{"el dijo"}, ReferenceText.GetStandardReferenceText(ReferenceTextType.English),
+				40, ScrVers.English));
+		}
+
+		[Test]
+		public void TryMatchToReportingClause_BlockCharacterIsNarrator_ReturnsTrue()
+		{
+			var block = new Block("p", 1, 2)
+			{
+				CharacterId = CharacterVerseData.GetStandardCharacterId("MAT", StandardCharacter.Narrator),
+				BookCode = "MAT",
+				BlockElements =
+				{
+					new Verse("2"),
+					new ScriptText("el dijo"),
+				}
+			};
+			Assert.IsTrue(block.TryMatchToReportingClause(new []{"el dijo"}, ReferenceText.GetStandardReferenceText(ReferenceTextType.English),
+				40, ScrVers.English));
+		}
+
+		[Test]
+		public void TryMatchToReportingClause_BlockCharacterIsNeedsReview_ReturnsTrue()
+		{
+			var block = new Block("p", 1, 2)
+			{
+				CharacterId = CharacterVerseData.kNeedsReview,
+				BookCode = "MAT",
+				BlockElements =
+				{
+					new Verse("2"),
+					new ScriptText("el dijo"),
+				}
+			};
+			Assert.IsTrue(block.TryMatchToReportingClause(new []{"el dijo"}, ReferenceText.GetStandardReferenceText(ReferenceTextType.English),
+				40, ScrVers.English));
+			Assert.AreEqual(CharacterVerseData.GetStandardCharacterId("MAT", StandardCharacter.Narrator),
+				block.CharacterId);
+		}
+
 		private Block GetBlockWithText(string text)
 		{
 			return new Block("p", 1, 1)

--- a/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
@@ -742,12 +742,39 @@ namespace GlyssenEngineTests.ViewModelTests
 		}
 
 		[Test]
-		public void AttemptRefBlockMatchup_SetToFalse_ClearsCurrentReferenceTextMatchup()
+		public void AttemptRefBlockMatchup_SetToFalseWithMatchupHavingSubsequentBlockRelevant_ClearsCurrentReferenceTextMatchupAndSetsFirstRelevantBlockInMatchupAsCurrent()
 		{
 			m_model.SetMode(m_model.Mode, true);
 			FindRefInMark(8, 5);
+			Block expectedBlock = null;
+			var markBlocks = m_testProject.IncludedBooks.Single(b => b.BookId == m_model.CurrentBookId).GetScriptBlocks();
+			for (int i = m_model.IndexOfFirstBlockInCurrentGroup; i < m_model.IndexOfLastBlockInCurrentGroup; i++)
+			{
+				if (markBlocks[i].CharacterIsUnclear)
+				{
+					expectedBlock = markBlocks[i];
+					break;
+				}
+			}
+			Assert.IsNotNull(expectedBlock);
 			m_model.SetMode(m_model.Mode, false);
 			Assert.IsNull(m_model.CurrentReferenceTextMatchup);
+			Assert.AreEqual(expectedBlock, m_model.CurrentBlock);
+		}
+
+		[Test]
+		public void AttemptRefBlockMatchup_SetToFalseWithMatchupHavingFirstBlockRelevant_ClearsCurrentReferenceTextMatchupAndSetsFirstBlockInMatchupAsCurrent()
+		{
+			m_model.SetMode(BlocksToDisplay.AllScripture, true);
+			while (m_model.CurrentReferenceTextMatchup.OriginalBlockCount == 1 && m_model.CanNavigateToNextRelevantBlock)
+				m_model.LoadNextRelevantBlock();
+			Assert.That(m_model.CurrentReferenceTextMatchup.OriginalBlockCount > 1,
+				"SETUP error: No suitable block found.");
+
+			var expectedBlock = m_model.IndexOfFirstBlockInCurrentGroup;
+			m_model.SetMode(BlocksToDisplay.AllScripture, false);
+			Assert.IsNull(m_model.CurrentReferenceTextMatchup);
+			Assert.AreEqual(expectedBlock, m_model.CurrentBlockIndexInBook);
 		}
 
 		[Test]


### PR DESCRIPTION
Note: this might also solve PG-1403

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/723)
<!-- Reviewable:end -->
