### PR TITLE
Added a narrow no-break space (U+202F) between adjacent quote marks

### DIFF
--- a/DistFiles/reference_texts/English/1CH.xml
+++ b/DistFiles/reference_texts/English/1CH.xml
@@ -1552,7 +1552,7 @@
   </block>
   <block style="p" chapter="11" initialStartVerse="2" characterId="Israel, all">
     <verse num="2" />
-    <text>In times past, even when Saul was king, it was you who led out and brought in Israel. God your God said to you, ‹You shall be shepherd of my people Israel, and you shall be prince over my people Israel.› »</text>
+    <text>In times past, even when Saul was king, it was you who led out and brought in Israel. God your God said to you, ‹You shall be shepherd of my people Israel, and you shall be prince over my people Israel.› »</text>
   </block>
   <block style="p" chapter="11" initialStartVerse="3" characterId="narrator-1CH">
     <verse num="3" />
@@ -2335,7 +2335,7 @@
   </block>
   <block style="p" chapter="17" initialStartVerse="6" characterId="God">
     <verse num="6" />
-    <text>In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‹Why have you not built me a house of cedar?› » ›</text>
+    <text>In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‹Why have you not built me a house of cedar?› » ›</text>
   </block>
   <block style="p" chapter="17" initialStartVerse="7" characterId="God">
     <verse num="7" />
@@ -2365,7 +2365,7 @@
   </block>
   <block style="p" chapter="17" initialStartVerse="14" characterId="God">
     <verse num="14" />
-    <text>but I will settle him in my house and in my kingdom forever. His throne shall be established forever.» › »</text>
+    <text>but I will settle him in my house and in my kingdom forever. His throne shall be established forever.» › »</text>
   </block>
   <block style="p" chapter="17" initialStartVerse="15" characterId="narrator-1CH">
     <verse num="15" />
@@ -2665,7 +2665,7 @@
   <block style="p" chapter="21" initialStartVerse="11" characterId="Gad the prophet, David's seer">
     <text>«Thus says God, ‹Take your choice: </text>
     <verse num="12" />
-    <text>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days the sword of God, even pestilence in the land, and the angel of God destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.› »</text>
+    <text>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days the sword of God, even pestilence in the land, and the angel of God destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.› »</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="13" characterId="narrator-1CH">
     <verse num="13" />

--- a/DistFiles/reference_texts/English/1KI.xml
+++ b/DistFiles/reference_texts/English/1KI.xml
@@ -245,7 +245,7 @@
   </block>
   <block style="p" chapter="1" initialStartVerse="48" characterId="Jonathan, son of Abiathar">
     <verse num="48" />
-    <text>Also thus said the king, ‹Blessed be God, the God of Israel, who has given one to sit on my throne this day, my eyes even seeing it.› »</text>
+    <text>Also thus said the king, ‹Blessed be God, the God of Israel, who has given one to sit on my throne this day, my eyes even seeing it.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="49" characterId="narrator-1KI">
     <verse num="49" />
@@ -258,7 +258,7 @@
     <text>It was told Solomon, saying,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="51" characterId="informer">
-    <text>«Behold, Adonijah fears king Solomon; for, behold, he has laid hold on the horns of the altar, saying, ‹Let king Solomon swear to me first that he will not kill his servant with the sword.› »</text>
+    <text>«Behold, Adonijah fears king Solomon; for, behold, he has laid hold on the horns of the altar, saying, ‹Let king Solomon swear to me first that he will not kill his servant with the sword.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="52" characterId="narrator-1KI">
     <verse num="52" />
@@ -457,7 +457,7 @@
     <text>Benaiah came to the Tent of God, and said to him,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="30" characterId="Benaiah, son of Jehoiada">
-    <text>«Thus says the king, ‹Come forth!› »</text>
+    <text>«Thus says the king, ‹Come forth!› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="30" characterId="narrator-1KI">
     <text>He said,</text>
@@ -668,7 +668,7 @@
     <text>Then the king said,</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="23" characterId="Solomon, king">
-    <text>«The one says, ‹This is my son who lives, and your son is the dead;› and the other says, ‹No; but your son is the dead one, and my son is the living one.› »</text>
+    <text>«The one says, ‹This is my son who lives, and your son is the dead;› and the other says, ‹No; but your son is the dead one, and my son is the living one.› »</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="24" characterId="narrator-1KI">
     <verse num="24" />
@@ -1589,7 +1589,7 @@
   </block>
   <block style="p" chapter="9" initialStartVerse="9" characterId="God">
     <verse num="9" />
-    <text>and they shall answer, ‹Because they forsook God their God, who brought forth their fathers out of the land of Egypt, and laid hold of other gods, and worshiped them, and served them. Therefore God has brought all this evil on them.› »</text>
+    <text>and they shall answer, ‹Because they forsook God their God, who brought forth their fathers out of the land of Egypt, and laid hold of other gods, and worshiped them, and served them. Therefore God has brought all this evil on them.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="10" characterId="narrator-1KI">
     <verse num="10" />
@@ -2024,7 +2024,7 @@
     <text>He said to them,</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="9" characterId="Rehoboam, king">
-    <text>«What counsel do you give, that we may return answer to this people, who have spoken to me, saying, ‹Make the yoke that your father did put on us lighter?› »</text>
+    <text>«What counsel do you give, that we may return answer to this people, who have spoken to me, saying, ‹Make the yoke that your father did put on us lighter?› »</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="10" characterId="narrator-1KI">
     <verse num="10" />
@@ -2035,7 +2035,7 @@
   </block>
   <block style="p" chapter="12" initialStartVerse="11" characterId="young men (advisors of Rehoboam)">
     <verse num="11" />
-    <text>Now whereas my father burdened you with a heavy yoke, I will add to your yoke: my father chastised you with whips, but I will chastise you with scorpions.› »</text>
+    <text>Now whereas my father burdened you with a heavy yoke, I will add to your yoke: my father chastised you with whips, but I will chastise you with scorpions.› »</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="12" characterId="narrator-1KI">
     <verse num="12" />
@@ -2142,7 +2142,7 @@
     <text>He cried against the altar by the word of God, and said,</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="2" characterId="man of God from Judah">
-    <text>«Altar, altar, thus says God: ‹Behold, a son shall be born to the house of David, Josiah by name. On you he shall sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.› »</text>
+    <text>«Altar, altar, thus says God: ‹Behold, a son shall be born to the house of David, Josiah by name. On you he shall sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="3" characterId="narrator-1KI">
     <verse num="3" />
@@ -2187,7 +2187,7 @@
   </block>
   <block style="p" chapter="13" initialStartVerse="9" characterId="man of God from Judah">
     <verse num="9" />
-    <text>for so was it commanded me by the word of God, saying, ‹You shall eat no bread, nor drink water, neither return by the way that you came.› »</text>
+    <text>for so was it commanded me by the word of God, saying, ‹You shall eat no bread, nor drink water, neither return by the way that you came.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="10" characterId="narrator-1KI">
     <verse num="10" />
@@ -2240,14 +2240,14 @@
   </block>
   <block style="p" chapter="13" initialStartVerse="17" characterId="man of God from Judah">
     <verse num="17" />
-    <text>For it was said to me by the word of God, ‹You shall eat no bread nor drink water there, nor turn again to go by the way that you came.› »</text>
+    <text>For it was said to me by the word of God, ‹You shall eat no bread nor drink water there, nor turn again to go by the way that you came.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="18" characterId="narrator-1KI">
     <verse num="18" />
     <text>He said to him,</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="18" characterId="old prophet in Bethel" delivery="deceitful">
-    <text>«I also am a prophet as you are; and an angel spoke to me by the word of God, saying, ‹Bring him back with you into your house, that he may eat bread and drink water.› »</text>
+    <text>«I also am a prophet as you are; and an angel spoke to me by the word of God, saying, ‹Bring him back with you into your house, that he may eat bread and drink water.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="18" characterId="narrator-1KI">
     <text>He lied to him. </text>
@@ -2263,7 +2263,7 @@
   <block style="p" chapter="13" initialStartVerse="21" characterId="old prophet in Bethel">
     <text>«Thus says God, ‹Because you have been disobedient to the mouth of God, and have not kept the commandment which God your God commanded you, </text>
     <verse num="22" />
-    <text>but came back, and have eaten bread and drunk water in the place of which he said to you, «Eat no bread, and drink no water;» your body shall not come to the tomb of your fathers.› »</text>
+    <text>but came back, and have eaten bread and drunk water in the place of which he said to you, «Eat no bread, and drink no water;» your body shall not come to the tomb of your fathers.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="23" characterId="narrator-1KI">
     <verse num="23" />
@@ -2804,7 +2804,7 @@
   </block>
   <block style="p" chapter="17" initialStartVerse="14" characterId="Elijah">
     <verse num="14" />
-    <text>For thus says God, the God of Israel, ‹The jar of meal shall not empty, neither shall the jar of oil fail, until the day that God sends rain on the earth.› »</text>
+    <text>For thus says God, the God of Israel, ‹The jar of meal shall not empty, neither shall the jar of oil fail, until the day that God sends rain on the earth.› »</text>
   </block>
   <block style="p" chapter="17" initialStartVerse="15" characterId="narrator-1KI">
     <verse num="15" />
@@ -2906,7 +2906,7 @@
     <text>He answered him,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="8" characterId="Elijah">
-    <text>«It is I. Go, tell your lord, ‹Behold, Elijah is here!› »</text>
+    <text>«It is I. Go, tell your lord, ‹Behold, Elijah is here!› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="9" characterId="narrator-1KI">
     <verse num="9" />
@@ -3140,7 +3140,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="44" characterId="Elijah">
-    <text>«Go up, tell Ahab, ‹Get ready and go down, so that the rain doesn’t stop you.› »</text>
+    <text>«Go up, tell Ahab, ‹Get ready and go down, so that the rain doesn’t stop you.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="45" characterId="narrator-1KI">
     <verse num="45" />
@@ -3291,7 +3291,7 @@
   <block style="p" chapter="20" initialStartVerse="2" characterId="messengers of Ben-Hadad, king of Aram">
     <text>«Thus says Ben Hadad, </text>
     <verse num="3" />
-    <text>Your silver and your gold is mine. Your wives also and your children, even the best, are mine.› »</text>
+    <text>Your silver and your gold is mine. Your wives also and your children, even the best, are mine.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="4" characterId="narrator-1KI">
     <verse num="4" />
@@ -3330,7 +3330,7 @@
     <text>Therefore he said to the messengers of Ben Hadad,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="9" characterId="Ahab, king of Israel">
-    <text>«Tell my lord the king, ‹All that you sent for to your servant at the first I will do; but this thing I cannot do.› »</text>
+    <text>«Tell my lord the king, ‹All that you sent for to your servant at the first I will do; but this thing I cannot do.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="9" characterId="narrator-1KI">
     <text>The messengers departed, and brought him back the message. </text>
@@ -3345,7 +3345,7 @@
     <text>The king of Israel answered,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="11" characterId="Ahab, king of Israel">
-    <text>«Tell him, ‹Don’t let him who puts on his armor brag like he who takes it off.› »</text>
+    <text>«Tell him, ‹Don’t let him who puts on his armor brag like he who takes it off.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="12" characterId="narrator-1KI">
     <verse num="12" />
@@ -3360,7 +3360,7 @@
     <text>Behold, a prophet came near to Ahab king of Israel, and said,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="13" characterId="prophet of the LORD">
-    <text>«Thus says God, ‹Have you seen all this great multitude? Behold, I will deliver it into your hand this day; and you shall know that I am God.› »</text>
+    <text>«Thus says God, ‹Have you seen all this great multitude? Behold, I will deliver it into your hand this day; and you shall know that I am God.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="14" characterId="narrator-1KI">
     <verse num="14" />
@@ -3373,7 +3373,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="14" characterId="prophet of the LORD">
-    <text>«Thus says God, ‹By the young men of the princes of the provinces.› »</text>
+    <text>«Thus says God, ‹By the young men of the princes of the provinces.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="14" characterId="narrator-1KI">
     <text>Then he said,</text>
@@ -3453,7 +3453,7 @@
     <text>A man of God came near and spoke to the king of Israel, and said,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="28" characterId="prophet of the LORD">
-    <text>«Thus says God, ‹Because the Syrians have said, «God is a god of the hills, but he is not a god of the valleys;» therefore I will deliver all this great multitude into your hand, and you shall know that I am God.› »</text>
+    <text>«Thus says God, ‹Because the Syrians have said, «God is a god of the hills, but he is not a god of the valleys;» therefore I will deliver all this great multitude into your hand, and you shall know that I am God.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="29" characterId="narrator-1KI">
     <verse num="29" />
@@ -3475,7 +3475,7 @@
     <text>So they put sackcloth on their bodies and ropes on their heads, and came to the king of Israel, and said,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="32" characterId="officials of Ben-Hadad, king of Aram">
-    <text>«Your servant Ben Hadad says, ‹Please let me live.› »</text>
+    <text>«Your servant Ben Hadad says, ‹Please let me live.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="32" characterId="narrator-1KI">
     <text>He said,</text>
@@ -3563,7 +3563,7 @@
     <text>He said to him,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="42" characterId="prophet who confronts Ahab">
-    <text>«Thus says God, ‹Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life shall go for his life, and your people for his people.› »</text>
+    <text>«Thus says God, ‹Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life shall go for his life, and your people for his people.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="43" characterId="narrator-1KI">
     <verse num="43" />
@@ -3608,7 +3608,7 @@
     <text>He said to her,</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="6" characterId="Ahab, king of Israel">
-    <text>«Because I spoke to Naboth the Jezreelite, and said to him, ‹Give me your vineyard for money; or else, if it pleases you, I will give you another vineyard for it.› He answered, ‹I will not give you my vineyard.› »</text>
+    <text>«Because I spoke to Naboth the Jezreelite, and said to him, ‹Give me your vineyard for money; or else, if it pleases you, I will give you another vineyard for it.› He answered, ‹I will not give you my vineyard.› »</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="7" characterId="narrator-1KI">
     <verse num="7" />
@@ -3810,7 +3810,7 @@
     <text>Zedekiah the son of Chenaanah made him horns of iron, and said,</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="11" characterId="Zedekiah, son of Kenaanah, false prophet">
-    <text>«Thus says God, ‹With these you shall push the Syrians, until they are consumed.› »</text>
+    <text>«Thus says God, ‹With these you shall push the Syrians, until they are consumed.› »</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="12" characterId="narrator-1KI">
     <verse num="12" />
@@ -3858,7 +3858,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="17" characterId="Micaiah, prophet of the LORD">
-    <text>«I saw all Israel scattered on the mountains, as sheep that have no shepherd. God said, ‹These have no master. Let them each return to his house in peace.› »</text>
+    <text>«I saw all Israel scattered on the mountains, as sheep that have no shepherd. God said, ‹These have no master. Let them each return to his house in peace.› »</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="18" characterId="narrator-1KI">
     <verse num="18" />

--- a/DistFiles/reference_texts/English/1SA.xml
+++ b/DistFiles/reference_texts/English/1SA.xml
@@ -394,7 +394,7 @@
     <text>Therefore Eli said to Samuel,</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="9" characterId="Eli">
-    <text>«Go, lie down: and it shall be, if he calls you, that you shall say, ‹Speak, God; for your servant hears.› »</text>
+    <text>«Go, lie down: and it shall be, if he calls you, that you shall say, ‹Speak, God; for your servant hears.› »</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="9" characterId="narrator-1SA">
     <text>So Samuel went and lay down in his place. </text>
@@ -1107,14 +1107,14 @@
     <text>Samuel said to the cook,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="23" characterId="Samuel">
-    <text>«Bring the portion which I gave you, of which I said to you, ‹Set it aside.› »</text>
+    <text>«Bring the portion which I gave you, of which I said to you, ‹Set it aside.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="24" characterId="narrator-1SA">
     <verse num="24" />
     <text>The cook took up the thigh, and that which was on it, and set it before Saul. Samuel said,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="24" characterId="Samuel">
-    <text>«Behold, that which has been reserved! Set it before yourself and eat; because for the appointed time has it been kept for you, for I said, ‹I have invited the people.› »</text>
+    <text>«Behold, that which has been reserved! Set it before yourself and eat; because for the appointed time has it been kept for you, for I said, ‹I have invited the people.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="24" characterId="narrator-1SA">
     <text>So Saul ate with Samuel that day. </text>
@@ -1354,7 +1354,7 @@
     <text>They said to the messengers who came,</text>
   </block>
   <block style="p" chapter="11" initialStartVerse="9" characterId="Saul/Israel, men of">
-    <text>«Thus you shall tell the men of Jabesh Gilead, ‹Tomorrow, by the time the sun is hot, you shall have deliverance.› »</text>
+    <text>«Thus you shall tell the men of Jabesh Gilead, ‹Tomorrow, by the time the sun is hot, you shall have deliverance.› »</text>
   </block>
   <block style="p" chapter="11" initialStartVerse="9" characterId="narrator-1SA">
     <text>The messengers came and told the men of Jabesh; and they were glad. </text>
@@ -1779,7 +1779,7 @@
     <text>Then one of the people answered, and said,</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="28" characterId="Israelite soldier in Saul's army">
-    <text>«Your father directly commanded the people with an oath, saying, ‹Cursed is the man who eats food this day.› » The people were faint.</text>
+    <text>«Your father directly commanded the people with an oath, saying, ‹Cursed is the man who eats food this day.› » The people were faint.</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="29" characterId="narrator-1SA">
     <verse num="29" />
@@ -1818,7 +1818,7 @@
     <text>Saul said,</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="34" characterId="Saul">
-    <text>«Disperse yourselves among the people, and tell them, ‹Bring me here every man his ox, and every man his sheep, and kill them here, and eat; and don’t sin against God in eating meat with the blood.› »</text>
+    <text>«Disperse yourselves among the people, and tell them, ‹Bring me here every man his ox, and every man his sheep, and kill them here, and eat; and don’t sin against God in eating meat with the blood.› »</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="34" characterId="narrator-1SA">
     <text>All the people brought every man his ox with him that night, and killed them there.</text>
@@ -1967,7 +1967,7 @@
   </block>
   <block style="p" chapter="15" initialStartVerse="3" characterId="Samuel">
     <verse num="3" />
-    <text>Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.› »</text>
+    <text>Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.› »</text>
   </block>
   <block style="p" chapter="15" initialStartVerse="4" characterId="narrator-1SA">
     <verse num="4" />
@@ -2732,7 +2732,7 @@
     <text>Saul commanded his servants,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="22" characterId="Saul">
-    <text>«Talk with David secretly, and say, ‹Behold, the king has delight in you, and all his servants love you: now therefore be the king’s son-in-law.› »</text>
+    <text>«Talk with David secretly, and say, ‹Behold, the king has delight in you, and all his servants love you: now therefore be the king’s son-in-law.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="23" characterId="narrator-1SA">
     <verse num="23" />
@@ -2748,7 +2748,7 @@
     <text>Saul said,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="25" characterId="Saul">
-    <text>«You shall tell David, ‹The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.› »</text>
+    <text>«You shall tell David, ‹The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="25" characterId="narrator-1SA">
     <text>Now Saul thought to make David fall by the hand of the Philistines.</text>
@@ -2863,7 +2863,7 @@
     <text>Michal answered Saul,</text>
   </block>
   <block style="p" chapter="19" initialStartVerse="17" characterId="Michal, David's wife">
-    <text>«He said to me, ‹Let me go! Why should I kill you?› »</text>
+    <text>«He said to me, ‹Let me go! Why should I kill you?› »</text>
   </block>
   <block style="p" chapter="19" initialStartVerse="18" characterId="narrator-1SA">
     <verse num="18" />
@@ -3139,7 +3139,7 @@
     <text>Jonathan said to David,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="42" characterId="Jonathan">
-    <text>«Go in peace, because we have both sworn in the name of God, saying, ‹God shall be between me and you, and between my seed and your seed, forever.› »</text>
+    <text>«Go in peace, because we have both sworn in the name of God, saying, ‹God shall be between me and you, and between my seed and your seed, forever.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="42" characterId="narrator-1SA">
     <text>He arose and departed; and Jonathan went into the city.</text>
@@ -3212,7 +3212,7 @@
     <text>The servants of Achish said to him,</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="11" characterId="servants of Achish, king of Gath">
-    <text>«Isn’t this David the king of the land? Didn’t they sing one to another about him in dances, saying, ‹Saul has slain his thousands, David his ten thousands?› »</text>
+    <text>«Isn’t this David the king of the land? Didn’t they sing one to another about him in dances, saying, ‹Saul has slain his thousands, David his ten thousands?› »</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="12" characterId="narrator-1SA">
     <verse num="12" />
@@ -3560,7 +3560,7 @@
     <text>The men of David said to him,</text>
   </block>
   <block style="p" chapter="24" initialStartVerse="4" characterId="David's men">
-    <text>«Behold, the day of which God said to you, ‹Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.› »</text>
+    <text>«Behold, the day of which God said to you, ‹Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.› »</text>
   </block>
   <block style="p" chapter="24" initialStartVerse="4" characterId="narrator-1SA">
     <text>Then David arose, and cut off the skirt of Saul's robe secretly.</text>
@@ -3688,7 +3688,7 @@
   </block>
   <block style="p" chapter="25" initialStartVerse="8" characterId="David">
     <verse num="8" />
-    <text>Ask your young men, and they will tell you. Therefore, let the young men find favor in your eyes; for we come in a good day. Please give whatever comes to your hand, to your servants, and to your son David.› »</text>
+    <text>Ask your young men, and they will tell you. Therefore, let the young men find favor in your eyes; for we come in a good day. Please give whatever comes to your hand, to your servants, and to your son David.› »</text>
   </block>
   <block style="p" chapter="25" initialStartVerse="9" characterId="narrator-1SA">
     <verse num="9" />
@@ -4079,7 +4079,7 @@
     <text>David saved neither man nor woman alive, to bring them to Gath, saying,</text>
   </block>
   <block style="p" chapter="27" initialStartVerse="11" characterId="David" delivery="thought">
-    <text>«Lest they should tell of us, saying, ‹So did David, and so has been his way all the while he has lived in the country of the Philistines.› »</text>
+    <text>«Lest they should tell of us, saying, ‹So did David, and so has been his way all the while he has lived in the country of the Philistines.› »</text>
   </block>
   <block style="p" chapter="27" initialStartVerse="12" characterId="narrator-1SA">
     <verse num="12" />
@@ -4304,7 +4304,7 @@
   </block>
   <block style="p" chapter="29" initialStartVerse="5" characterId="Philistine commanders">
     <verse num="5" />
-    <text>Is not this David, of whom they sang one to another in dances, saying, ‹Saul has slain his thousands, David his ten thousands?› »</text>
+    <text>Is not this David, of whom they sang one to another in dances, saying, ‹Saul has slain his thousands, David his ten thousands?› »</text>
   </block>
   <block style="p" chapter="29" initialStartVerse="6" characterId="narrator-1SA">
     <verse num="6" />

--- a/DistFiles/reference_texts/English/2CH.xml
+++ b/DistFiles/reference_texts/English/2CH.xml
@@ -651,7 +651,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="22" characterId="God">
     <verse num="22" />
-    <text>They shall answer, ‹Because they abandoned God, the God of their fathers, who brought them forth out of the land of Egypt, and took other gods, worshiped them, and served them. Therefore he has brought all this evil on them.› »</text>
+    <text>They shall answer, ‹Because they abandoned God, the God of their fathers, who brought them forth out of the land of Egypt, and took other gods, worshiped them, and served them. Therefore he has brought all this evil on them.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="8" book="2CH" initialStartVerse="0" characterId="BC-2CH">
     <text>8</text>
@@ -903,7 +903,7 @@
     <text>He said to them,</text>
   </block>
   <block style="p" chapter="10" initialStartVerse="9" characterId="Rehoboam, king">
-    <text>«What counsel do you give, that we may return answer to this people, who have spoken to me, saying, ‹Make the yoke that your father did put on us lighter?› »</text>
+    <text>«What counsel do you give, that we may return answer to this people, who have spoken to me, saying, ‹Make the yoke that your father did put on us lighter?› »</text>
   </block>
   <block style="p" chapter="10" initialStartVerse="10" characterId="narrator-2CH">
     <verse num="10" />
@@ -914,7 +914,7 @@
   </block>
   <block style="p" chapter="10" initialStartVerse="11" characterId="young men (advisors of Rehoboam)">
     <verse num="11" />
-    <text>Now whereas my father burdened you with a heavy yoke, I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.› »</text>
+    <text>Now whereas my father burdened you with a heavy yoke, I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.› »</text>
   </block>
   <block style="p" chapter="10" initialStartVerse="12" characterId="narrator-2CH">
     <verse num="12" />
@@ -1074,7 +1074,7 @@
     <text>Now Shemaiah the prophet came to Rehoboam, and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them,</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="5" characterId="Shemaiah, prophet">
-    <text>«Thus says God, ‹You have forsaken me, therefore have I also left you in the hand of Shishak.› »</text>
+    <text>«Thus says God, ‹You have forsaken me, therefore have I also left you in the hand of Shishak.› »</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="6" characterId="narrator-2CH">
     <verse num="6" />
@@ -1587,7 +1587,7 @@
     <text>Zedekiah the son of Chenaanah made him horns of iron, and said,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="10" characterId="Zedekiah, son of Kenaanah, false prophet">
-    <text>«Thus says God, ‹With these you shall push the Syrians, until they are consumed.› »</text>
+    <text>«Thus says God, ‹With these you shall push the Syrians, until they are consumed.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="11" characterId="narrator-2CH">
     <verse num="11" />
@@ -1635,7 +1635,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="16" characterId="Micaiah, prophet of the LORD">
-    <text>«I saw all Israel scattered on the mountains, as sheep that have no shepherd. God said, ‹These have no master. Let them return every man to his house in peace.› »</text>
+    <text>«I saw all Israel scattered on the mountains, as sheep that have no shepherd. God said, ‹These have no master. Let them return every man to his house in peace.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="17" characterId="narrator-2CH">
     <verse num="17" />
@@ -1874,7 +1874,7 @@
   </block>
   <block style="p" chapter="20" initialStartVerse="17" characterId="Jahaziel (Spirit of the Lord on)">
     <verse num="17" />
-    <text>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of God with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for God is with you.› »</text>
+    <text>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of God with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for God is with you.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="18" characterId="narrator-2CH">
     <verse num="18" />
@@ -2030,7 +2030,7 @@
   </block>
   <block style="p" chapter="21" initialStartVerse="15" characterId="Elijah" delivery="letter">
     <verse num="15" />
-    <text>and you shall have great sickness by disease of your bowels, until your bowels fall out by reason of the sickness, day by day.› »</text>
+    <text>and you shall have great sickness by disease of your bowels, until your bowels fall out by reason of the sickness, day by day.› »</text>
   </block>
   <block style="p" chapter="21" initialStartVerse="16" characterId="narrator-2CH">
     <verse num="16" />
@@ -2305,7 +2305,7 @@
     <text>The Spirit of God came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them,</text>
   </block>
   <block style="p" chapter="24" initialStartVerse="20" characterId="Zechariah, son of Jehoiada the priest">
-    <text>«Thus says God, ‹Why do you disobey the commandments of God, so that you can’t prosper? Because you have forsaken God, he has also forsaken you.› »</text>
+    <text>«Thus says God, ‹Why do you disobey the commandments of God, so that you can’t prosper? Because you have forsaken God, he has also forsaken you.› »</text>
   </block>
   <block style="p" chapter="24" initialStartVerse="21" characterId="narrator-2CH">
     <verse num="21" />
@@ -2446,7 +2446,7 @@
   </block>
   <block style="p" chapter="25" initialStartVerse="19" characterId="Jehoash, king of Israel">
     <verse num="19" />
-    <text>You say to yourself that you have struck Edom; and your heart lifts you up to boast. Now stay at home. Why should you meddle with trouble, that you should fall, even you, and Judah with you?› »</text>
+    <text>You say to yourself that you have struck Edom; and your heart lifts you up to boast. Now stay at home. Why should you meddle with trouble, that you should fall, even you, and Judah with you?› »</text>
   </block>
   <block style="p" chapter="25" initialStartVerse="20" characterId="narrator-2CH">
     <verse num="20" />
@@ -3480,7 +3480,7 @@
   </block>
   <block style="p" chapter="34" initialStartVerse="28" characterId="Huldah, prophetess">
     <verse num="28" />
-    <text>Behold, I will gather you to your fathers, and you shall be gathered to your grave in peace, neither shall your eyes see all the evil that I will bring on this place, and on its inhabitants.› »</text>
+    <text>Behold, I will gather you to your fathers, and you shall be gathered to your grave in peace, neither shall your eyes see all the evil that I will bring on this place, and on its inhabitants.› »</text>
   </block>
   <block style="p" chapter="34" initialStartVerse="28" characterId="narrator-2CH">
     <text>They brought back word to the king. </text>

--- a/DistFiles/reference_texts/English/2CO.xml
+++ b/DistFiles/reference_texts/English/2CO.xml
@@ -490,7 +490,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="17" characterId="scripture">
     <verse num="17" />
-    <text>Therefore « ‹Come out from among them, and be separate,› says the Lord. ‹Touch no unclean thing. I will receive you.</text>
+    <text>Therefore « ‹Come out from among them, and be separate,› says the Lord. ‹Touch no unclean thing. I will receive you.</text>
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="18" characterId="scripture">
     <verse num="18" />

--- a/DistFiles/reference_texts/English/2KI.xml
+++ b/DistFiles/reference_texts/English/2KI.xml
@@ -41,7 +41,7 @@
     <text>They said to him,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="6" characterId="messengers of Ahaziah">
-    <text>«A man came up to meet us, and said to us, ‹Go, return to the king who sent you, and tell him, «Thus says God, ‹Is it because there is no God in Israel, that you send to inquire of Baal Zebub, the god of Ekron? Therefore you shall not come down from the bed where you have gone up, but shall surely die.› »</text>
+    <text>«A man came up to meet us, and said to us, ‹Go, return to the king who sent you, and tell him, «Thus says God, ‹Is it because there is no God in Israel, that you send to inquire of Baal Zebub, the god of Ekron? Therefore you shall not come down from the bed where you have gone up, but shall surely die.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="7" characterId="narrator-2KI">
     <verse num="7" />
@@ -68,7 +68,7 @@
     <text>Then the king sent a captain of fifty with his fifty to him. He went up to him; and behold, he was sitting on the top of the hill. He said to him,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="9" characterId="captain, first">
-    <text>«Man of God, the king has said, ‹Come down!› »</text>
+    <text>«Man of God, the king has said, ‹Come down!› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="10" characterId="narrator-2KI">
     <verse num="10" />
@@ -85,7 +85,7 @@
     <text>Again he sent to him another captain of fifty and his fifty. He answered him,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="11" characterId="captain, second">
-    <text>«Man of God, the king has said, ‹Come down quickly!› »</text>
+    <text>«Man of God, the king has said, ‹Come down quickly!› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="12" characterId="narrator-2KI">
     <verse num="12" />
@@ -121,7 +121,7 @@
     <text>He said to him,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="16" characterId="Elijah">
-    <text>«Thus says God, ‹Because you have sent messengers to inquire of Baal Zebub, the god of Ekron, is it because there is no God in Israel to inquire of his word? Therefore you shall not come down from the bed where you have gone up, but shall surely die.› »</text>
+    <text>«Thus says God, ‹Because you have sent messengers to inquire of Baal Zebub, the god of Ekron, is it because there is no God in Israel to inquire of his word? Therefore you shall not come down from the bed where you have gone up, but shall surely die.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="17" characterId="narrator-2KI">
     <verse num="17" />
@@ -294,7 +294,7 @@
     <text>They came back to him, while he stayed at Jericho; and he said to them,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="18" characterId="Elisha">
-    <text>«Didn’t I tell you, ‹Don’t go?› »</text>
+    <text>«Didn’t I tell you, ‹Don’t go?› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="19" characterId="narrator-2KI">
     <verse num="19" />
@@ -316,7 +316,7 @@
     <text>He went out to the spring of the waters, and threw salt into it, and said,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="21" characterId="Elisha">
-    <text>«Thus says God, ‹I have healed these waters. There shall not be from there any more death or miscarrying.› »</text>
+    <text>«Thus says God, ‹I have healed these waters. There shall not be from there any more death or miscarrying.› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="22" characterId="narrator-2KI">
     <verse num="22" />
@@ -462,7 +462,7 @@
   </block>
   <block style="p" chapter="3" initialStartVerse="19" characterId="Elisha">
     <verse num="19" />
-    <text>You shall strike every fortified city, and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.› »</text>
+    <text>You shall strike every fortified city, and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.› »</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="20" characterId="narrator-2KI">
     <verse num="20" />
@@ -582,7 +582,7 @@
     <text>He said to him,</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="13" characterId="Elisha">
-    <text>«Say now to her, ‹Behold, you have cared for us with all this care. What is to be done for you? Would you like to be spoken for to the king, or to the captain of the army?› »</text>
+    <text>«Say now to her, ‹Behold, you have cared for us with all this care. What is to be done for you? Would you like to be spoken for to the king, or to the captain of the army?› »</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="13" characterId="narrator-2KI">
     <text>She answered,</text>
@@ -685,7 +685,7 @@
   </block>
   <block style="p" chapter="4" initialStartVerse="26" characterId="Elisha">
     <verse num="26" />
-    <text>Please run now to meet her, and ask her, ‹Is it well with you? Is it well with your husband? Is it well with the child?› »</text>
+    <text>Please run now to meet her, and ask her, ‹Is it well with you? Is it well with your husband? Is it well with the child?› »</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="26" characterId="narrator-2KI">
     <text>She answered,</text>
@@ -813,7 +813,7 @@
     <text>But he said,</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="43" characterId="Elisha">
-    <text>«Give the people, that they may eat; for thus says God, ‹They will eat, and will have some left over.› »</text>
+    <text>«Give the people, that they may eat; for thus says God, ‹They will eat, and will have some left over.› »</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="44" characterId="narrator-2KI">
     <verse num="44" />
@@ -897,7 +897,7 @@
     <text>His servants came near, and spoke to him, and said,</text>
   </block>
   <block style="p" chapter="5" initialStartVerse="13" characterId="Naaman's servants">
-    <text>«My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‹Wash, and be clean?› »</text>
+    <text>«My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‹Wash, and be clean?› »</text>
   </block>
   <block style="p" chapter="5" initialStartVerse="14" characterId="narrator-2KI">
     <verse num="14" />
@@ -956,7 +956,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="5" initialStartVerse="22" characterId="Gehazi">
-    <text>«All is well. My master has sent me, saying, ‹Behold, even now two young men of the sons of the prophets have come to me from the hill country of Ephraim. Please give them a talent of silver and two changes of clothing.› »</text>
+    <text>«All is well. My master has sent me, saying, ‹Behold, even now two young men of the sons of the prophets have come to me from the hill country of Ephraim. Please give them a talent of silver and two changes of clothing.› »</text>
   </block>
   <block style="p" chapter="5" initialStartVerse="23" characterId="narrator-2KI">
     <verse num="23" />
@@ -1248,7 +1248,7 @@
     <text>Elisha said,</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="1" characterId="Elisha">
-    <text>«Hear the word of God. Thus says God, Tomorrow about this time a measure of fine flour will be sold for a shekel, and two measures of barley for a shekel, in the gate of Samaria.› »</text>
+    <text>«Hear the word of God. Thus says God, Tomorrow about this time a measure of fine flour will be sold for a shekel, and two measures of barley for a shekel, in the gate of Samaria.› »</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="2" characterId="narrator-2KI">
     <verse num="2" />
@@ -1312,7 +1312,7 @@
     <text>The king arose in the night, and said to his servants,</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="12" characterId="Joram (Jehoram), king of Israel">
-    <text>«I will now show you what the Syrians have done to us. They know that we are hungry. Therefore are they gone out of the camp to hide themselves in the field, saying, ‹When they come out of the city, we shall take them alive, and get into the city.› »</text>
+    <text>«I will now show you what the Syrians have done to us. They know that we are hungry. Therefore are they gone out of the camp to hide themselves in the field, saying, ‹When they come out of the city, we shall take them alive, and get into the city.› »</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="13" characterId="narrator-2KI">
     <verse num="13" />
@@ -1415,14 +1415,14 @@
     <text>The king said to Hazael,</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="8" characterId="Ben-Hadad, king of Aram">
-    <text>«Take a present in your hand, and go, meet the man of God, and inquire of God by him, saying, ‹Will I recover from this sickness?› »</text>
+    <text>«Take a present in your hand, and go, meet the man of God, and inquire of God by him, saying, ‹Will I recover from this sickness?› »</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="9" characterId="narrator-2KI">
     <verse num="9" />
     <text>So Hazael went to meet him, and took a present with him, even of every good thing of Damascus, forty camels’ burden, and came and stood before him, and said,</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="9" characterId="Hazael of Aram">
-    <text>«Your son Benhadad king of Syria has sent me to you, saying, ‹Will I recover from this sickness?› »</text>
+    <text>«Your son Benhadad king of Syria has sent me to you, saying, ‹Will I recover from this sickness?› »</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="10" characterId="narrator-2KI">
     <verse num="10" />
@@ -1594,7 +1594,7 @@
   </block>
   <block style="p" chapter="9" initialStartVerse="10" characterId="company of the prophets, one of (young man)">
     <verse num="10" />
-    <text>The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be none to bury her.› »</text>
+    <text>The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be none to bury her.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="10" characterId="narrator-2KI">
     <text>He opened the door, and fled. </text>
@@ -1621,7 +1621,7 @@
     <text>He said,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="12" characterId="Jehu, son of Nimshi">
-    <text>«He said to me, ‹Thus says God, I have anointed you king over Israel.› »</text>
+    <text>«He said to me, ‹Thus says God, I have anointed you king over Israel.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="13" characterId="narrator-2KI">
     <verse num="13" />
@@ -1656,14 +1656,14 @@
     <text>Joram said,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="17" characterId="Joram (Jehoram), king of Israel">
-    <text>«Take a horseman, and send to meet them, and let him say, ‹Is it peace?› »</text>
+    <text>«Take a horseman, and send to meet them, and let him say, ‹Is it peace?› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="18" characterId="narrator-2KI">
     <verse num="18" />
     <text>So there went one on horseback to meet him, and said,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="18" characterId="horseman, first">
-    <text>«Thus says the king, ‹Is it peace?› »</text>
+    <text>«Thus says the king, ‹Is it peace?› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="18" characterId="narrator-2KI">
     <text>Jehu said,</text>
@@ -1682,7 +1682,7 @@
     <text>Then he sent out a second on horseback, who came to them, and said,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="19" characterId="horseman, second">
-    <text>«Thus says the king, ‹Is it peace?› »</text>
+    <text>«Thus says the king, ‹Is it peace?› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="19" characterId="narrator-2KI">
     <text>Jehu answered,</text>
@@ -2416,7 +2416,7 @@
   </block>
   <block style="p" chapter="14" initialStartVerse="10" characterId="Jehoash, king of Israel">
     <verse num="10" />
-    <text>You have indeed struck Edom, and your heart has lifted you up. Enjoy the glory of it, and stay at home; for why should you meddle to your harm, that you should fall, even you, and Judah with you?› »</text>
+    <text>You have indeed struck Edom, and your heart has lifted you up. Enjoy the glory of it, and stay at home; for why should you meddle to your harm, that you should fall, even you, and Judah with you?› »</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="11" characterId="narrator-2KI">
     <verse num="11" />
@@ -3022,7 +3022,7 @@
   </block>
   <block style="p" chapter="18" initialStartVerse="25" characterId="Rabshakeh">
     <verse num="25" />
-    <text>Have I now come up without God against this place to destroy it? God said to me, ‹Go up against this land, and destroy it.› »</text>
+    <text>Have I now come up without God against this place to destroy it? God said to me, ‹Go up against this land, and destroy it.› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="26" characterId="narrator-2KI">
     <verse num="26" />
@@ -3071,7 +3071,7 @@
   </block>
   <block style="p" chapter="18" initialStartVerse="35" characterId="Rabshakeh">
     <verse num="35" />
-    <text>Who are they among all the gods of the countries, that have delivered their country out of my hand, that God should deliver Jerusalem out of my hand?› »</text>
+    <text>Who are they among all the gods of the countries, that have delivered their country out of my hand, that God should deliver Jerusalem out of my hand?› »</text>
   </block>
   <block style="p" chapter="18" initialStartVerse="36" characterId="narrator-2KI">
     <verse num="36" />
@@ -3102,7 +3102,7 @@
   </block>
   <block style="p" chapter="19" initialStartVerse="4" characterId="Eliakim/Shebna/chief priests">
     <verse num="4" />
-    <text>It may be God your God will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living God, and will rebuke the words which God your God has heard. Therefore lift up your prayer for the remnant that is left.› »</text>
+    <text>It may be God your God will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living God, and will rebuke the words which God your God has heard. Therefore lift up your prayer for the remnant that is left.› »</text>
   </block>
   <block style="p" chapter="19" initialStartVerse="5" characterId="narrator-2KI">
     <verse num="5" />
@@ -3231,7 +3231,7 @@
   </block>
   <block style="p" chapter="19" initialStartVerse="34" characterId="Isaiah">
     <verse num="34" />
-    <text>For I will defend this city to save it, for my own sake, and for my servant David’s sake.› »</text>
+    <text>For I will defend this city to save it, for my own sake, and for my servant David’s sake.› »</text>
   </block>
   <block style="p" chapter="19" initialStartVerse="35" characterId="narrator-2KI">
     <verse num="35" />
@@ -3253,7 +3253,7 @@
     <text>In those days was Hezekiah sick to death. Isaiah the prophet the son of Amoz came to him, and said to him,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="1" characterId="Isaiah">
-    <text>«Thus says God, ‹Set your house in order; for you shall die, and not live.› »</text>
+    <text>«Thus says God, ‹Set your house in order; for you shall die, and not live.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="2" characterId="narrator-2KI">
     <verse num="2" />
@@ -3354,7 +3354,7 @@
   </block>
   <block style="p" chapter="20" initialStartVerse="18" characterId="Isaiah">
     <verse num="18" />
-    <text>Of your sons who shall issue from you, whom you shall father, shall they take away; and they shall be eunuchs in the palace of the king of Babylon.› »</text>
+    <text>Of your sons who shall issue from you, whom you shall father, shall they take away; and they shall be eunuchs in the palace of the king of Babylon.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="19" characterId="narrator-2KI">
     <verse num="19" />
@@ -3577,7 +3577,7 @@
   </block>
   <block style="p" chapter="22" initialStartVerse="20" characterId="Huldah, prophetess">
     <verse num="20" />
-    <text>Therefore, behold, I will gather you to your fathers, and you shall be gathered to your grave in peace, neither shall your eyes see all the evil which I will bring on this place.› »</text>
+    <text>Therefore, behold, I will gather you to your fathers, and you shall be gathered to your grave in peace, neither shall your eyes see all the evil which I will bring on this place.› »</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="20" characterId="narrator-2KI">
     <text>They brought back this message to the king.</text>
@@ -3708,7 +3708,7 @@
     <text>God said,</text>
   </block>
   <block style="p" chapter="23" initialStartVerse="27" characterId="God">
-    <text>«I will remove Judah also out of my sight, as I have removed Israel, and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‹My name shall be there.› »</text>
+    <text>«I will remove Judah also out of my sight, as I have removed Israel, and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‹My name shall be there.› »</text>
   </block>
   <block style="p" chapter="23" initialStartVerse="28" characterId="narrator-2KI">
     <verse num="28" />

--- a/DistFiles/reference_texts/English/2SA.xml
+++ b/DistFiles/reference_texts/English/2SA.xml
@@ -109,7 +109,7 @@
     <text>David said to him,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="16" characterId="David">
-    <text>«Your blood be on your head; for your mouth has testified against you, saying, ‹I have slain God’s anointed.› »</text>
+    <text>«Your blood be on your head; for your mouth has testified against you, saying, ‹I have slain God’s anointed.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="17" characterId="narrator-2SA">
     <verse num="17" />
@@ -437,7 +437,7 @@
   </block>
   <block style="p" chapter="3" initialStartVerse="18" characterId="Abner, commander of Saul's army">
     <verse num="18" />
-    <text>Now then do it; for God has spoken of David, saying, ‹By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.› »</text>
+    <text>Now then do it; for God has spoken of David, saying, ‹By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.› »</text>
   </block>
   <block style="p" chapter="3" initialStartVerse="19" characterId="narrator-2SA">
     <verse num="19" />
@@ -615,7 +615,7 @@
   </block>
   <block style="p" chapter="5" initialStartVerse="2" characterId="Israel, all the tribes">
     <verse num="2" />
-    <text>In times past, when Saul was king over us, it was you who led out and brought in Israel. God said to you, ‹You shall be shepherd of my people Israel, and you shall be prince over Israel.› »</text>
+    <text>In times past, when Saul was king over us, it was you who led out and brought in Israel. God said to you, ‹You shall be shepherd of my people Israel, and you shall be prince over Israel.› »</text>
   </block>
   <block style="p" chapter="5" initialStartVerse="3" characterId="narrator-2SA">
     <verse num="3" />
@@ -876,7 +876,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="7" characterId="God">
     <verse num="7" />
-    <text>In all places in which I have walked with all the children of Israel, did I say a word to any of the tribes of Israel, whom I commanded to be shepherd of my people Israel, saying, ‹Why have you not built me a house of cedar?› »</text>
+    <text>In all places in which I have walked with all the children of Israel, did I say a word to any of the tribes of Israel, whom I commanded to be shepherd of my people Israel, saying, ‹Why have you not built me a house of cedar?› »</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="8" characterId="God">
     <verse num="8" />
@@ -1355,7 +1355,7 @@
   </block>
   <block style="p" chapter="11" initialStartVerse="21" characterId="Joab">
     <verse num="21" />
-    <text>who struck Abimelech the son of Jerubbesheth? Didn’t a woman cast an upper millstone on him from the wall, so that he died at Thebez? Why did you go so near the wall?› then you shall say, ‹Your servant Uriah the Hittite is dead also.› »</text>
+    <text>who struck Abimelech the son of Jerubbesheth? Didn’t a woman cast an upper millstone on him from the wall, so that he died at Thebez? Why did you go so near the wall?› then you shall say, ‹Your servant Uriah the Hittite is dead also.› »</text>
   </block>
   <block style="p" chapter="11" initialStartVerse="22" characterId="narrator-2SA">
     <verse num="22" />
@@ -1578,7 +1578,7 @@
     <text>Jonadab said to him,</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="5" characterId="Jonadab" delivery="shrewd">
-    <text>«Lay down on your bed, and pretend to be sick. When your father comes to see you, tell him, ‹Please let my sister Tamar come and give me bread to eat, and dress the food in my sight, that I may see it, and eat it from her hand.› »</text>
+    <text>«Lay down on your bed, and pretend to be sick. When your father comes to see you, tell him, ‹Please let my sister Tamar come and give me bread to eat, and dress the food in my sight, that I may see it, and eat it from her hand.› »</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="6" characterId="narrator-2SA">
     <verse num="6" />
@@ -1893,7 +1893,7 @@
   </block>
   <block style="p" chapter="14" initialStartVerse="17" characterId="woman from Tekoa">
     <verse num="17" />
-    <text>Then your handmaid said, ‹Please let the word of my lord the king bring rest; for as an angel of God, so is my lord the king to discern good and bad. May God, your God, be with you.› »</text>
+    <text>Then your handmaid said, ‹Please let the word of my lord the king bring rest; for as an angel of God, so is my lord the king to discern good and bad. May God, your God, be with you.› »</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="18" characterId="narrator-2SA">
     <verse num="18" />
@@ -2050,7 +2050,7 @@
   </block>
   <block style="p" chapter="15" initialStartVerse="8" characterId="Absalom, son of David">
     <verse num="8" />
-    <text>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‹If God shall indeed bring me again to Jerusalem, then I will serve God.› »</text>
+    <text>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‹If God shall indeed bring me again to Jerusalem, then I will serve God.› »</text>
   </block>
   <block style="p" chapter="15" initialStartVerse="9" characterId="narrator-2SA">
     <verse num="9" />
@@ -2065,7 +2065,7 @@
     <text>But Absalom sent spies throughout all the tribes of Israel, saying,</text>
   </block>
   <block style="p" chapter="15" initialStartVerse="10" characterId="Absalom, son of David">
-    <text>«As soon as you hear the sound of the trumpet, then you shall say, ‹Absalom is king in Hebron!› »</text>
+    <text>«As soon as you hear the sound of the trumpet, then you shall say, ‹Absalom is king in Hebron!› »</text>
   </block>
   <block style="p" chapter="15" initialStartVerse="11" characterId="narrator-2SA">
     <verse num="11" />
@@ -2239,7 +2239,7 @@
     <text>Ziba said to the king,</text>
   </block>
   <block style="p" chapter="16" initialStartVerse="3" characterId="Ziba, servant of Saul's household">
-    <text>«Behold, he is staying in Jerusalem; for he said, ‹Today the house of Israel will restore me the kingdom of my father.› »</text>
+    <text>«Behold, he is staying in Jerusalem; for he said, ‹Today the house of Israel will restore me the kingdom of my father.› »</text>
   </block>
   <block style="p" chapter="16" initialStartVerse="4" characterId="narrator-2SA">
     <verse num="4" />
@@ -2283,7 +2283,7 @@
     <text>The king said,</text>
   </block>
   <block style="p" chapter="16" initialStartVerse="10" characterId="David">
-    <text>«What have I to do with you, you sons of Zeruiah? Because he curses, and because God has said to him, ‹Curse David;› who then shall say, ‹Why have you done so?› »</text>
+    <text>«What have I to do with you, you sons of Zeruiah? Because he curses, and because God has said to him, ‹Curse David;› who then shall say, ‹Why have you done so?› »</text>
   </block>
   <block style="p" chapter="16" initialStartVerse="11" characterId="narrator-2SA">
     <verse num="11" />
@@ -2442,7 +2442,7 @@
   </block>
   <block style="p" chapter="17" initialStartVerse="16" characterId="Hushai, David's friend">
     <verse num="16" />
-    <text>Now therefore send quickly, and tell David, saying, ‹Don’t lodge this night at the fords of the wilderness, but by all means pass over; lest the king be swallowed up, and all the people who are with him.› »</text>
+    <text>Now therefore send quickly, and tell David, saying, ‹Don’t lodge this night at the fords of the wilderness, but by all means pass over; lest the king be swallowed up, and all the people who are with him.› »</text>
   </block>
   <block style="p" chapter="17" initialStartVerse="17" characterId="narrator-2SA">
     <verse num="17" />
@@ -2847,7 +2847,7 @@
   </block>
   <block style="p" chapter="19" initialStartVerse="13" characterId="David">
     <verse num="13" />
-    <text>Say to Amasa, ‹Aren’t you my bone and my flesh? God do so to me, and more also, if you aren’t captain of the army before me continually in the room of Joab.› »</text>
+    <text>Say to Amasa, ‹Aren’t you my bone and my flesh? God do so to me, and more also, if you aren’t captain of the army before me continually in the room of Joab.› »</text>
   </block>
   <block style="p" chapter="19" initialStartVerse="14" characterId="narrator-2SA">
     <verse num="14" />
@@ -3094,7 +3094,7 @@
     <text>Then a wise woman cried out of the city,</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="16" characterId="woman, wise">
-    <text>«Hear, hear! Please say to Joab, ‹Come near here, that I may speak with you.› »</text>
+    <text>«Hear, hear! Please say to Joab, ‹Come near here, that I may speak with you.› »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="17" characterId="narrator-2SA">
     <verse num="17" />

--- a/DistFiles/reference_texts/English/ACT.xml
+++ b/DistFiles/reference_texts/English/ACT.xml
@@ -272,7 +272,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="35" characterId="Peter (Simon)">
     <verse num="35" />
-    <text>until I make your enemies a footstool for your feet.» ›</text>
+    <text>until I make your enemies a footstool for your feet.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="36" characterId="Peter (Simon)">
     <verse num="36" />
@@ -2279,7 +2279,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="41" characterId="Paul" delivery="preaching">
     <verse num="41" />
-    <text>‹Behold, you scoffers, and wonder, and perish; for I work a work in your days, a work which you will in no way believe, if one declares it to you.› »</text>
+    <text>‹Behold, you scoffers, and wonder, and perish; for I work a work in your days, a work which you will in no way believe, if one declares it to you.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="42" characterId="narrator-ACT">
     <verse num="42" />
@@ -2309,7 +2309,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="47" characterId="Paul/Barnabas" delivery="boldly">
     <verse num="47" />
-    <text>For so has the Lord commanded us, saying, ‹I have set you as a light for the Gentiles, that you should bring salvation to the uttermost parts of the earth.› »</text>
+    <text>For so has the Lord commanded us, saying, ‹I have set you as a light for the Gentiles, that you should bring salvation to the uttermost parts of the earth.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="48" characterId="narrator-ACT">
     <verse num="48" />
@@ -3499,7 +3499,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="35" characterId="Paul">
     <verse num="35" />
-    <text>In all things I gave you an example, that so laboring you ought to help the weak. We must remember the words that the Lord Jesus said, ‹It is more blessed to give than to receive.› »</text>
+    <text>In all things I gave you an example, that so laboring you ought to help the weak. We must remember the words that the Lord Jesus said, ‹It is more blessed to give than to receive.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="36" characterId="narrator-ACT">
     <verse num="36" />
@@ -3561,7 +3561,7 @@
     <text>Coming to us, and taking Paul’s belt, he bound his own feet and hands, and said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="11" characterId="Agabus the prophet" delivery="proclaim">
-    <text>«Thus says the Holy Spirit: ‹So will the Jews at Jerusalem bind the man who owns this belt, and will deliver him into the hands of the Gentiles.› »</text>
+    <text>«Thus says the Holy Spirit: ‹So will the Jews at Jerusalem bind the man who owns this belt, and will deliver him into the hands of the Gentiles.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="12" characterId="narrator-ACT">
     <verse num="12" />
@@ -3792,7 +3792,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="21" characterId="Paul" delivery="preaching">
     <verse num="21" />
-    <text>«He said to me, ‹Depart, for I will send you out far from here to the Gentiles.› »</text>
+    <text>«He said to me, ‹Depart, for I will send you out far from here to the Gentiles.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="22" characterId="narrator-ACT">
     <verse num="22" />
@@ -3890,7 +3890,7 @@
     <text>Paul said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="5" characterId="Paul">
-    <text>«I didn’t know, brothers, that he was high priest. For it is written, ‹You shall not speak evil of a ruler of your people.› »</text>
+    <text>«I didn’t know, brothers, that he was high priest. For it is written, ‹You shall not speak evil of a ruler of your people.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="6" characterId="narrator-ACT">
     <verse num="6" />
@@ -4154,7 +4154,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="24" initialStartVerse="21" characterId="Paul">
     <verse num="21" />
-    <text>unless it is for this one thing that I cried standing among them, ‹Concerning the resurrection of the dead I am being judged before you today!› »</text>
+    <text>unless it is for this one thing that I cried standing among them, ‹Concerning the resurrection of the dead I am being judged before you today!› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="24" initialStartVerse="22" characterId="narrator-ACT">
     <verse num="22" />

--- a/DistFiles/reference_texts/English/AMO.xml
+++ b/DistFiles/reference_texts/English/AMO.xml
@@ -603,7 +603,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="11" characterId="Amaziah, priest of Bethel">
     <verse num="11" />
-    <text>For Amos says, ‹Jeroboam will die by the sword, and Israel shall surely be led away captive out of his land.› »</text>
+    <text>For Amos says, ‹Jeroboam will die by the sword, and Israel shall surely be led away captive out of his land.› »</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="12" characterId="narrator-AMO">
     <verse num="12" />
@@ -637,7 +637,7 @@
     <text>Therefore thus says God:</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="17" characterId="God">
-    <text>‹Your wife shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.› »</text>
+    <text>‹Your wife shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="8" book="AMO" initialStartVerse="0" characterId="BC-AMO">
     <text>8</text>
@@ -678,7 +678,7 @@
   </block>
   <block style="p" chapter="8" initialStartVerse="6" characterId="oppressors of poor">
     <verse num="6" />
-    <text>that we may buy the poor for silver, and the needy for a pair of shoes, and sell the sweepings with the wheat?› »</text>
+    <text>that we may buy the poor for silver, and the needy for a pair of shoes, and sell the sweepings with the wheat?› »</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="7" characterId="narrator-AMO">
     <verse num="7" />

--- a/DistFiles/reference_texts/English/EST.xml
+++ b/DistFiles/reference_texts/English/EST.xml
@@ -485,7 +485,7 @@
   </block>
   <block style="p" chapter="6" initialStartVerse="9" characterId="Haman, highest noble to Xerxes, king">
     <verse num="9" />
-    <text>Let the clothing and the horse be delivered to the hand of one of the king’s most noble princes, that they may array the man whom the king delights to honor with them, and have him ride on horseback through the city square, and proclaim before him, ‹Thus shall it be done to the man whom the king delights to honor!› »</text>
+    <text>Let the clothing and the horse be delivered to the hand of one of the king’s most noble princes, that they may array the man whom the king delights to honor with them, and have him ride on horseback through the city square, and proclaim before him, ‹Thus shall it be done to the man whom the king delights to honor!› »</text>
   </block>
   <block style="p" chapter="6" initialStartVerse="10" characterId="narrator-EST">
     <verse num="10" />

--- a/DistFiles/reference_texts/English/EZK.xml
+++ b/DistFiles/reference_texts/English/EZK.xml
@@ -582,7 +582,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="15" characterId="God">
     <verse num="15" />
-    <text>« ‹The sword is outside, and the pestilence and the famine within. He who is in the field will die by the sword. He who is in the city will be devoured by famine and pestilence.</text>
+    <text>« ‹The sword is outside, and the pestilence and the famine within. He who is in the field will die by the sword. He who is in the city will be devoured by famine and pestilence.</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="16" characterId="God">
     <verse num="16" />
@@ -614,7 +614,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="23" characterId="God">
     <verse num="23" />
-    <text>« ‹Make chains, for the land is full of bloody crimes, and the city is full of violence.</text>
+    <text>« ‹Make chains, for the land is full of bloody crimes, and the city is full of violence.</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="24" characterId="God">
     <verse num="24" />
@@ -630,7 +630,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="27" characterId="God">
     <verse num="27" />
-    <text>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am God.› »
+    <text>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am God.› »
 </text>
   </block>
   <block style="c" paragraphStart="true" chapter="8" book="EZK" initialStartVerse="0" characterId="BC-EZK">
@@ -950,7 +950,7 @@
   </block>
   <block style="p" chapter="11" initialStartVerse="12" characterId="God">
     <verse num="12" />
-    <text>You will know that I am God, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.» › »</text>
+    <text>You will know that I am God, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.» › »</text>
   </block>
   <block style="p" chapter="11" initialStartVerse="13" characterId="narrator-EZK">
     <verse num="13" />
@@ -1106,7 +1106,7 @@
   </block>
   <block style="p" chapter="12" initialStartVerse="20" characterId="God">
     <verse num="20" />
-    <text>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am God.» › »</text>
+    <text>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am God.» › »</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="21" characterId="narrator-EZK">
     <verse num="21" />
@@ -1122,7 +1122,7 @@
     <text>The Lord God says:</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="23" characterId="God">
-    <text>«I will make this proverb to cease, and they will no more use it as a proverb in Israel;» › but tell them, ‹ «The days are at hand, and the fulfillment of every vision.</text>
+    <text>«I will make this proverb to cease, and they will no more use it as a proverb in Israel;» › but tell them, ‹ «The days are at hand, and the fulfillment of every vision.</text>
   </block>
   <block style="p" chapter="12" initialStartVerse="24" characterId="God">
     <verse num="24" />
@@ -1299,7 +1299,7 @@
   </block>
   <block style="p" chapter="14" initialStartVerse="5" characterId="God">
     <verse num="5" />
-    <text>that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.» ›</text>
+    <text>that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.» ›</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="6" characterId="God">
     <verse num="6" />
@@ -1313,7 +1313,7 @@
   </block>
   <block style="p" chapter="14" initialStartVerse="7" characterId="God">
     <verse num="7" />
-    <text>« ‹ «For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I God will answer him by myself.</text>
+    <text>« ‹ «For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I God will answer him by myself.</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="8" characterId="God">
     <verse num="8" />
@@ -1321,7 +1321,7 @@
   </block>
   <block style="p" chapter="14" initialStartVerse="9" characterId="God">
     <verse num="9" />
-    <text>« ‹ «If the prophet is deceived and speaks a word, I, God, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel.</text>
+    <text>« ‹ «If the prophet is deceived and speaks a word, I, God, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel.</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="10" characterId="God">
     <verse num="10" />
@@ -1332,7 +1332,7 @@
     <text>that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their God,»</text>
   </block>
   <block style="p" chapter="14" initialStartVerse="11" characterId="narrator-EZK">
-    <text>says the Lord God.› » </text>
+    <text>says the Lord God.› » </text>
     <verse num="12" />
     <text>God’s word came to me, saying,</text>
   </block>
@@ -2309,11 +2309,11 @@
   </block>
   <block style="p" chapter="20" initialStartVerse="48" characterId="God">
     <verse num="48" />
-    <text>All flesh will see that I, God, have kindled it. It will not be quenched.» › »</text>
+    <text>All flesh will see that I, God, have kindled it. It will not be quenched.» › »</text>
   </block>
   <block style="p" chapter="20" initialStartVerse="49" characterId="narrator-EZK">
     <verse num="49" />
-    <text>Then I said, «Ah Lord God! They say of me, ‹Isn’t he a speaker of parables?› »</text>
+    <text>Then I said, «Ah Lord God! They say of me, ‹Isn’t he a speaker of parables?› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="21" book="EZK" initialStartVerse="0" characterId="BC-EZK">
     <text>21</text>
@@ -2935,7 +2935,7 @@
   </block>
   <block style="p" chapter="24" initialStartVerse="24" characterId="God">
     <verse num="24" />
-    <text>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord God.› » › »</text>
+    <text>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord God.› » › »</text>
   </block>
   <block style="p" chapter="24" initialStartVerse="25" characterId="God">
     <verse num="25" />
@@ -4258,7 +4258,7 @@
   </block>
   <block style="p" chapter="35" initialStartVerse="5" characterId="God">
     <verse num="5" />
-    <text>« ‹ «Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, </text>
+    <text>« ‹ «Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, </text>
     <verse num="6" />
     <text>therefore, as I live,»</text>
   </block>
@@ -4726,7 +4726,7 @@
     <text>Sheba, Dedan, and the merchants of Tarshish, with all its young lions, will ask you,</text>
   </block>
   <block style="p" chapter="38" initialStartVerse="13" characterId="Sheba, Dedan, and the merchants of Tarshish">
-    <text>‹Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?› » ›</text>
+    <text>‹Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?› » ›</text>
   </block>
   <block style="p" chapter="38" initialStartVerse="14" characterId="God">
     <verse num="14" />

--- a/DistFiles/reference_texts/English/HAG.xml
+++ b/DistFiles/reference_texts/English/HAG.xml
@@ -195,7 +195,7 @@
     <text>Then Haggai answered,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="14" characterId="God">
-    <text>« ‹So is this people, and so is this nation before me,›</text>
+    <text>« ‹So is this people, and so is this nation before me,›</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="14" characterId="narrator-HAG">
     <text>says God;</text>
@@ -224,7 +224,7 @@
   </block>
   <block style="p" chapter="2" initialStartVerse="19" characterId="God">
     <verse num="19" />
-    <text>Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t brought forth. From this day will I bless you.› »</text>
+    <text>Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t brought forth. From this day will I bless you.› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="20" characterId="narrator-HAG">
     <verse num="20" />

--- a/DistFiles/reference_texts/English/HEB.xml
+++ b/DistFiles/reference_texts/English/HEB.xml
@@ -225,7 +225,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="11" characterId="scripture">
     <verse num="11" />
-    <text>I swore in my wrath, ‹They will not enter into my rest.› »</text>
+    <text>I swore in my wrath, ‹They will not enter into my rest.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="12" characterId="narrator-HEB">
     <verse num="12" />
@@ -566,7 +566,7 @@
     <text>(They indeed have been made priests without an oath), but he with an oath by him that says of him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="21" characterId="scripture">
-    <text>«The Lord swore and will not change his mind, ‹You are a priest forever, according to the order of Melchizedek.› »</text>
+    <text>«The Lord swore and will not change his mind, ‹You are a priest forever, according to the order of Melchizedek.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="22" characterId="narrator-HEB">
     <verse num="22" />
@@ -808,7 +808,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="7" characterId="scripture">
     <verse num="7" />
-    <text>Then I said, ‹Behold, I have come (in the scroll of the book it is written of me) to do your will, O God.› »</text>
+    <text>Then I said, ‹Behold, I have come (in the scroll of the book it is written of me) to do your will, O God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="8" characterId="narrator-HEB">
     <verse num="8" />
@@ -847,7 +847,7 @@
     <text>«This is the covenant that I will make with them:</text>
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="16" characterId="scripture">
-    <text>‹After those days,› says the Lord, ‹I will put my laws on their heart, I will also write them on their mind;› »</text>
+    <text>‹After those days,› says the Lord, ‹I will put my laws on their heart, I will also write them on their mind;› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="17" characterId="narrator-HEB">
     <verse num="17" />

--- a/DistFiles/reference_texts/English/HOS.xml
+++ b/DistFiles/reference_texts/English/HOS.xml
@@ -162,7 +162,7 @@
   </block>
   <block style="p" chapter="2" initialStartVerse="23" characterId="God">
     <verse num="23" />
-    <text>I will sow her to me in the earth; and I will have mercy on her who had not obtained mercy; and I will tell those who were not my people, ‹You are my people;› and they will say, ‹My God!› »</text>
+    <text>I will sow her to me in the earth; and I will have mercy on her who had not obtained mercy; and I will tell those who were not my people, ‹You are my people;› and they will say, ‹My God!› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="3" book="HOS" initialStartVerse="0" characterId="BC-HOS">
     <text>3</text>

--- a/DistFiles/reference_texts/English/ISA.xml
+++ b/DistFiles/reference_texts/English/ISA.xml
@@ -603,7 +603,7 @@
   </block>
   <block style="p" chapter="7" initialStartVerse="9" characterId="God">
     <verse num="9" />
-    <text>and the head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.› »</text>
+    <text>and the head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.› »</text>
   </block>
   <block style="p" chapter="7" initialStartVerse="10" characterId="narrator-ISA">
     <verse num="10" />
@@ -1685,7 +1685,7 @@
   </block>
   <block style="p" chapter="20" initialStartVerse="6" characterId="God">
     <verse num="6" />
-    <text>The inhabitants of this coast land will say in that day, Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?› »</text>
+    <text>The inhabitants of this coast land will say in that day, Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="21" book="ISA" initialStartVerse="0" characterId="BC-ISA">
     <text>21</text>
@@ -3032,7 +3032,7 @@
   </block>
   <block style="p" chapter="36" initialStartVerse="7" characterId="Rabshakeh">
     <verse num="7" />
-    <text>But if you tell me, ‹We trust in God our God,› isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‹You shall worship before this altar?› »</text>
+    <text>But if you tell me, ‹We trust in God our God,› isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‹You shall worship before this altar?› »</text>
   </block>
   <block style="p" chapter="36" initialStartVerse="8" characterId="Rabshakeh">
     <verse num="8" />
@@ -3093,7 +3093,7 @@
   </block>
   <block style="p" chapter="36" initialStartVerse="20" characterId="Rabshakeh">
     <verse num="20" />
-    <text>Who are they among all the gods of these countries that have delivered their country out of my hand, that God should deliver Jerusalem out of my hand?› »</text>
+    <text>Who are they among all the gods of these countries that have delivered their country out of my hand, that God should deliver Jerusalem out of my hand?› »</text>
   </block>
   <block style="p" chapter="36" initialStartVerse="21" characterId="narrator-ISA">
     <verse num="21" />
@@ -3124,7 +3124,7 @@
   </block>
   <block style="p" chapter="37" initialStartVerse="4" characterId="Eliakim/Shebna/chief priests">
     <verse num="4" />
-    <text>It may be God your God will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living God, and will rebuke the words which God your God has heard. Therefore lift up your prayer for the remnant that is left.› »</text>
+    <text>It may be God your God will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living God, and will rebuke the words which God your God has heard. Therefore lift up your prayer for the remnant that is left.› »</text>
   </block>
   <block style="p" chapter="37" initialStartVerse="5" characterId="narrator-ISA">
     <verse num="5" />
@@ -3167,7 +3167,7 @@
   </block>
   <block style="p" chapter="37" initialStartVerse="13" characterId="Rabshakeh">
     <verse num="13" />
-    <text>Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?› »</text>
+    <text>Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?› »</text>
   </block>
   <block style="p" chapter="37" initialStartVerse="14" characterId="narrator-ISA">
     <verse num="14" />
@@ -3256,7 +3256,7 @@
     <verse num="34" />
     <text>By the way that he came, by the same he shall return, and he shall not come to this city,› says God. </text>
     <verse num="35" />
-    <text>For I will defend this city to save it, for my own sake, and for my servant David’s sake.› »</text>
+    <text>For I will defend this city to save it, for my own sake, and for my servant David’s sake.› »</text>
   </block>
   <block style="p" chapter="37" initialStartVerse="36" characterId="narrator-ISA">
     <verse num="36" />
@@ -3278,7 +3278,7 @@
     <text>In those days was Hezekiah sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him,</text>
   </block>
   <block style="p" chapter="38" initialStartVerse="1" characterId="Isaiah">
-    <text>«Thus says God, ‹Set your house in order, for you will die, and not live.› »</text>
+    <text>«Thus says God, ‹Set your house in order, for you will die, and not live.› »</text>
   </block>
   <block style="p" chapter="38" initialStartVerse="2" characterId="narrator-ISA">
     <verse num="2" />
@@ -3427,7 +3427,7 @@
   </block>
   <block style="p" chapter="39" initialStartVerse="7" characterId="Isaiah">
     <verse num="7" />
-    <text>They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.› »</text>
+    <text>They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.› »</text>
   </block>
   <block style="p" chapter="39" initialStartVerse="8" characterId="narrator-ISA">
     <verse num="8" />
@@ -3853,7 +3853,7 @@
   </block>
   <block style="p" chapter="43" initialStartVerse="7" characterId="God">
     <verse num="7" />
-    <text>everyone who is called by my name, and whom I have created for my glory, whom I have formed, yes, whom I have made.› »</text>
+    <text>everyone who is called by my name, and whom I have created for my glory, whom I have formed, yes, whom I have made.› »</text>
   </block>
   <block style="p" chapter="43" initialStartVerse="8" characterId="narrator-ISA">
     <verse num="8" />
@@ -4083,7 +4083,7 @@
   </block>
   <block style="p" chapter="44" initialStartVerse="28" characterId="God">
     <verse num="28" />
-    <text>Who says of Cyrus, ‹He is my shepherd, and shall perform all my pleasure,› even saying of Jerusalem, ‹She will be built;› and of the temple, ‹Your foundation will be laid.› »</text>
+    <text>Who says of Cyrus, ‹He is my shepherd, and shall perform all my pleasure,› even saying of Jerusalem, ‹She will be built;› and of the temple, ‹Your foundation will be laid.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="45" book="ISA" initialStartVerse="0" characterId="BC-ISA">
     <text>45</text>
@@ -4152,7 +4152,7 @@
     <text>«The labor of Egypt, and the merchandise of Ethiopia, and the Sabeans, men of stature, shall come over to you, and they shall be yours. They will go after you. They shall come over in chains; and they will bow down to you. They will make supplication to you:</text>
   </block>
   <block style="p" chapter="45" initialStartVerse="14" characterId="God">
-    <text>‹Surely God is in you; and there is no one else. There is no other god.› »</text>
+    <text>‹Surely God is in you; and there is no one else. There is no other god.› »</text>
   </block>
   <block style="p" chapter="45" initialStartVerse="15" characterId="Needs Review">
     <verse num="15" />
@@ -4193,7 +4193,7 @@
   </block>
   <block style="p" chapter="45" initialStartVerse="24" characterId="God">
     <verse num="24" />
-    <text>They will say of me, ‹There is righteousness and strength only in God.› »</text>
+    <text>They will say of me, ‹There is righteousness and strength only in God.› »</text>
   </block>
   <block style="p" chapter="45" initialStartVerse="24" characterId="narrator-ISA">
     <text>Even to him shall men come; and all those who were incensed against him shall be disappointed.</text>
@@ -5488,7 +5488,7 @@
     <text>Behold, God has proclaimed to the end of the earth,</text>
   </block>
   <block style="p" chapter="62" initialStartVerse="11" characterId="God">
-    <text>«Say to the daughter of Zion, ‹Behold, your salvation comes. Behold, his reward is with him, and his recompense before him.› »</text>
+    <text>«Say to the daughter of Zion, ‹Behold, your salvation comes. Behold, his reward is with him, and his recompense before him.› »</text>
   </block>
   <block style="p" chapter="62" initialStartVerse="12" characterId="narrator-ISA">
     <verse num="12" />

--- a/DistFiles/reference_texts/English/JER.xml
+++ b/DistFiles/reference_texts/English/JER.xml
@@ -1364,7 +1364,7 @@
     <text>For a voice of wailing is heard out of Zion,</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="19" characterId="daughter of Zion" delivery="wailing">
-    <text>‹How are we ruined! we are greatly confounded, because we have forsaken the land, because they have cast down our dwellings.› »</text>
+    <text>‹How are we ruined! we are greatly confounded, because we have forsaken the land, because they have cast down our dwellings.› »</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="20" characterId="narrator-JER">
     <verse num="20" />
@@ -3471,7 +3471,7 @@
     <text>«Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying,</text>
   </block>
   <block style="p" chapter="26" initialStartVerse="18" characterId="elders of the land">
-    <text>‹Thus says God of Armies: «Zion shall be plowed as a field, and Jerusalem shall become heaps, and the mountain of the house as the high places of a forest.» ›</text>
+    <text>‹Thus says God of Armies: «Zion shall be plowed as a field, and Jerusalem shall become heaps, and the mountain of the house as the high places of a forest.» ›</text>
   </block>
   <block style="p" chapter="26" initialStartVerse="19" characterId="elders of the land">
     <verse num="19" />
@@ -3629,7 +3629,7 @@
     <text>says God;</text>
   </block>
   <block style="p" chapter="27" initialStartVerse="22" characterId="God">
-    <text>‹then will I bring them up, and restore them to this place.› »</text>
+    <text>‹then will I bring them up, and restore them to this place.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="28" book="JER" initialStartVerse="0" characterId="BC-JER">
     <text>28</text>
@@ -4589,7 +4589,7 @@
   </block>
   <block style="p" chapter="34" initialStartVerse="3" characterId="God">
     <verse num="3" />
-    <text>You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.» ›</text>
+    <text>You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.» ›</text>
   </block>
   <block style="p" chapter="34" initialStartVerse="4" characterId="narrator-JER">
     <verse num="4" />

--- a/DistFiles/reference_texts/English/JHN.xml
+++ b/DistFiles/reference_texts/English/JHN.xml
@@ -67,7 +67,7 @@
     <text>John testified about him. He cried out, saying,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="15" characterId="John the Baptist">
-    <text>«This was he of whom I said, ‹He who comes after me has surpassed me, for he was before me.› »</text>
+    <text>«This was he of whom I said, ‹He who comes after me has surpassed me, for he was before me.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="16" characterId="narrator-JHN">
     <verse num="16" />
@@ -981,7 +981,7 @@
     <text>He answered them,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="11" characterId="invalid for 38 years">
-    <text>«He who made me well, the same said to me, ‹Take up your mat, and walk.› »</text>
+    <text>«He who made me well, the same said to me, ‹Take up your mat, and walk.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="12" characterId="narrator-JHN">
     <verse num="12" />
@@ -1290,7 +1290,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="31" characterId="people in crowd by Sea of Galilee" delivery="superior">
     <verse num="31" />
-    <text>Our fathers ate the manna in the wilderness. As it is written, ‹He gave them bread out of heaven to eat.› »</text>
+    <text>Our fathers ate the manna in the wilderness. As it is written, ‹He gave them bread out of heaven to eat.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="32" characterId="narrator-JHN">
     <verse num="32" />
@@ -1346,7 +1346,7 @@
     <text>They said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="42" characterId="Jews, the" delivery="grumbling">
-    <text>«Isn’t this Jesus, the son of Joseph, whose father and mother we know? How then does he say, ‹I have come down out of heaven?› »</text>
+    <text>«Isn’t this Jesus, the son of Joseph, whose father and mother we know? How then does he say, ‹I have come down out of heaven?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="43" characterId="narrator-JHN">
     <verse num="43" />
@@ -1901,7 +1901,7 @@
     <text>The Jews therefore said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="22" characterId="Jews, the">
-    <text>«Will he kill himself, that he says, ‹Where I am going, you can’t come?› »</text>
+    <text>«Will he kill himself, that he says, ‹Where I am going, you can’t come?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="23" characterId="narrator-JHN">
     <verse num="23" />
@@ -1964,7 +1964,7 @@
     <text>They answered him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="33" characterId="Jews who had believed Jesus" delivery="superior">
-    <text>«We are Abraham’s seed, and have never been in bondage to anyone. How do you say, ‹You will be made free?› »</text>
+    <text>«We are Abraham’s seed, and have never been in bondage to anyone. How do you say, ‹You will be made free?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="34" characterId="narrator-JHN">
     <verse num="34" />
@@ -3685,7 +3685,7 @@
     <text>Some of his disciples therefore said to one another,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="17" characterId="disciples" delivery="puzzled">
-    <text>«What is this that he says to us, ‹A little while, and you won’t see me, and again a little while, and you will see me;› and, ‹Because I go to the Father?› »</text>
+    <text>«What is this that he says to us, ‹A little while, and you won’t see me, and again a little while, and you will see me;› and, ‹Because I go to the Father?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="18" characterId="narrator-JHN">
     <verse num="18" />
@@ -4282,7 +4282,7 @@
     <text>The chief priests of the Jews therefore said to Pilate,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="21" characterId="chief priests" delivery="protesting">
-    <text>«Don’t write, ‹The King of the Jews,› but, ‹he said, I am King of the Jews.› »</text>
+    <text>«Don’t write, ‹The King of the Jews,› but, ‹he said, I am King of the Jews.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="22" characterId="narrator-JHN">
     <verse num="22" />
@@ -4511,7 +4511,7 @@
     <text>Jesus said to her,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="17" characterId="Jesus">
-    <text>«Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers, and tell them, ‹I am ascending to my Father and your Father, to my God and your God.› »</text>
+    <text>«Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers, and tell them, ‹I am ascending to my Father and your Father, to my God and your God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="18" characterId="narrator-JHN">
     <verse num="18" />

--- a/DistFiles/reference_texts/English/JOB.xml
+++ b/DistFiles/reference_texts/English/JOB.xml
@@ -2662,7 +2662,7 @@
   </block>
   <block style="p" chapter="28" initialStartVerse="28" characterId="Job">
     <verse num="28" />
-    <text>To man he said, ‹Behold, the fear of the Lord, that is wisdom. To depart from evil is understanding.› »</text>
+    <text>To man he said, ‹Behold, the fear of the Lord, that is wisdom. To depart from evil is understanding.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="29" book="JOB" initialStartVerse="0" characterId="BC-JOB">
     <text>29</text>

--- a/DistFiles/reference_texts/English/JOL.xml
+++ b/DistFiles/reference_texts/English/JOL.xml
@@ -164,7 +164,7 @@
     <text>Let the priests, the ministers of God, weep between the porch and the altar, and let them say,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="17" characterId="priests" delivery="weeping, pleading">
-    <text>«Spare your people, God, and don’t give your heritage to reproach, that the nations should rule over them. Why should they say among the peoples, ‹Where is their God?› »</text>
+    <text>«Spare your people, God, and don’t give your heritage to reproach, that the nations should rule over them. Why should they say among the peoples, ‹Where is their God?› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="18" characterId="narrator-JOL">
     <verse num="18" />

--- a/DistFiles/reference_texts/English/JOS.xml
+++ b/DistFiles/reference_texts/English/JOS.xml
@@ -2529,7 +2529,7 @@
   </block>
   <block style="p" chapter="22" initialStartVerse="25" characterId="Reubenites/Gadites/half-tribe of Manasseh">
     <verse num="25" />
-    <text>For God has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in God.» › So your children might make our children cease from fearing God.</text>
+    <text>For God has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in God.» › So your children might make our children cease from fearing God.</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="26" characterId="Reubenites/Gadites/half-tribe of Manasseh">
     <verse num="26" />
@@ -2541,7 +2541,7 @@
   </block>
   <block style="p" chapter="22" initialStartVerse="28" characterId="Reubenites/Gadites/half-tribe of Manasseh">
     <verse num="28" />
-    <text>Therefore we said, ‹It shall be, when they tell us or our generations this in time to come, that we shall say, «Behold the pattern of the altar of God, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.» ›</text>
+    <text>Therefore we said, ‹It shall be, when they tell us or our generations this in time to come, that we shall say, «Behold the pattern of the altar of God, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.» ›</text>
   </block>
   <block style="p" chapter="22" initialStartVerse="29" characterId="Reubenites/Gadites/half-tribe of Manasseh">
     <verse num="29" />

--- a/DistFiles/reference_texts/English/LUK.xml
+++ b/DistFiles/reference_texts/English/LUK.xml
@@ -631,7 +631,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="scripture">
     <verse num="6" />
-    <text>All flesh will see God’s salvation.› »</text>
+    <text>All flesh will see God’s salvation.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="7" characterId="narrator-LUK">
     <verse num="7" />
@@ -822,7 +822,7 @@
     <text>Jesus answered him, saying,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-    <text>«It is written, ‹Man shall not live by bread alone, but by every word of God.› »</text>
+    <text>«It is written, ‹Man shall not live by bread alone, but by every word of God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="5" characterId="narrator-LUK">
     <verse num="5" />
@@ -842,7 +842,7 @@
     <text>Jesus answered him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="8" characterId="Jesus">
-    <text>«Get behind me Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+    <text>«Get behind me Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="9" characterId="narrator-LUK">
     <verse num="9" />
@@ -864,7 +864,7 @@
     <text>Jesus answering, said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus">
-    <text>«It has been said, ‹You shall not tempt the Lord your God.› »</text>
+    <text>«It has been said, ‹You shall not tempt the Lord your God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="13" characterId="narrator-LUK">
     <verse num="13" />
@@ -916,7 +916,7 @@
     <text>He said to them,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="23" characterId="Jesus">
-    <text>«Doubtless you will tell me this parable, ‹Physician, heal yourself! Whatever we have heard done at Capernaum, do also here in your hometown.› »</text>
+    <text>«Doubtless you will tell me this parable, ‹Physician, heal yourself! Whatever we have heard done at Capernaum, do also here in your hometown.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="24" characterId="narrator-LUK">
     <verse num="24" />
@@ -1236,7 +1236,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="39" characterId="Jesus">
     <verse num="39" />
-    <text>No man having drunk old wine immediately desires new, for he says, ‹The old is better.› »</text>
+    <text>No man having drunk old wine immediately desires new, for he says, ‹The old is better.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="6" book="LUK" initialStartVerse="0" characterId="BC-LUK">
     <text>6</text>
@@ -1574,7 +1574,7 @@
     <text>When the men had come to him, they said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="20" characterId="disciples of John the Baptist" delivery="puzzled">
-    <text>«John the Baptizer has sent us to you, saying, ‹Are you he who comes, or should we look for another?› »</text>
+    <text>«John the Baptizer has sent us to you, saying, ‹Are you he who comes, or should we look for another?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="21" characterId="narrator-LUK">
     <verse num="21" />
@@ -1997,7 +1997,7 @@
     <text>Peter said:</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="45" characterId="Peter (Simon)" delivery="perplexed">
-    <text>«Master, the multitudes press and jostle you, and you say, ‹Who touched me?› »</text>
+    <text>«Master, the multitudes press and jostle you, and you say, ‹Who touched me?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="46" characterId="narrator-LUK">
     <verse num="46" />
@@ -2186,7 +2186,7 @@
     <text>They answered,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="19" characterId="disciples" delivery="excited">
-    <text>« ‹John the Baptizer,› but others say, ‹Elijah,› and others, that one of the old prophets is risen again.»</text>
+    <text>« ‹John the Baptizer,› but others say, ‹Elijah,› and others, that one of the old prophets is risen again.»</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="20" characterId="narrator-LUK">
     <verse num="20" />
@@ -2608,7 +2608,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="35" characterId="Jesus">
     <verse num="35" />
-    <text>On the next day, when he departed, he took out two denarii, and gave them to the host, and said to him, ‹Take care of him. Whatever you spend beyond that, I will repay you when I return.› »</text>
+    <text>On the next day, when he departed, he took out two denarii, and gave them to the host, and said to him, ‹Take care of him. Whatever you spend beyond that, I will repay you when I return.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="36" characterId="narrator-LUK">
     <verse num="36" />
@@ -2677,7 +2677,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="11" initialStartVerse="4" characterId="Jesus" delivery="instructing">
     <verse num="4" />
-    <text>Forgive us our sins, for we ourselves also forgive everyone who is indebted to us. Bring us not into temptation, but deliver us from evil.› »</text>
+    <text>Forgive us our sins, for we ourselves also forgive everyone who is indebted to us. Bring us not into temptation, but deliver us from evil.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="11" initialStartVerse="5" characterId="narrator-LUK">
     <verse num="5" />
@@ -3003,7 +3003,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="19" characterId="Jesus">
     <verse num="19" />
-    <text>I will tell my soul, «Soul, you have many goods laid up for many years. Take your ease, eat, drink, be merry.» ›</text>
+    <text>I will tell my soul, «Soul, you have many goods laid up for many years. Take your ease, eat, drink, be merry.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="20" characterId="Jesus">
     <verse num="20" />
@@ -3218,7 +3218,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="9" characterId="Jesus">
     <verse num="9" />
-    <text>If it bears fruit, fine; but if not, after that, you can cut it down.› »</text>
+    <text>If it bears fruit, fine; but if not, after that, you can cut it down.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="10" characterId="narrator-LUK">
     <verse num="10" />
@@ -3348,7 +3348,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="35" characterId="Jesus">
     <verse num="35" />
-    <text>Behold, your house is left to you desolate. I tell you, you will not see me, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+    <text>Behold, your house is left to you desolate. I tell you, you will not see me, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="14" book="LUK" initialStartVerse="0" characterId="BC-LUK">
     <text>14</text>
@@ -3460,7 +3460,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="24" characterId="Jesus">
     <verse num="24" />
-    <text>For I tell you that none of those men who were invited will taste of my supper.› »</text>
+    <text>For I tell you that none of those men who were invited will taste of my supper.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="25" characterId="narrator-LUK">
     <verse num="25" />
@@ -3585,7 +3585,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="19" characterId="Jesus">
     <verse num="19" />
-    <text>I am no more worthy to be called your son. Make me as one of your hired servants.» ›</text>
+    <text>I am no more worthy to be called your son. Make me as one of your hired servants.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="20" characterId="Jesus">
     <verse num="20" />
@@ -3637,7 +3637,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="32" characterId="Jesus">
     <verse num="32" />
-    <text>But it was appropriate to celebrate and be glad, for this, your brother, was dead, and is alive again. He was lost, and is found.› »</text>
+    <text>But it was appropriate to celebrate and be glad, for this, your brother, was dead, and is alive again. He was lost, and is found.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="16" book="LUK" initialStartVerse="0" characterId="BC-LUK">
     <text>16</text>
@@ -3768,7 +3768,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="31" characterId="Jesus">
     <verse num="31" />
-    <text>«He said to him, ‹If they don’t listen to Moses and the prophets, neither will they be persuaded if one rises from the dead.› »</text>
+    <text>«He said to him, ‹If they don’t listen to Moses and the prophets, neither will they be persuaded if one rises from the dead.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="17" book="LUK" initialStartVerse="0" characterId="BC-LUK">
     <text>17</text>
@@ -3820,7 +3820,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="17" initialStartVerse="10" characterId="Jesus">
     <verse num="10" />
-    <text>Even so you also, when you have done all the things that are commanded you, say, ‹We are unworthy servants. We have done our duty.› »</text>
+    <text>Even so you also, when you have done all the things that are commanded you, say, ‹We are unworthy servants. We have done our duty.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="17" initialStartVerse="11" characterId="narrator-LUK">
     <verse num="11" />
@@ -3987,7 +3987,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="5" characterId="Jesus">
     <verse num="5" />
-    <text>However, because this widow keeps bothering me, I will defend her, or else she will wear me out by her continual coming.› »</text>
+    <text>However, because this widow keeps bothering me, I will defend her, or else she will wear me out by her continual coming.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="6" characterId="narrator-LUK">
     <verse num="6" />
@@ -4062,7 +4062,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="20" characterId="Jesus">
     <verse num="20" />
-    <text>You know the commandments: ‹Don’t commit adultery,› ‹Don’t murder,› ‹Don’t steal,› ‹Don’t give false testimony,› ‹Honor your father and your mother.› »</text>
+    <text>You know the commandments: ‹Don’t commit adultery,› ‹Don’t murder,› ‹Don’t steal,› ‹Don’t give false testimony,› ‹Honor your father and your mother.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="21" characterId="narrator-LUK">
     <verse num="21" />
@@ -4331,7 +4331,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="27" characterId="Jesus">
     <verse num="27" />
-    <text>But bring those enemies of mine who didn’t want me to reign over them here, and kill them before me.› »</text>
+    <text>But bring those enemies of mine who didn’t want me to reign over them here, and kill them before me.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="28" characterId="narrator-LUK">
     <verse num="28" />
@@ -4348,7 +4348,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="31" characterId="Jesus">
     <verse num="31" />
-    <text>If anyone asks you, ‹Why are you untying it?› say to him: ‹The Lord needs it.› »</text>
+    <text>If anyone asks you, ‹Why are you untying it?› say to him: ‹The Lord needs it.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="32" characterId="narrator-LUK">
     <verse num="32" />
@@ -4645,7 +4645,7 @@
     <verse num="42" />
     <text>David himself says in the book of Psalms, ‹The Lord said to my Lord, «Sit at my right hand, </text>
     <verse num="43" />
-    <text>until I make your enemies the footstool of your feet.» ›</text>
+    <text>until I make your enemies the footstool of your feet.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="44" characterId="Jesus">
     <verse num="44" />
@@ -4895,7 +4895,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="11" characterId="Jesus">
     <verse num="11" />
-    <text>Tell the master of the house, ‹The Teacher says to you, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
+    <text>Tell the master of the house, ‹The Teacher says to you, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="12" characterId="Jesus">
     <verse num="12" />

--- a/DistFiles/reference_texts/English/MAT.xml
+++ b/DistFiles/reference_texts/English/MAT.xml
@@ -142,7 +142,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law">
     <verse num="6" />
-    <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
+    <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="7" characterId="narrator-MAT">
     <verse num="7" />
@@ -342,7 +342,7 @@
     <text>But he answered,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-    <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
+    <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="5" characterId="narrator-MAT">
     <verse num="5" />
@@ -351,14 +351,14 @@
     <text>and said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)">
-    <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don’t dash your foot against a stone.› »</text>
+    <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don’t dash your foot against a stone.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="narrator-MAT">
     <verse num="7" />
     <text>Jesus said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus">
-    <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
+    <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="8" characterId="narrator-MAT">
     <verse num="8" />
@@ -374,7 +374,7 @@
     <text>Then Jesus said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking">
-    <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+    <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="11" characterId="narrator-MAT">
     <verse num="11" />
@@ -2014,7 +2014,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus">
     <verse num="30" />
-    <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, «First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.» › »</text>
+    <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, «First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.» › »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="31" characterId="narrator-MAT">
     <verse num="31" />
@@ -2391,7 +2391,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus">
     <verse num="9" />
-    <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
+    <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="10" characterId="narrator-MAT">
     <verse num="10" />
@@ -3148,11 +3148,11 @@
     <text>Jesus said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus">
-    <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
+    <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus">
     <verse num="19" />
-    <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
+    <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="20" characterId="narrator-MAT">
     <verse num="20" />
@@ -3483,7 +3483,7 @@
     <text>Jesus said to them,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus">
-    <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
+    <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="17" characterId="narrator-MAT">
     <verse num="17" />
@@ -3674,7 +3674,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus">
     <verse num="4" />
-    <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» ›</text>
+    <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="5" characterId="Jesus">
     <verse num="5" />
@@ -3830,7 +3830,7 @@
     <text>Jesus said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus">
-    <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
+    <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="38" characterId="Jesus">
     <verse num="38" />
@@ -4036,7 +4036,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking">
     <verse num="39" />
-    <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+    <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="24" book="MAT" initialStartVerse="0" characterId="BC-MAT">
     <text>24</text>
@@ -4535,7 +4535,7 @@
     <text>He said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus">
-    <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
+    <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="19" characterId="narrator-MAT">
     <verse num="19" />
@@ -4781,7 +4781,7 @@
     <text>and said,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false">
-    <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
+    <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="62" characterId="narrator-MAT">
     <verse num="62" />
@@ -5122,7 +5122,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering">
     <verse num="43" />
-    <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
+    <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="27" initialStartVerse="44" characterId="narrator-MAT">
     <verse num="44" />

--- a/DistFiles/reference_texts/English/MIC.xml
+++ b/DistFiles/reference_texts/English/MIC.xml
@@ -91,7 +91,7 @@
     <text>In that day they will take up a parable against you, and lament with a doleful lamentation, saying,</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="4" characterId="people" delivery="lament">
-    <text>We are utterly ruined! My people’s possession is divided up. Indeed he takes it from me and assigns our fields to traitors!› »</text>
+    <text>We are utterly ruined! My people’s possession is divided up. Indeed he takes it from me and assigns our fields to traitors!› »</text>
   </block>
   <block style="p" chapter="2" initialStartVerse="5" characterId="narrator-MIC">
     <verse num="5" />

--- a/DistFiles/reference_texts/English/MRK.xml
+++ b/DistFiles/reference_texts/English/MRK.xml
@@ -19,7 +19,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="3" characterId="scripture">
     <verse num="3" />
-    <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
+    <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="4" characterId="narrator-MRK">
     <verse num="4" />
@@ -605,7 +605,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus">
     <verse num="12" />
-    <text>that ‹seeing they may see, and not perceive; and hearing they may hear, and not understand; lest perhaps they should turn again, and their sins should be forgiven them.› »</text>
+    <text>that ‹seeing they may see, and not perceive; and hearing they may hear, and not understand; lest perhaps they should turn again, and their sins should be forgiven them.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="13" characterId="narrator-MRK">
     <verse num="13" />
@@ -916,7 +916,7 @@
     <text>His disciples said to him,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="31" characterId="disciples" delivery="perplexed">
-    <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
+    <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="32" characterId="narrator-MRK">
     <verse num="32" />
@@ -1373,7 +1373,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="11" characterId="Jesus" delivery="rebuking">
     <verse num="11" />
-    <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban,» › that is to say, given to God;</text>
+    <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban,» › that is to say, given to God;</text>
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="12" characterId="Jesus" delivery="rebuking">
     <verse num="12" />
@@ -2124,7 +2124,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="19" characterId="Jesus">
     <verse num="19" />
-    <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
+    <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="20" characterId="narrator-MRK">
     <verse num="20" />
@@ -2710,7 +2710,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="36" characterId="Jesus">
     <verse num="36" />
-    <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
+    <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="37" characterId="Jesus">
     <verse num="37" />
@@ -2999,7 +2999,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="14" characterId="Jesus">
     <verse num="14" />
-    <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
+    <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="15" characterId="Jesus">
     <verse num="15" />
@@ -3218,7 +3218,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="58" characterId="witnesses, false" delivery="mocking">
     <verse num="58" />
-    <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
+    <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="59" characterId="narrator-MRK">
     <verse num="59" />
@@ -3619,7 +3619,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="7" characterId="angels in white, two">
     <verse num="7" />
-    <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
+    <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="8" characterId="narrator-MRK">
     <verse num="8" />

--- a/DistFiles/reference_texts/English/NUM.xml
+++ b/DistFiles/reference_texts/English/NUM.xml
@@ -5414,7 +5414,7 @@
   </block>
   <block style="p" chapter="35" initialStartVerse="34" characterId="God">
     <verse num="34" />
-    <text>You shall not defile the land which you inhabit, in the midst of which I dwell: for I, God, dwell in the midst of the children of Israel.› »</text>
+    <text>You shall not defile the land which you inhabit, in the midst of which I dwell: for I, God, dwell in the midst of the children of Israel.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="36" book="NUM" initialStartVerse="0" characterId="BC-NUM">
     <text>36</text>

--- a/DistFiles/reference_texts/English/REV.xml
+++ b/DistFiles/reference_texts/English/REV.xml
@@ -103,7 +103,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="2" characterId="Jesus">
     <verse num="2" />
-    <text>« ‹I know your works, and your toil and perseverance, and that you can’t tolerate evil men. You have tested those who call themselves apostles, and they are not, and found them false.</text>
+    <text>« ‹I know your works, and your toil and perseverance, and that you can’t tolerate evil men. You have tested those who call themselves apostles, and they are not, and found them false.</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="3" characterId="Jesus">
     <verse num="3" />
@@ -123,7 +123,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="7" characterId="Jesus">
     <verse num="7" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat of the tree of life, which is in the Paradise of my God.» ›</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat of the tree of life, which is in the Paradise of my God.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="8" characterId="Jesus">
     <verse num="8" />
@@ -131,7 +131,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="9" characterId="Jesus">
     <verse num="9" />
-    <text>« ‹I know your works, oppression, and your poverty (but you are rich). The blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan.</text>
+    <text>« ‹I know your works, oppression, and your poverty (but you are rich). The blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan.</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="10" characterId="Jesus">
     <verse num="10" />
@@ -139,7 +139,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="11" characterId="Jesus">
     <verse num="11" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.» ›</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="12" characterId="Jesus">
     <verse num="12" />
@@ -147,7 +147,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="13" characterId="Jesus">
     <verse num="13" />
-    <text>« ‹I know your works and where you dwell, where Satan’s seat is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells.</text>
+    <text>« ‹I know your works and where you dwell, where Satan’s seat is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells.</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="14" characterId="Jesus">
     <verse num="14" />
@@ -163,7 +163,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="17" characterId="Jesus">
     <verse num="17" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, and I will give him a white stone, and on the stone a new name written, which no one knows but he who receives it.» ›</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, and I will give him a white stone, and on the stone a new name written, which no one knows but he who receives it.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="18" characterId="Jesus">
     <verse num="18" />
@@ -211,7 +211,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="29" characterId="Jesus">
     <verse num="29" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="3" book="REV" initialStartVerse="0" characterId="BC-REV">
     <text>3</text>
@@ -238,7 +238,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="Jesus">
     <verse num="6" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies.» ›</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies.» ›</text>
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="7" characterId="Jesus">
     <verse num="7" />
@@ -266,7 +266,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="13" characterId="Jesus">
     <verse num="13" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="14" characterId="Jesus">
     <verse num="14" />
@@ -302,7 +302,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="22" characterId="Jesus">
     <verse num="22" />
-    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+    <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="4" book="REV" initialStartVerse="0" characterId="BC-REV">
     <text>4</text>
@@ -1171,7 +1171,7 @@
     <text>I heard the voice from heaven saying,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="voice from heaven (God?)">
-    <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
+    <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="Holy Spirit, the">
     <text>«Yes,»</text>
@@ -1627,7 +1627,7 @@
     <text>He said to me,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="9" characterId="angel (one of the seven)">
-    <text>«Write, ‹Blessed are those who are invited to the marriage supper of the Lamb.› »</text>
+    <text>«Write, ‹Blessed are those who are invited to the marriage supper of the Lamb.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="9" characterId="narrator-REV">
     <text>He said to me,</text>

--- a/DistFiles/reference_texts/English/ROM.xml
+++ b/DistFiles/reference_texts/English/ROM.xml
@@ -1047,7 +1047,7 @@
     <text>But indeed, O man, who are you to reply against God?</text>
   </block>
   <block style="p" chapter="9" initialStartVerse="20" characterId="scripture">
-    <text>«Will the thing formed ask him who formed it, ‹Why did you make me like this?› »</text>
+    <text>«Will the thing formed ask him who formed it, ‹Why did you make me like this?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="21" characterId="narrator-ROM">
     <verse num="21" />
@@ -1074,7 +1074,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="26" characterId="scripture">
     <verse num="26" />
-    <text>«It will be that in the place where it was said to them, ‹You are not my people,› There they will be called ‹children of the living God.› »</text>
+    <text>«It will be that in the place where it was said to them, ‹You are not my people,› There they will be called ‹children of the living God.› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="27" characterId="narrator-ROM">
     <verse num="27" />
@@ -1597,7 +1597,7 @@
     <text>For it is written,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="11" characterId="scripture">
-    <text>« ‹As I live,› says the Lord, ‹to me every knee will bow. Every tongue will confess to God.»</text>
+    <text>« ‹As I live,› says the Lord, ‹to me every knee will bow. Every tongue will confess to God.»</text>
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="12" characterId="narrator-ROM">
     <verse num="12" />

--- a/DistFiles/reference_texts/English/ZEC.xml
+++ b/DistFiles/reference_texts/English/ZEC.xml
@@ -49,7 +49,7 @@
     <text>Then they repented and said,</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="6" characterId="Judah, repentant leaders">
-    <text>Just as God of Armies determined to do to us, according to our ways, and according to our practices, so he has dealt with us.› »</text>
+    <text>Just as God of Armies determined to do to us, according to our ways, and according to our practices, so he has dealt with us.› »</text>
   </block>
   <block style="p" chapter="1" initialStartVerse="7" characterId="narrator-ZEC">
     <verse num="7" />
@@ -308,7 +308,7 @@
   </block>
   <block style="p" chapter="4" initialStartVerse="7" characterId="God">
     <verse num="7" />
-    <text>Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‹Grace, grace, to it!› »</text>
+    <text>Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‹Grace, grace, to it!› »</text>
   </block>
   <block style="p" chapter="4" initialStartVerse="8" characterId="narrator-ZEC">
     <verse num="8" />
@@ -564,7 +564,7 @@
     <text>Thus says God:</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="3" characterId="God">
-    <text>«I have returned to Zion, and will dwell in the midst of Jerusalem. Jerusalem shall be called ‹The City of Truth;› and the mountain of God of Armies, ‹The Holy Mountain.› »</text>
+    <text>«I have returned to Zion, and will dwell in the midst of Jerusalem. Jerusalem shall be called ‹The City of Truth;› and the mountain of God of Armies, ‹The Holy Mountain.› »</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="4" characterId="narrator-ZEC">
     <verse num="4" />
@@ -677,7 +677,7 @@
     <text>«In those days, ten men will take hold, out of all the languages of the nations, they will take hold of the skirt of him who is a Jew, saying,</text>
   </block>
   <block style="p" chapter="8" initialStartVerse="23" characterId="nations">
-    <text>‹We will go with you, for we have heard that God is with you.› »</text>
+    <text>‹We will go with you, for we have heard that God is with you.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="9" book="ZEC" initialStartVerse="0" characterId="BC-ZEC">
     <text>9</text>
@@ -1028,7 +1028,7 @@
     <text>I will bring the third part into the fire, and will refine them as silver is refined, and will test them like gold is tested. They will call on my name, and I will hear them. I will say, ‹It is my people;› and they will say,</text>
   </block>
   <block style="p" chapter="13" initialStartVerse="9" characterId="people, God's">
-    <text>‹God is my God.› »</text>
+    <text>‹God is my God.› »</text>
   </block>
   <block style="c" paragraphStart="true" chapter="14" book="ZEC" initialStartVerse="0" characterId="BC-ZEC">
     <text>14</text>

--- a/DistFiles/reference_texts/Russian/2CO.xml
+++ b/DistFiles/reference_texts/Russian/2CO.xml
@@ -979,7 +979,7 @@
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="17" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="6" initialStartVerse="17" characterId="scripture">
       <verse num="17" />
-      <text>Therefore « ‹Come out from among them, and be separate,› says the Lord. ‹Touch no unclean thing. I will receive you.</text>
+      <text>Therefore « ‹Come out from among them, and be separate,› says the Lord. ‹Touch no unclean thing. I will receive you.</text>
     </ReferenceBlocks>
     <verse num="17" />
     <text>И потому выйдите из среды их и отделитесь, говорит Господь, и не прикасайтесь к нечистому; и Я прииму вас.</text>

--- a/DistFiles/reference_texts/Russian/ACT.xml
+++ b/DistFiles/reference_texts/Russian/ACT.xml
@@ -543,7 +543,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="35" characterId="Peter (Simon)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="35" characterId="Peter (Simon)">
       <verse num="35" />
-      <text>until I make your enemies a footstool for your feet.» ›</text>
+      <text>until I make your enemies a footstool for your feet.» ›</text>
     </ReferenceBlocks>
     <verse num="35" />
     <text>доколе положу врагов Твоих в подножие ног Твоих.»</text>
@@ -4557,7 +4557,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="41" characterId="Paul" delivery="preaching" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="41" characterId="Paul" delivery="preaching">
       <verse num="41" />
-      <text>‹Behold, you scoffers, and wonder, and perish; for I work a work in your days, a work which you will in no way believe, if one declares it to you.› »</text>
+      <text>‹Behold, you scoffers, and wonder, and perish; for I work a work in your days, a work which you will in no way believe, if one declares it to you.› »</text>
     </ReferenceBlocks>
     <verse num="41" />
     <text>смотрите, презрители, подивитесь и исчезните; ибо Я делаю дело во дни ваши, дело, которому не поверили бы вы, если бы кто рассказывал вам.»</text>
@@ -4617,7 +4617,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="47" characterId="Paul/Barnabas" delivery="boldly" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="47" characterId="Paul/Barnabas" delivery="boldly">
       <verse num="47" />
-      <text>For so has the Lord commanded us, saying, ‹I have set you as a light for the Gentiles, that you should bring salvation to the uttermost parts of the earth.› »</text>
+      <text>For so has the Lord commanded us, saying, ‹I have set you as a light for the Gentiles, that you should bring salvation to the uttermost parts of the earth.› »</text>
     </ReferenceBlocks>
     <verse num="47" />
     <text>Ибо так заповедал нам Господь: Я положил Тебя во свет язычникам, чтобы Ты был во спасение до края земли.»</text>
@@ -6997,7 +6997,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="35" characterId="Paul" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="35" characterId="Paul">
       <verse num="35" />
-      <text>In all things I gave you an example, that so laboring you ought to help the weak. We must remember the words that the Lord Jesus said, ‹It is more blessed to give than to receive.› »</text>
+      <text>In all things I gave you an example, that so laboring you ought to help the weak. We must remember the words that the Lord Jesus said, ‹It is more blessed to give than to receive.› »</text>
     </ReferenceBlocks>
     <verse num="35" />
     <text>Во всем показал я вам, что, так трудясь, надобно поддерживать слабых и памятовать слова Господа Иисуса, ибо Он Сам сказал: ‹блаженнее давать, нежели принимать›.»</text>
@@ -7122,7 +7122,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="11" characterId="Agabus the prophet" delivery="proclaim" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="11" characterId="Agabus the prophet" delivery="proclaim">
-      <text>«Thus says the Holy Spirit: ‹So will the Jews at Jerusalem bind the man who owns this belt, and will deliver him into the hands of the Gentiles.› »</text>
+      <text>«Thus says the Holy Spirit: ‹So will the Jews at Jerusalem bind the man who owns this belt, and will deliver him into the hands of the Gentiles.› »</text>
     </ReferenceBlocks>
     <text>«так говорит Дух Святый: мужа, чей этот пояс, так свяжут в Иерусалиме Иудеи и предадут в руки язычников.»</text>
   </block>
@@ -7583,7 +7583,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="21" characterId="Paul" delivery="preaching" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="21" characterId="Paul" delivery="preaching">
       <verse num="21" />
-      <text>«He said to me, ‹Depart, for I will send you out far from here to the Gentiles.› »</text>
+      <text>«He said to me, ‹Depart, for I will send you out far from here to the Gentiles.› »</text>
     </ReferenceBlocks>
     <verse num="21" />
     <text>«И Он сказал мне: иди; Я пошлю тебя далеко к язычникам.»</text>
@@ -7780,7 +7780,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="5" characterId="Paul" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="23" initialStartVerse="5" characterId="Paul">
-      <text>«I didn’t know, brothers, that he was high priest. For it is written, ‹You shall not speak evil of a ruler of your people.› »</text>
+      <text>«I didn’t know, brothers, that he was high priest. For it is written, ‹You shall not speak evil of a ruler of your people.› »</text>
     </ReferenceBlocks>
     <text>«я не знал, братия, что он первосвященник; ибо написано: начальствующего в народе твоем не злословь.»</text>
   </block>
@@ -8307,7 +8307,7 @@
   <block style="p" paragraphStart="true" chapter="24" initialStartVerse="21" characterId="Paul" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="24" initialStartVerse="21" characterId="Paul">
       <verse num="21" />
-      <text>unless it is for this one thing that I cried standing among them, ‹Concerning the resurrection of the dead I am being judged before you today!› »</text>
+      <text>unless it is for this one thing that I cried standing among them, ‹Concerning the resurrection of the dead I am being judged before you today!› »</text>
     </ReferenceBlocks>
     <verse num="21" />
     <text>разве только то одно слово, которое громко произнес я, стоя между ними, что за учение о воскресении мертвых я ныне судим вами.»</text>

--- a/DistFiles/reference_texts/Russian/HEB.xml
+++ b/DistFiles/reference_texts/Russian/HEB.xml
@@ -448,7 +448,7 @@
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="11" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="3" initialStartVerse="11" characterId="scripture">
       <verse num="11" />
-      <text>I swore in my wrath, ‹They will not enter into my rest.› »</text>
+      <text>I swore in my wrath, ‹They will not enter into my rest.› »</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>посему Я поклялся во гневе Моем, что они не войдут в покой Мой.»</text>
@@ -1131,7 +1131,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="21" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="7" initialStartVerse="21" characterId="scripture">
-      <text>«The Lord swore and will not change his mind, ‹You are a priest forever, according to the order of Melchizedek.› »</text>
+      <text>«The Lord swore and will not change his mind, ‹You are a priest forever, according to the order of Melchizedek.› »</text>
     </ReferenceBlocks>
     <text>клялся Господь, и не раскается: Ты священник вовек по чину Мелхиседека, —</text>
   </block>
@@ -1614,7 +1614,7 @@
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="7" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="10" initialStartVerse="7" characterId="scripture">
       <verse num="7" />
-      <text>Then I said, ‹Behold, I have come (in the scroll of the book it is written of me) to do your will, O God.› »</text>
+      <text>Then I said, ‹Behold, I have come (in the scroll of the book it is written of me) to do your will, O God.› »</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Тогда Я сказал: вот, иду, как в начале книги написано о Мне, исполнить волю Твою, Боже.»</text>
@@ -1693,7 +1693,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="16" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="10" initialStartVerse="16" characterId="scripture">
-      <text>‹After those days,› says the Lord, ‹I will put my laws on their heart, I will also write them on their mind;› »</text>
+      <text>‹After those days,› says the Lord, ‹I will put my laws on their heart, I will also write them on their mind;› »</text>
     </ReferenceBlocks>
     <text>вложу законы Мои в сердца их, и в мыслях их напишу их,»</text>
   </block>

--- a/DistFiles/reference_texts/Russian/JHN.xml
+++ b/DistFiles/reference_texts/Russian/JHN.xml
@@ -134,7 +134,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="15" characterId="John the Baptist" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="1" initialStartVerse="15" characterId="John the Baptist">
-      <text>«This was he of whom I said, ‹He who comes after me has surpassed me, for he was before me.› »</text>
+      <text>«This was he of whom I said, ‹He who comes after me has surpassed me, for he was before me.› »</text>
     </ReferenceBlocks>
     <text>«Сей был Тот, о Котором я сказал, что Идущий за мною стал впереди меня, потому что был прежде меня.»</text>
   </block>
@@ -1962,7 +1962,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="11" characterId="invalid for 38 years" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="5" initialStartVerse="11" characterId="invalid for 38 years">
-      <text>«He who made me well, the same said to me, ‹Take up your mat, and walk.› »</text>
+      <text>«He who made me well, the same said to me, ‹Take up your mat, and walk.› »</text>
     </ReferenceBlocks>
     <text>«Кто меня исцелил, Тот мне сказал: возьми постель твою и ходи.»</text>
   </block>
@@ -2579,7 +2579,7 @@
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="31" characterId="people in crowd by Sea of Galilee" delivery="superior" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="6" initialStartVerse="31" characterId="people in crowd by Sea of Galilee" delivery="superior">
       <verse num="31" />
-      <text>Our fathers ate the manna in the wilderness. As it is written, ‹He gave them bread out of heaven to eat.› »</text>
+      <text>Our fathers ate the manna in the wilderness. As it is written, ‹He gave them bread out of heaven to eat.› »</text>
     </ReferenceBlocks>
     <verse num="31" />
     <text>Отцы наши ели манну в пустыне, как написано: хлеб с неба дал им есть.»</text>
@@ -2692,7 +2692,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="6" initialStartVerse="42" characterId="Jews, the" delivery="grumbling" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="6" initialStartVerse="42" characterId="Jews, the" delivery="grumbling">
-      <text>«Isn’t this Jesus, the son of Joseph, whose father and mother we know? How then does he say, ‹I have come down out of heaven?› »</text>
+      <text>«Isn’t this Jesus, the son of Joseph, whose father and mother we know? How then does he say, ‹I have come down out of heaven?› »</text>
     </ReferenceBlocks>
     <text>«не Иисус ли это, сын Иосифов, Которого отца и Мать мы знаем? Как же говорит Он: я сшел с небес?»</text>
   </block>
@@ -3802,7 +3802,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="22" characterId="Jews, the" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="8" initialStartVerse="22" characterId="Jews, the">
-      <text>«Will he kill himself, that he says, ‹Where I am going, you can’t come?› »</text>
+      <text>«Will he kill himself, that he says, ‹Where I am going, you can’t come?› »</text>
     </ReferenceBlocks>
     <text>«неужели Он убьет Сам Себя, что говорит: ‹куда Я иду, вы не можете придти›?»</text>
   </block>
@@ -3928,7 +3928,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="33" characterId="Jews who had believed Jesus" delivery="superior" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="8" initialStartVerse="33" characterId="Jews who had believed Jesus" delivery="superior">
-      <text>«We are Abraham’s seed, and have never been in bondage to anyone. How do you say, ‹You will be made free?› »</text>
+      <text>«We are Abraham’s seed, and have never been in bondage to anyone. How do you say, ‹You will be made free?› »</text>
     </ReferenceBlocks>
     <text>«мы семя Авраамово и не были рабами никому никогда; как же Ты говоришь: сделаетесь свободными?»</text>
   </block>
@@ -7370,7 +7370,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="17" characterId="disciples" delivery="puzzled" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="16" initialStartVerse="17" characterId="disciples" delivery="puzzled">
-      <text>«What is this that he says to us, ‹A little while, and you won’t see me, and again a little while, and you will see me;› and, ‹Because I go to the Father?› »</text>
+      <text>«What is this that he says to us, ‹A little while, and you won’t see me, and again a little while, and you will see me;› and, ‹Because I go to the Father?› »</text>
     </ReferenceBlocks>
     <text>«что это Он говорит нам: вскоре не увидите Меня, и опять вскоре увидите Меня, и: Я иду к Отцу?»</text>
   </block>
@@ -8564,7 +8564,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="21" characterId="chief priests" delivery="protesting" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="21" characterId="chief priests" delivery="protesting">
-      <text>«Don’t write, ‹The King of the Jews,› but, ‹he said, I am King of the Jews.› »</text>
+      <text>«Don’t write, ‹The King of the Jews,› but, ‹he said, I am King of the Jews.› »</text>
     </ReferenceBlocks>
     <text>«не пиши: Царь Иудейский, но что Он говорил: Я Царь Иудейский.»</text>
   </block>
@@ -9022,7 +9022,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="17" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="17" characterId="Jesus">
-      <text>«Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers, and tell them, ‹I am ascending to my Father and your Father, to my God and your God.› »</text>
+      <text>«Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers, and tell them, ‹I am ascending to my Father and your Father, to my God and your God.› »</text>
     </ReferenceBlocks>
     <text>«не прикасайся ко Мне, ибо Я еще не восшел к Отцу Моему; а иди к братьям Моим и скажи им: восхожу к Отцу Моему и Отцу вашему, и к Богу Моему и Богу вашему.»</text>
   </block>

--- a/DistFiles/reference_texts/Russian/LUK.xml
+++ b/DistFiles/reference_texts/Russian/LUK.xml
@@ -1261,7 +1261,7 @@
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="scripture">
       <verse num="6" />
-      <text>All flesh will see God’s salvation.› »</text>
+      <text>All flesh will see God’s salvation.› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>и узрит всякая плоть спасение Божие.»</text>
@@ -1644,7 +1644,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-      <text>«It is written, ‹Man shall not live by bread alone, but by every word of God.› »</text>
+      <text>«It is written, ‹Man shall not live by bread alone, but by every word of God.› »</text>
     </ReferenceBlocks>
     <text>«написано, что не хлебом одним будет жить человек, но всяким словом Божиим.»</text>
   </block>
@@ -1684,7 +1684,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="8" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="8" characterId="Jesus">
-      <text>«Get behind me Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+      <text>«Get behind me Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
     </ReferenceBlocks>
     <text>«отойди от Меня, сатана; написано: Господу Богу твоему поклоняйся, и Ему одному служи.»</text>
   </block>
@@ -1728,7 +1728,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus">
-      <text>«It has been said, ‹You shall not tempt the Lord your God.› »</text>
+      <text>«It has been said, ‹You shall not tempt the Lord your God.› »</text>
     </ReferenceBlocks>
     <text>«сказано: не искушай Господа Бога твоего.»</text>
   </block>
@@ -1832,7 +1832,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="23" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="23" characterId="Jesus">
-      <text>«Doubtless you will tell me this parable, ‹Physician, heal yourself! Whatever we have heard done at Capernaum, do also here in your hometown.› »</text>
+      <text>«Doubtless you will tell me this parable, ‹Physician, heal yourself! Whatever we have heard done at Capernaum, do also here in your hometown.› »</text>
     </ReferenceBlocks>
     <text>«конечно, вы скажете Мне присловие: врач! исцели Самого Себя; сделай и здесь, в Твоем отечестве, то, что, мы слышали, было в Капернауме.»</text>
   </block>
@@ -2471,7 +2471,7 @@
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="39" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="5" initialStartVerse="39" characterId="Jesus">
       <verse num="39" />
-      <text>No man having drunk old wine immediately desires new, for he says, ‹The old is better.› »</text>
+      <text>No man having drunk old wine immediately desires new, for he says, ‹The old is better.› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>И никто, пив старое вино, не захочет тотчас молодого, ибо говорит: старое лучше.»</text>
@@ -3148,7 +3148,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="20" characterId="disciples of John the Baptist" delivery="puzzled" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="7" initialStartVerse="20" characterId="disciples of John the Baptist" delivery="puzzled">
-      <text>«John the Baptizer has sent us to you, saying, ‹Are you he who comes, or should we look for another?› »</text>
+      <text>«John the Baptizer has sent us to you, saying, ‹Are you he who comes, or should we look for another?› »</text>
     </ReferenceBlocks>
     <text>«Иоанн Креститель послал нас к Тебе спросить: Ты ли Тот, Которому должно придти, или другого ожидать нам?»</text>
   </block>
@@ -3995,7 +3995,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="8" initialStartVerse="45" characterId="Peter (Simon)" delivery="perplexed" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="8" initialStartVerse="45" characterId="Peter (Simon)" delivery="perplexed">
-      <text>«Master, the multitudes press and jostle you, and you say, ‹Who touched me?› »</text>
+      <text>«Master, the multitudes press and jostle you, and you say, ‹Who touched me?› »</text>
     </ReferenceBlocks>
     <text>Наставник! народ окружает Тебя и теснит, —и Ты говоришь: кто прикоснулся ко Мне?»</text>
   </block>
@@ -4373,7 +4373,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="19" characterId="disciples" delivery="excited" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="9" initialStartVerse="19" characterId="disciples" delivery="excited">
-      <text>« ‹John the Baptizer,› but others say, ‹Elijah,› and others, that one of the old prophets is risen again.»</text>
+      <text>« ‹John the Baptizer,› but others say, ‹Elijah,› and others, that one of the old prophets is risen again.»</text>
     </ReferenceBlocks>
     <text>«за Иоанна Крестителя, а иные за Илию; другие же говорят, что один из древних пророков воскрес.»</text>
   </block>
@@ -5216,7 +5216,7 @@
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="35" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="10" initialStartVerse="35" characterId="Jesus">
       <verse num="35" />
-      <text>On the next day, when he departed, he took out two denarii, and gave them to the host, and said to him, ‹Take care of him. Whatever you spend beyond that, I will repay you when I return.› »</text>
+      <text>On the next day, when he departed, he took out two denarii, and gave them to the host, and said to him, ‹Take care of him. Whatever you spend beyond that, I will repay you when I return.› »</text>
     </ReferenceBlocks>
     <verse num="35" />
     <text>а на другой день, отъезжая, вынул два динария, дал содержателю гостиницы и сказал ему: позаботься о нем; и если издержишь что более, я, когда возвращусь, отдам тебе.»</text>
@@ -5354,7 +5354,7 @@
   <block style="p" paragraphStart="true" chapter="11" initialStartVerse="4" characterId="Jesus" delivery="instructing" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="11" initialStartVerse="4" characterId="Jesus" delivery="instructing">
       <verse num="4" />
-      <text>Forgive us our sins, for we ourselves also forgive everyone who is indebted to us. Bring us not into temptation, but deliver us from evil.› »</text>
+      <text>Forgive us our sins, for we ourselves also forgive everyone who is indebted to us. Bring us not into temptation, but deliver us from evil.› »</text>
     </ReferenceBlocks>
     <verse num="4" />
     <text>и прости нам грехи наши, ибо и мы прощаем всякому должнику нашему; и не введи нас в искушение, но избавь нас от лукавого.»</text>
@@ -6006,7 +6006,7 @@
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="19" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="12" initialStartVerse="19" characterId="Jesus">
       <verse num="19" />
-      <text>I will tell my soul, «Soul, you have many goods laid up for many years. Take your ease, eat, drink, be merry.» ›</text>
+      <text>I will tell my soul, «Soul, you have many goods laid up for many years. Take your ease, eat, drink, be merry.» ›</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>и скажу душе моей: душа! много добра лежит у тебя на многие годы: покойся, ешь, пей, веселись.»</text>
@@ -6436,7 +6436,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="9" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="9" characterId="Jesus">
       <verse num="9" />
-      <text>If it bears fruit, fine; but if not, after that, you can cut it down.› »</text>
+      <text>If it bears fruit, fine; but if not, after that, you can cut it down.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>не принесет ли плода; если же нет, то в следующий год срубишь ее.»</text>
@@ -6696,7 +6696,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="35" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="35" characterId="Jesus">
       <verse num="35" />
-      <text>Behold, your house is left to you desolate. I tell you, you will not see me, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+      <text>Behold, your house is left to you desolate. I tell you, you will not see me, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
     </ReferenceBlocks>
     <verse num="35" />
     <text>Се, оставляется вам дом ваш пуст. Сказываю же вам, что вы не увидите Меня, пока не придет время, когда скажете: благословен Грядый во имя Господне!»</text>
@@ -6920,7 +6920,7 @@
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="24" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="24" characterId="Jesus">
       <verse num="24" />
-      <text>For I tell you that none of those men who were invited will taste of my supper.› »</text>
+      <text>For I tell you that none of those men who were invited will taste of my supper.› »</text>
     </ReferenceBlocks>
     <verse num="24" />
     <text>Ибо сказываю вам, что никто из тех званых не вкусит моего ужина, ибо много званых, но мало избранных.»</text>
@@ -7170,7 +7170,7 @@
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="19" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="15" initialStartVerse="19" characterId="Jesus">
       <verse num="19" />
-      <text>I am no more worthy to be called your son. Make me as one of your hired servants.» ›</text>
+      <text>I am no more worthy to be called your son. Make me as one of your hired servants.» ›</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>и уже недостоин называться сыном твоим; прими меня в число наемников твоих.»</text>
@@ -7274,7 +7274,7 @@
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="32" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="15" initialStartVerse="32" characterId="Jesus">
       <verse num="32" />
-      <text>But it was appropriate to celebrate and be glad, for this, your brother, was dead, and is alive again. He was lost, and is found.› »</text>
+      <text>But it was appropriate to celebrate and be glad, for this, your brother, was dead, and is alive again. He was lost, and is found.› »</text>
     </ReferenceBlocks>
     <verse num="32" />
     <text>а о том надобно было радоваться и веселиться, что брат твой сей был мертв и ожил, пропадал и нашелся.»</text>
@@ -7536,7 +7536,7 @@
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="31" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="16" initialStartVerse="31" characterId="Jesus">
       <verse num="31" />
-      <text>«He said to him, ‹If they don’t listen to Moses and the prophets, neither will they be persuaded if one rises from the dead.› »</text>
+      <text>«He said to him, ‹If they don’t listen to Moses and the prophets, neither will they be persuaded if one rises from the dead.› »</text>
     </ReferenceBlocks>
     <verse num="31" />
     <text>«Тогда Авраам сказал ему: если Моисея и пророков не слушают, то если бы кто и из мертвых воскрес, не поверят.»</text>
@@ -7640,7 +7640,7 @@
   <block style="p" paragraphStart="true" chapter="17" initialStartVerse="10" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="17" initialStartVerse="10" characterId="Jesus">
       <verse num="10" />
-      <text>Even so you also, when you have done all the things that are commanded you, say, ‹We are unworthy servants. We have done our duty.› »</text>
+      <text>Even so you also, when you have done all the things that are commanded you, say, ‹We are unworthy servants. We have done our duty.› »</text>
     </ReferenceBlocks>
     <verse num="10" />
     <text>Так и вы, когда исполните всё повеленное вам, говорите: мы рабы ничего не стоящие, потому что сделали, что должны были сделать.»</text>
@@ -7974,7 +7974,7 @@
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="5" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="18" initialStartVerse="5" characterId="Jesus">
       <verse num="5" />
-      <text>However, because this widow keeps bothering me, I will defend her, or else she will wear me out by her continual coming.› »</text>
+      <text>However, because this widow keeps bothering me, I will defend her, or else she will wear me out by her continual coming.› »</text>
     </ReferenceBlocks>
     <verse num="5" />
     <text>но, как эта вдова не дает мне покоя, защищу ее, чтобы она не приходила больше докучать мне.»</text>
@@ -8662,7 +8662,7 @@
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="27" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="27" characterId="Jesus">
       <verse num="27" />
-      <text>But bring those enemies of mine who didn’t want me to reign over them here, and kill them before me.› »</text>
+      <text>But bring those enemies of mine who didn’t want me to reign over them here, and kill them before me.› »</text>
     </ReferenceBlocks>
     <verse num="27" />
     <text>врагов же моих тех, которые не хотели, чтобы я царствовал над ними, приведите сюда и избейте предо мною.»</text>
@@ -8696,7 +8696,7 @@
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="31" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="31" characterId="Jesus">
       <verse num="31" />
-      <text>If anyone asks you, ‹Why are you untying it?› say to him: ‹The Lord needs it.› »</text>
+      <text>If anyone asks you, ‹Why are you untying it?› say to him: ‹The Lord needs it.› »</text>
     </ReferenceBlocks>
     <verse num="31" />
     <text>и если кто спросит вас: зачем отвязываете? скажите ему так: он надобен Господу.»</text>
@@ -9287,7 +9287,7 @@
       <verse num="42" />
       <text>David himself says in the book of Psalms, ‹The Lord said to my Lord, «Sit at my right hand, </text>
       <verse num="43" />
-      <text>until I make your enemies the footstool of your feet.» ›</text>
+      <text>until I make your enemies the footstool of your feet.» ›</text>
     </ReferenceBlocks>
     <verse num="42" />
     <text>а сам Давид говорит в книге псалмов: сказал Господь Господу моему: седи одесную Меня, </text>
@@ -9789,7 +9789,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="11" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="11" characterId="Jesus">
       <verse num="11" />
-      <text>Tell the master of the house, ‹The Teacher says to you, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
+      <text>Tell the master of the house, ‹The Teacher says to you, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>и скажите хозяину дома: Учитель говорит тебе: где комната, в которой бы Мне есть пасху с учениками Моими?»</text>

--- a/DistFiles/reference_texts/Russian/LUK.xml
+++ b/DistFiles/reference_texts/Russian/LUK.xml
@@ -8124,7 +8124,7 @@
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="20" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="18" initialStartVerse="20" characterId="Jesus">
       <verse num="20" />
-      <text>You know the commandments: ‹Don’t commit adultery,› ‹Don’t murder,› ‹Don’t steal,› ‹Don’t give false testimony,› ‹Honor your father and your mother.› »</text>
+      <text>You know the commandments: ‹Don’t commit adultery,› ‹Don’t murder,› ‹Don’t steal,› ‹Don’t give false testimony,› ‹Honor your father and your mother.› »</text>
     </ReferenceBlocks>
     <verse num="20" />
     <text>знаешь заповеди: не прелюбодействуй, не убивай, не кради, не лжесвидетельствуй, почитай отца твоего и матерь твою.»</text>

--- a/DistFiles/reference_texts/Russian/MAT.xml
+++ b/DistFiles/reference_texts/Russian/MAT.xml
@@ -282,7 +282,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law">
       <verse num="6" />
-      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
+      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>и ты, Вифлеем, земля Иудина, ничем не меньше воеводств Иудиных, ибо из тебя произойдет Вождь, Который упасет народ Мой, Израиля.»</text>
@@ -685,7 +685,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
+      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
     </ReferenceBlocks>
     <text>«написано: не хлебом одним будет жить человек, но всяким словом, исходящим из уст Божиих.»</text>
   </block>
@@ -703,7 +703,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)">
-      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don’t dash your foot against a stone.› »</text>
+      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don’t dash your foot against a stone.› »</text>
     </ReferenceBlocks>
     <text>«если Ты Сын Божий, бросься вниз, ибо написано: Ангелам Своим заповедает о Тебе, и на руках понесут Тебя, да не преткнешься о камень ногою Твоею.»</text>
   </block>
@@ -717,7 +717,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus">
-      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
+      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
     </ReferenceBlocks>
     <text>«написано также: не искушай Господа Бога твоего.»</text>
   </block>
@@ -749,7 +749,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking">
-      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
     </ReferenceBlocks>
     <text>«отойди от Меня, сатана, ибо написано: Господу Богу твоему поклоняйся и Ему одному служи.»</text>
   </block>
@@ -4027,7 +4027,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus">
       <verse num="30" />
-      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, «First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.» › »</text>
+      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, «First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.» › »</text>
     </ReferenceBlocks>
     <verse num="30" />
     <text>оставьте расти вместе то и другое до жатвы; и во время жатвы я скажу жнецам: соберите прежде плевелы и свяжите их в снопы, чтобы сжечь их, а пшеницу уберите в житницу мою.»</text>
@@ -4781,7 +4781,7 @@
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus">
       <verse num="9" />
-      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
+      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>но тщетно чтут Меня, уча учениям, заповедям человеческим.»</text>
@@ -6304,7 +6304,7 @@
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus">
       <verse num="19" />
-      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
+      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>почитай отца и мать; и: люби ближнего твоего, как самого себя.»</text>
@@ -6968,7 +6968,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus">
-      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
+      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
     </ReferenceBlocks>
     <text>«да! разве вы никогда не читали: из уст младенцев и грудных детей Ты устроил хвалу?»</text>
   </block>
@@ -7349,7 +7349,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus">
       <verse num="4" />
-      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» ›</text>
+      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» ›</text>
     </ReferenceBlocks>
     <verse num="4" />
     <text>Опять послал других рабов, сказав: скажите званым: вот, я приготовил обед мой, тельцы мои и что откормлено, заколото, и всё готово; приходите на брачный пир.»</text>
@@ -7661,7 +7661,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus">
-      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
+      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
     </ReferenceBlocks>
     <text>«возлюби Господа Бога твоего всем сердцем твоим и всею душею твоею и всем разумением твоим:</text>
   </block>
@@ -8071,7 +8071,7 @@
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking">
       <verse num="39" />
-      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>Ибо сказываю вам: не увидите Меня отныне, доколе не воскликнете: благословен Грядый во имя Господне!»</text>
@@ -9070,7 +9070,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus">
-      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
+      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
     </ReferenceBlocks>
     <text>пойдите в город к такому-то и скажите ему: Учитель говорит: время Мое близко; у тебя совершу пасху с учениками Моими.»</text>
   </block>
@@ -9562,7 +9562,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false">
-      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
+      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
     </ReferenceBlocks>
     <text>«Он говорил: могу разрушить храм Божий и в три дня создать его.»</text>
   </block>
@@ -10242,7 +10242,7 @@
   <block style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering">
       <verse num="43" />
-      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
+      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
     </ReferenceBlocks>
     <verse num="43" />
     <text>уповал на Бога; пусть теперь избавит Его, если Он угоден Ему. Ибо Он сказал: Я Божий Сын.»</text>

--- a/DistFiles/reference_texts/Russian/MAT.xml
+++ b/DistFiles/reference_texts/Russian/MAT.xml
@@ -6297,7 +6297,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus">
-      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
+      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
     </ReferenceBlocks>
     <text>«не убивай; не прелюбодействуй; не кради; не лжесвидетельствуй;</text>
   </block>

--- a/DistFiles/reference_texts/Russian/MRK.xml
+++ b/DistFiles/reference_texts/Russian/MRK.xml
@@ -37,7 +37,7 @@
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="3" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="1" initialStartVerse="3" characterId="scripture">
       <verse num="3" />
-      <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
+      <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
     </ReferenceBlocks>
     <verse num="3" />
     <text>Глас вопиющего в пустыне: приготовьте путь Господу, прямыми сделайте стези Ему.»</text>
@@ -1208,7 +1208,7 @@
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="12" characterId="Jesus">
       <verse num="12" />
-      <text>that ‹seeing they may see, and not perceive; and hearing they may hear, and not understand; lest perhaps they should turn again, and their sins should be forgiven them.› »</text>
+      <text>that ‹seeing they may see, and not perceive; and hearing they may hear, and not understand; lest perhaps they should turn again, and their sins should be forgiven them.› »</text>
     </ReferenceBlocks>
     <verse num="12" />
     <text>так что они своими глазами смотрят, и не видят; своими ушами слышат, и не разумеют, да не обратятся, и прощены будут им грехи.»</text>
@@ -1831,7 +1831,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="31" characterId="disciples" delivery="perplexed" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="5" initialStartVerse="31" characterId="disciples" delivery="perplexed">
-      <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
+      <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
     </ReferenceBlocks>
     <text>«Ты видишь, что народ теснит Тебя, и говоришь: кто прикоснулся ко Мне?»</text>
   </block>
@@ -2744,7 +2744,7 @@
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="11" characterId="Jesus" delivery="rebuking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="7" initialStartVerse="11" characterId="Jesus" delivery="rebuking">
       <verse num="11" />
-      <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban,» › that is to say, given to God;</text>
+      <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban,» › that is to say, given to God;</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>А вы говорите: кто скажет отцу или матери: корван, то есть дар Богу то, чем бы ты от меня пользовался,»</text>
@@ -5416,7 +5416,7 @@
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="36" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="12" initialStartVerse="36" characterId="Jesus">
       <verse num="36" />
-      <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
+      <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
     </ReferenceBlocks>
     <verse num="36" />
     <text>Ибо сам Давид сказал Духом Святым: сказал Господь Господу моему: седи одесную Меня, доколе положу врагов Твоих в подножие ног Твоих.»</text>
@@ -5994,7 +5994,7 @@
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="14" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="14" characterId="Jesus">
       <verse num="14" />
-      <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
+      <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
     </ReferenceBlocks>
     <verse num="14" />
     <text>и куда он войдет, скажите хозяину дома того: Учитель говорит: где комната, в которой бы Мне есть пасху с учениками Моими?»</text>
@@ -6432,7 +6432,7 @@
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="58" characterId="witnesses, false" delivery="mocking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="58" characterId="witnesses, false" delivery="mocking">
       <verse num="58" />
-      <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
+      <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
     </ReferenceBlocks>
     <verse num="58" />
     <text>«мы слышали, как Он говорил: Я разрушу храм сей рукотворенный, и через три дня воздвигну другой, нерукотворенный.»</text>
@@ -7234,7 +7234,7 @@
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="7" characterId="angels in white, two" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="16" initialStartVerse="7" characterId="angels in white, two">
       <verse num="7" />
-      <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
+      <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Но идите, скажите ученикам Его и Петру, что Он предваряет вас в Галилее; там Его увидите, как Он сказал вам.»</text>

--- a/DistFiles/reference_texts/Russian/MRK.xml
+++ b/DistFiles/reference_texts/Russian/MRK.xml
@@ -4246,7 +4246,7 @@
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="19" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="10" initialStartVerse="19" characterId="Jesus">
       <verse num="19" />
-      <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
+      <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>Знаешь заповеди: не прелюбодействуй, не убивай, не кради, не лжесвидетельствуй, не обижай, почитай отца твоего и мать.»</text>

--- a/DistFiles/reference_texts/Russian/REV.xml
+++ b/DistFiles/reference_texts/Russian/REV.xml
@@ -205,7 +205,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="2" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="2" characterId="Jesus">
       <verse num="2" />
-      <text>« ‹I know your works, and your toil and perseverance, and that you can’t tolerate evil men. You have tested those who call themselves apostles, and they are not, and found them false.</text>
+      <text>« ‹I know your works, and your toil and perseverance, and that you can’t tolerate evil men. You have tested those who call themselves apostles, and they are not, and found them false.</text>
     </ReferenceBlocks>
     <verse num="2" />
     <text>«знаю дела твои, и труд твой, и терпение твое, и то, что ты не можешь сносить развратных, и испытал тех, которые называют себя апостолами, а они не таковы, и нашел, что они лжецы;</text>
@@ -245,7 +245,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="7" characterId="Jesus">
       <verse num="7" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat of the tree of life, which is in the Paradise of my God.» ›</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat of the tree of life, which is in the Paradise of my God.» ›</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Имеющий ухо да слышит, что Дух говорит церквам: побеждающему дам вкушать от древа жизни, которое посреди рая Божия.»</text>
@@ -261,7 +261,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="9" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="9" characterId="Jesus">
       <verse num="9" />
-      <text>« ‹I know your works, oppression, and your poverty (but you are rich). The blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan.</text>
+      <text>« ‹I know your works, oppression, and your poverty (but you are rich). The blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan.</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>«Знаю твои дела, и скорбь, и нищету (впрочем ты богат), и злословие от тех, которые говорят о себе, что они Иудеи, а они не таковы, но сборище сатанинское.</text>
@@ -277,7 +277,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="11" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="11" characterId="Jesus">
       <verse num="11" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.» ›</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.» ›</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>Имеющий ухо (слышать) да слышит, что Дух говорит церквам: побеждающий не потерпит вреда от второй смерти.»</text>
@@ -293,7 +293,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="13" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="13" characterId="Jesus">
       <verse num="13" />
-      <text>« ‹I know your works and where you dwell, where Satan’s seat is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells.</text>
+      <text>« ‹I know your works and where you dwell, where Satan’s seat is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells.</text>
     </ReferenceBlocks>
     <verse num="13" />
     <text>«знаю твои дела, и что ты живешь там, где престол сатаны, и что содержишь имя Мое, и не отрекся от веры Моей даже в те дни, в которые у вас, где живет сатана, умерщвлен верный свидетель Мой Антипа.</text>
@@ -325,7 +325,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="17" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="17" characterId="Jesus">
       <verse num="17" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, and I will give him a white stone, and on the stone a new name written, which no one knows but he who receives it.» ›</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, and I will give him a white stone, and on the stone a new name written, which no one knows but he who receives it.» ›</text>
     </ReferenceBlocks>
     <verse num="17" />
     <text>Имеющий ухо (слышать) да слышит, что Дух говорит церквам: побеждающему дам вкушать сокровенную манну, и дам ему белый камень и на камне написанное новое имя, которого никто не знает, кроме того, кто получает.»</text>
@@ -421,7 +421,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="29" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="29" characterId="Jesus">
       <verse num="29" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
     </ReferenceBlocks>
     <verse num="29" />
     <text>Имеющий ухо (слышать) да слышит, что Дух говорит церквам.»</text>
@@ -475,7 +475,7 @@
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="3" initialStartVerse="6" characterId="Jesus">
       <verse num="6" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies.» ›</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies.» ›</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>Имеющий ухо да слышит, что Дух говорит церквам.»</text>
@@ -531,7 +531,7 @@
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="13" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="3" initialStartVerse="13" characterId="Jesus">
       <verse num="13" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
     </ReferenceBlocks>
     <verse num="13" />
     <text>Имеющий ухо да слышит, что Дух говорит церквам.»</text>
@@ -603,7 +603,7 @@
   <block style="p" paragraphStart="true" chapter="3" initialStartVerse="22" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="3" initialStartVerse="22" characterId="Jesus">
       <verse num="22" />
-      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
+      <text>He who has an ear, let him hear what the Spirit says to the assemblies.› »</text>
     </ReferenceBlocks>
     <verse num="22" />
     <text>Имеющий ухо да слышит, что Дух говорит церквам.»</text>
@@ -2342,7 +2342,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="voice from heaven (God?)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="voice from heaven (God?)">
-      <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
+      <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
     </ReferenceBlocks>
     <text>«напиши: отныне блаженны мертвые, умирающие в Господе;»</text>
   </block>
@@ -2963,7 +2963,7 @@
       <text>However much she glorified herself, and grew wanton, so much give her of torment and mourning. For she says in her heart, ‹I sit as queen, and am no widow, and will in no way see mourning.›</text>
     </ReferenceBlocks>
     <verse num="7" />
-    <text>Сколько славилась она и роскошествовала, столько воздайте ей мучений и горестей. Ибо она говорит в сердце своем: ‹сижу царицею, я не вдова и не увижу горести!› »</text>
+    <text>Сколько славилась она и роскошествовала, столько воздайте ей мучений и горестей. Ибо она говорит в сердце своем: ‹сижу царицею, я не вдова и не увижу горести!› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="8" characterId="voice from heaven, another" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="18" initialStartVerse="8" characterId="voice from heaven, another">
@@ -3255,7 +3255,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="9" characterId="angel (one of the seven)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="9" characterId="angel (one of the seven)">
-      <text>«Write, ‹Blessed are those who are invited to the marriage supper of the Lamb.› »</text>
+      <text>«Write, ‹Blessed are those who are invited to the marriage supper of the Lamb.› »</text>
     </ReferenceBlocks>
     <text>«напиши: блаженны званые на брачную вечерю Агнца.»</text>
   </block>

--- a/DistFiles/reference_texts/Russian/ROM.xml
+++ b/DistFiles/reference_texts/Russian/ROM.xml
@@ -2094,9 +2094,9 @@
   </block>
   <block style="p" chapter="9" initialStartVerse="20" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" chapter="9" initialStartVerse="20" characterId="scripture">
-      <text>«Will the thing formed ask him who formed it, ‹Why did you make me like this?› »</text>
+      <text>«Will the thing formed ask him who formed it, ‹Why did you make me like this?› »</text>
     </ReferenceBlocks>
-    <text>«Изделие скажет ли сделавшему его: ‹зачем ты меня так сделал?› »</text>
+    <text>«Изделие скажет ли сделавшему его: ‹зачем ты меня так сделал?› »</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="21" characterId="narrator-ROM" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="9" initialStartVerse="21" characterId="narrator-ROM">
@@ -2147,7 +2147,7 @@
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="26" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="9" initialStartVerse="26" characterId="scripture">
       <verse num="26" />
-      <text>«It will be that in the place where it was said to them, ‹You are not my people,› There they will be called ‹children of the living God.› »</text>
+      <text>«It will be that in the place where it was said to them, ‹You are not my people,› There they will be called ‹children of the living God.› »</text>
     </ReferenceBlocks>
     <verse num="26" />
     <text>«И на том месте, где сказано им: вы не Мой народ, там названы будут сынами Бога живаго.»</text>
@@ -3194,7 +3194,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="11" characterId="scripture" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="11" characterId="scripture">
-      <text>« ‹As I live,› says the Lord, ‹to me every knee will bow. Every tongue will confess to God.»</text>
+      <text>« ‹As I live,› says the Lord, ‹to me every knee will bow. Every tongue will confess to God.»</text>
     </ReferenceBlocks>
     <text>«живу Я, говорит Господь, предо Мною преклонится всякое колено, и всякий язык будет исповедывать Бога.»</text>
   </block>

--- a/GlyssenSharedTests/Resources/AzeriREVRefText.xml
+++ b/GlyssenSharedTests/Resources/AzeriREVRefText.xml
@@ -2340,7 +2340,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="voice from heaven (God?)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="13" characterId="voice from heaven (God?)">
-      <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
+      <text>«Write, ‹Blessed are the dead who die in the Lord from now on.› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Yaz: bundan sonra Rә...әxtiyardır!&gt;&gt;</text>
   </block>

--- a/GlyssenSharedTests/Resources/FrenchMATRefText.xml
+++ b/GlyssenSharedTests/Resources/FrenchMATRefText.xml
@@ -283,7 +283,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law" multiBlockQuote="Continuation">
       <verse num="6" />
-      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
+      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>&lt;Et ... Israël.&gt;</text>
@@ -684,7 +684,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
+      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Dans ... Dieu.&gt;</text>
   </block>
@@ -702,7 +702,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)">
-      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don't dash your foot against a stone.› »</text>
+      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don't dash your foot against a stone.› »</text>
     </ReferenceBlocks>
     <text>&lt;Si ... pierres.&gt;</text>
   </block>
@@ -716,7 +716,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus">
-      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
+      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Dans ... Dieu.&gt;</text>
   </block>
@@ -748,7 +748,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking">
-      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Va-t'en, ... servir.&gt;</text>
   </block>
@@ -3901,7 +3901,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="15" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="15" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="15" />
-      <text>for this people's heart has grown callous, their ears are dull of hearing, they have closed their eyes; or else perhaps they might perceive with their eyes, hear with their ears, understand with their heart, and should turn again; and I would heal them.› »</text>
+      <text>for this people's heart has grown callous, their ears are dull of hearing, they have closed their eyes; or else perhaps they might perceive with their eyes, hear with their ears, understand with their heart, and should turn again; and I would heal them.› »</text>
     </ReferenceBlocks>
     <verse num="15" />
     <text>Oui, ... guérir!&gt;</text>
@@ -4003,7 +4003,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="27" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="27" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="27" />
-      <text>The servants of the householder came and said to him, ‹Sir, didn't you sow good seed in your field? Where did these weeds come from?› »</text>
+      <text>The servants of the householder came and said to him, ‹Sir, didn't you sow good seed in your field? Where did these weeds come from?› »</text>
     </ReferenceBlocks>
     <verse num="27" />
     <text>Les ... herbe?&gt;</text>
@@ -4011,7 +4011,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="28" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="28" characterId="Jesus">
       <verse num="28" />
-      <text>«He said to them, ‹An enemy has done this.› The servants asked him, ‹Do you want us to go and gather them up?› »</text>
+      <text>«He said to them, ‹An enemy has done this.› The servants asked him, ‹Do you want us to go and gather them up?› »</text>
     </ReferenceBlocks>
     <verse num="28" />
     <text>Il ... herbe?&gt;</text>
@@ -4027,7 +4027,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="30" />
-      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.› »</text>
+      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.› »</text>
     </ReferenceBlocks>
     <verse num="30" />
     <text>Laissez ... &gt;</text>
@@ -4781,7 +4781,7 @@
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="9" />
-      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
+      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>Ils ... humains.&gt;&gt;</text>
@@ -6021,7 +6021,7 @@
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="28" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="18" initialStartVerse="28" characterId="Jesus">
       <verse num="28" />
-      <text>«But that servant went out, and found one of his fellow servants, who owed him one hundred denarii, and he grabbed him, and took him by the throat, saying, ‹Pay me what you owe!› »</text>
+      <text>«But that servant went out, and found one of his fellow servants, who owed him one hundred denarii, and he grabbed him, and took him by the throat, saying, ‹Pay me what you owe!› »</text>
     </ReferenceBlocks>
     <verse num="28" />
     <text>&lt;&lt;Le ... dois!&gt;</text>
@@ -6296,14 +6296,14 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus" multiBlockQuote="Start" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus" multiBlockQuote="Start">
-      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
+      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Ne ... quelqu'un.</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="19" />
-      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
+      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>Respecte ... toi-même.&gt;&gt;</text>
@@ -6483,7 +6483,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="6" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="6" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="6" />
-      <text>About the eleventh hour he went out, and found others standing idle. He said to them, ‹Why do you stand here all day idle?› »</text>
+      <text>About the eleventh hour he went out, and found others standing idle. He said to them, ‹Why do you stand here all day idle?› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>Enfin, ... faire?&gt;</text>
@@ -6491,7 +6491,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="7" characterId="Jesus">
       <verse num="7" />
-      <text>«They said to him, ‹Because no one has hired us.› » «He said to them, ‹You also go into the vineyard, and you will receive whatever is right.›</text>
+      <text>«They said to him, ‹Because no one has hired us.› » «He said to them, ‹You also go into the vineyard, and you will receive whatever is right.›</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Ils ... vigne.&gt;</text>
@@ -6499,7 +6499,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="8" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="8" characterId="Jesus">
       <verse num="8" />
-      <text>When evening had come, the lord of the vineyard said to his manager, ‹Call the laborers and pay them their wages, beginning from the last to the first.› »</text>
+      <text>When evening had come, the lord of the vineyard said to his manager, ‹Call the laborers and pay them their wages, beginning from the last to the first.› »</text>
     </ReferenceBlocks>
     <verse num="8" />
     <text>&lt;&lt;Quand ... premier.&gt;</text>
@@ -6525,7 +6525,7 @@
       <verse num="11" />
       <text>When they received it, they murmured against the master of the household, </text>
       <verse num="12" />
-      <text>saying, ‹These last have spent one hour, and you have made them equal to us, who have borne the burden of the day and the scorching heat!› »</text>
+      <text>saying, ‹These last have spent one hour, and you have made them equal to us, who have borne the burden of the day and the scorching heat!› »</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>En ... </text>
@@ -6966,7 +6966,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus">
-      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
+      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Oui. ... voulu&gt;?&gt;&gt;</text>
   </block>
@@ -7272,7 +7272,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="42" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="42" characterId="Jesus">
-      <text>«Did you never read in the Scriptures, ‹The stone which the builders rejected, the same was made the head of the corner. This was from the Lord. It is marvelous in our eyes?› »</text>
+      <text>«Did you never read in the Scriptures, ‹The stone which the builders rejected, the same was made the head of the corner. This was from the Lord. It is marvelous in our eyes?› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Vous ... nous!&gt;&gt;</text>
   </block>
@@ -7347,7 +7347,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="4" />
-      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» › »</text>
+      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» › »</text>
     </ReferenceBlocks>
     <verse num="4" />
     <text>Il ... mariage!&gt;</text>
@@ -7387,7 +7387,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="9" />
-      <text>Go therefore to the intersections of the highways, and as many as you may find, invite to the marriage feast.› »</text>
+      <text>Go therefore to the intersections of the highways, and as many as you may find, invite to the marriage feast.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>Allez ... rencontrerez.&gt;</text>
@@ -7660,7 +7660,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus" multiBlockQuote="Start" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus" multiBlockQuote="Start">
-      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
+      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
     </ReferenceBlocks>
     <text>&lt;&lt; ... intelligence.&gt;</text>
   </block>
@@ -7734,7 +7734,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="44" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="44" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="44" />
-      <text>‹The Lord said to my Lord, sit on my right hand, until I make your enemies a footstool for your feet?› »</text>
+      <text>‹The Lord said to my Lord, sit on my right hand, until I make your enemies a footstool for your feet?› »</text>
     </ReferenceBlocks>
     <verse num="44" />
     <text>En ... pieds.&gt;</text>
@@ -8069,7 +8069,7 @@
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation">
       <verse num="39" />
-      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>En ... &gt;</text>
@@ -8673,7 +8673,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="20" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="20" characterId="Jesus">
       <verse num="20" />
-      <text>He who received the five talents came and brought another five talents, saying, ‹Lord, you delivered to me five talents. Behold, I have gained another five talents besides them.› »</text>
+      <text>He who received the five talents came and brought another five talents, saying, ‹Lord, you delivered to me five talents. Behold, I have gained another five talents besides them.› »</text>
     </ReferenceBlocks>
     <verse num="20" />
     <text>Le ... gagnées.&gt;</text>
@@ -8681,7 +8681,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="21" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="21" characterId="Jesus">
       <verse num="21" />
-      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
+      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
     </ReferenceBlocks>
     <verse num="21" />
     <text>Son ... moi.&gt;</text>
@@ -8689,7 +8689,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="22" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="22" characterId="Jesus">
       <verse num="22" />
-      <text>«He also who got the two talents came and said, ‹Lord, you delivered to me two talents. Behold, I have gained another two talents besides them.› »</text>
+      <text>«He also who got the two talents came and said, ‹Lord, you delivered to me two talents. Behold, I have gained another two talents besides them.› »</text>
     </ReferenceBlocks>
     <verse num="22" />
     <text>Le ... gagnées.&gt;</text>
@@ -8697,7 +8697,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="23" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="23" characterId="Jesus">
       <verse num="23" />
-      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
+      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
     </ReferenceBlocks>
     <verse num="23" />
     <text>Son ... moi.&gt;</text>
@@ -8713,7 +8713,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="25" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="25" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="25" />
-      <text>I was afraid, and went away and hid your talent in the ground. Behold, you have what is yours.› »</text>
+      <text>I was afraid, and went away and hid your talent in the ground. Behold, you have what is yours.› »</text>
     </ReferenceBlocks>
     <verse num="25" />
     <text>J'ai ... argent.&gt;</text>
@@ -8753,7 +8753,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="30" />
-      <text>Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.› »</text>
+      <text>Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.› »</text>
     </ReferenceBlocks>
     <verse num="30" />
     <text>Et ... dents.&gt;&gt;</text>
@@ -8801,7 +8801,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="36" />
-      <text>I was naked, and you clothed me. I was sick, and you visited me. I was in prison, and you came to me.› »</text>
+      <text>I was naked, and you clothed me. I was sick, and you visited me. I was in prison, and you came to me.› »</text>
     </ReferenceBlocks>
     <verse num="36" />
     <text>J'étais ... voir.&gt;</text>
@@ -8825,7 +8825,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="39" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="39" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="39" />
-      <text>When did we see you sick, or in prison, and come to you?› »</text>
+      <text>When did we see you sick, or in prison, and come to you?› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>Tu ... donc?&gt;</text>
@@ -8857,7 +8857,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="43" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="43" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="43" />
-      <text>I was a stranger, and you didn't take me in; naked, and you didn't clothe me; sick, and in prison, and you didn't visit me.› »</text>
+      <text>I was a stranger, and you didn't take me in; naked, and you didn't clothe me; sick, and in prison, and you didn't visit me.› »</text>
     </ReferenceBlocks>
     <verse num="43" />
     <text>J'étais ... visité.&gt;</text>
@@ -8865,7 +8865,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="44" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="44" characterId="Jesus">
       <verse num="44" />
-      <text>«Then they will also answer, saying, ‹Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn't help you?› »</text>
+      <text>«Then they will also answer, saying, ‹Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn't help you?› »</text>
     </ReferenceBlocks>
     <verse num="44" />
     <text>Alors ... donc?&gt;</text>
@@ -9062,7 +9062,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus">
-      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
+      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Allez ... &gt;</text>
   </block>
@@ -9552,7 +9552,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false">
-      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
+      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
     </ReferenceBlocks>
     <verse num="61" />
     <text>&lt;&lt;Cet ... &gt;</text>
@@ -10246,7 +10246,7 @@
   <block style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering" multiBlockQuote="Continuation">
       <verse num="43" />
-      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
+      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
     </ReferenceBlocks>
     <verse num="43" />
     <text>Il ... Dieu.&gt;&gt;</text>

--- a/GlyssenSharedTests/Resources/FrenchMRKRefText.xml
+++ b/GlyssenSharedTests/Resources/FrenchMRKRefText.xml
@@ -37,7 +37,7 @@
   <block style="p" paragraphStart="true" chapter="1" initialStartVerse="3" characterId="scripture" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="1" initialStartVerse="3" characterId="scripture" multiBlockQuote="Continuation">
       <verse num="3" />
-      <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
+      <text>The voice of one crying in the wilderness, ‹Make ready the way of the Lord! Make his paths straight!› »</text>
     </ReferenceBlocks>
     <verse num="3" />
     <text>Quelqu'un crie dansdésert: &lt;Préparez la route du Seigneur! Faites-luicheminsdroits!&gt;&gt;</text>
@@ -1866,7 +1866,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="5" initialStartVerse="31" characterId="disciples" delivery="perplexed" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="5" initialStartVerse="31" characterId="disciples" delivery="perplexed">
-      <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
+      <text>«You see the multitude pressing against you, and you say, ‹Who touched me?› »</text>
     </ReferenceBlocks>
     <text>&lt;&lt;Tu... tu demandes: &lt;Qui m'a touché?&gt;&gt;</text>
   </block>
@@ -2747,7 +2747,7 @@
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="7" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="7" initialStartVerse="7" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation">
       <verse num="7" />
-      <text>But in vain do they worship me, teaching as doctrines the commandments of men.› »</text>
+      <text>But in vain do they worship me, teaching as doctrines the commandments of men.› »</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Ils me fontpri...es commandements humains.&gt;&gt;</text>
@@ -2785,7 +2785,7 @@
   <block style="p" paragraphStart="true" chapter="7" initialStartVerse="11" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="7" initialStartVerse="11" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation">
       <verse num="11" />
-      <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban, that is to say, given to God» ›;</text>
+      <text>But you say, ‹If a man tells his father or his mother, «Whatever profit you might have received from me is Corban, that is to say, given to God» ›;</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>Mais vous,dites aux gens: &lt;Tu peux dire ... -dire une offrande pour Dieu.&gt;</text>
@@ -4293,7 +4293,7 @@
   <block style="p" paragraphStart="true" chapter="10" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="10" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="19" />
-      <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
+      <text>You know the commandments: ‹Do not murder,› ‹Do not commit adultery,› ‹Do not steal,› ‹Do not give false testimony,› ‹Do not defraud,› ‹Honor your father and mother.› »</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>Tu connais...... et...re.&gt;&gt;</text>
@@ -5464,7 +5464,7 @@
   <block style="p" paragraphStart="true" chapter="12" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="12" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="36" />
-      <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
+      <text>For David himself said in the Holy Spirit, ‹The Lord said to my Lord, «Sit at my right hand, until I make your enemies the footstool of your feet.» ›</text>
     </ReferenceBlocks>
     <verse num="36" />
     <text>David lui-m... ma droite, je vais mettre tes ennimis sous tes pieds. »</text>
@@ -6030,7 +6030,7 @@
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="14" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="14" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="14" />
-      <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
+      <text>Wherever he enters in, tell the master of the house, ‹The Teacher says, «Where is the guest room, where I may eat the Passover with my disciples?» ›</text>
     </ReferenceBlocks>
     <verse num="14" />
     <text>Il entrera dans une maison, et ...e la maison: &lt;Le ma...la Pâquemes disciples?&gt;</text>
@@ -6472,7 +6472,7 @@
   <block style="p" paragraphStart="true" chapter="14" initialStartVerse="58" characterId="witnesses, false" delivery="mocking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="14" initialStartVerse="58" characterId="witnesses, false" delivery="mocking">
       <verse num="58" />
-      <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
+      <text>«We heard him say, ‹I will destroy this temple that is made with hands, and in three days I will build another made without hands.› »</text>
     </ReferenceBlocks>
     <verse num="58" />
     <text>&lt;&lt;Nous l'avons entendu dire: &lt;Je dparhommes.&gt;&gt;</text>
@@ -7292,7 +7292,7 @@
   <block style="p" paragraphStart="true" chapter="16" initialStartVerse="7" characterId="angels in white, two" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="16" initialStartVerse="7" characterId="angels in white, two" multiBlockQuote="Continuation">
       <verse num="7" />
-      <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
+      <text>But go, tell his disciples and Peter, ‹He goes before you into Galilee. There you will see him, as he said to you.› »</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Maintenant, allez dire à Pierre et aux autres disciples: &lt;J...l'a dit.&gt;&gt;</text>

--- a/GlyssenSharedTests/Resources/SpanishMATRefText.xml
+++ b/GlyssenSharedTests/Resources/SpanishMATRefText.xml
@@ -283,7 +283,7 @@
   <block style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="2" initialStartVerse="6" characterId="chief priests/teachers of religious law" multiBlockQuote="Continuation">
       <verse num="6" />
-      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
+      <text>‹You Bethlehem, land of Judah, are in no way least among the princes of Judah: for out of you shall come forth a governor, who shall shepherd my people, Israel.› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>&lt;En ... Israel.&gt;</text>
@@ -684,7 +684,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="4" characterId="Jesus">
-      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
+      <text>«It is written, ‹Man shall not live by bread alone, but by every word that proceeds out of the mouth of God.› »</text>
     </ReferenceBlocks>
     <text>La ... Dios.&gt;</text>
   </block>
@@ -702,7 +702,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="6" characterId="Satan (Devil)">
-      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don't dash your foot against a stone.› »</text>
+      <text>«If you are the Son of God, throw yourself down, for it is written, ‹He will put his angels in charge of you.› and, ‹On their hands they will bear you up, so that you don't dash your foot against a stone.› »</text>
     </ReferenceBlocks>
     <text>Si ... alguna.&gt;</text>
   </block>
@@ -716,7 +716,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="7" characterId="Jesus">
-      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
+      <text>«Again, it is written, ‹You shall not test the Lord, your God.› »</text>
     </ReferenceBlocks>
     <text>También ... Dios.&gt;</text>
   </block>
@@ -748,7 +748,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="4" initialStartVerse="10" characterId="Jesus" delivery="rebuking">
-      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
+      <text>«Get behind me, Satan! For it is written, ‹You shall worship the Lord your God, and you shall serve him only.› »</text>
     </ReferenceBlocks>
     <text>Vete, ... él.&gt;</text>
   </block>
@@ -3901,7 +3901,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="15" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="15" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="15" />
-      <text>for this people's heart has grown callous, their ears are dull of hearing, they have closed their eyes; or else perhaps they might perceive with their eyes, hear with their ears, understand with their heart, and should turn again; and I would heal them.› »</text>
+      <text>for this people's heart has grown callous, their ears are dull of hearing, they have closed their eyes; or else perhaps they might perceive with their eyes, hear with their ears, understand with their heart, and should turn again; and I would heal them.› »</text>
     </ReferenceBlocks>
     <verse num="15" />
     <text>Pues ... sane.&gt;</text>
@@ -4003,7 +4003,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="27" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="27" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="27" />
-      <text>The servants of the householder came and said to him, ‹Sir, didn't you sow good seed in your field? Where did these weeds come from?› »</text>
+      <text>The servants of the householder came and said to him, ‹Sir, didn't you sow good seed in your field? Where did these weeds come from?› »</text>
     </ReferenceBlocks>
     <verse num="27" />
     <text>Entonces ... hierba?&gt;</text>
@@ -4011,7 +4011,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="28" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="28" characterId="Jesus">
       <verse num="28" />
-      <text>«He said to them, ‹An enemy has done this.› The servants asked him, ‹Do you want us to go and gather them up?› »</text>
+      <text>«He said to them, ‹An enemy has done this.› The servants asked him, ‹Do you want us to go and gather them up?› »</text>
     </ReferenceBlocks>
     <verse num="28" />
     <text>El ... hierba?&gt;</text>
@@ -4027,7 +4027,7 @@
   <block style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="13" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="30" />
-      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.› »</text>
+      <text>Let both grow together until the harvest, and in the harvest time I will tell the reapers, First, gather up the weeds, and bind them in bundles to burn them; but gather the wheat into my barn.› »</text>
     </ReferenceBlocks>
     <verse num="30" />
     <text>Lo ... granero.&gt;&gt;&gt;</text>
@@ -4781,7 +4781,7 @@
   <block style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="15" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="9" />
-      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
+      <text>And in vain do they worship me, teaching as doctrine rules made by men.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>De ... hombres.&gt;</text>
@@ -6021,7 +6021,7 @@
   <block style="p" paragraphStart="true" chapter="18" initialStartVerse="28" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="18" initialStartVerse="28" characterId="Jesus">
       <verse num="28" />
-      <text>«But that servant went out, and found one of his fellow servants, who owed him one hundred denarii, and he grabbed him, and took him by the throat, saying, ‹Pay me what you owe!› »</text>
+      <text>«But that servant went out, and found one of his fellow servants, who owed him one hundred denarii, and he grabbed him, and took him by the throat, saying, ‹Pay me what you owe!› »</text>
     </ReferenceBlocks>
     <verse num="28" />
     <text>&lt;&lt;Pero ... debes!&gt;</text>
@@ -6296,14 +6296,14 @@
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus" multiBlockQuote="Start" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="18" characterId="Jesus" multiBlockQuote="Start">
-      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
+      <text>« ‹You shall not murder.› ‹You shall not commit adultery.› ‹You shall not steal.› ‹You shall not offer false testimony.›</text>
     </ReferenceBlocks>
     <text>&lt;No ... nadie,</text>
   </block>
   <block style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="19" initialStartVerse="19" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="19" />
-      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
+      <text>‹Honor your father and mother.› And, ‹You shall love your neighbor as yourself.› »</text>
     </ReferenceBlocks>
     <verse num="19" />
     <text>honra ... mismo.&gt;</text>
@@ -6483,7 +6483,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="6" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="6" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="6" />
-      <text>About the eleventh hour he went out, and found others standing idle. He said to them, ‹Why do you stand here all day idle?› »</text>
+      <text>About the eleventh hour he went out, and found others standing idle. He said to them, ‹Why do you stand here all day idle?› »</text>
     </ReferenceBlocks>
     <verse num="6" />
     <text>Alrededor ... trabajar?&gt;</text>
@@ -6491,7 +6491,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="7" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="7" characterId="Jesus">
       <verse num="7" />
-      <text>«They said to him, ‹Because no one has hired us.› » «He said to them, ‹You also go into the vineyard, and you will receive whatever is right.›</text>
+      <text>«They said to him, ‹Because no one has hired us.› » «He said to them, ‹You also go into the vineyard, and you will receive whatever is right.›</text>
     </ReferenceBlocks>
     <verse num="7" />
     <text>Le ... viñedo.&gt;</text>
@@ -6499,7 +6499,7 @@
   <block style="p" paragraphStart="true" chapter="20" initialStartVerse="8" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="20" initialStartVerse="8" characterId="Jesus">
       <verse num="8" />
-      <text>When evening had come, the lord of the vineyard said to his manager, ‹Call the laborers and pay them their wages, beginning from the last to the first.› »</text>
+      <text>When evening had come, the lord of the vineyard said to his manager, ‹Call the laborers and pay them their wages, beginning from the last to the first.› »</text>
     </ReferenceBlocks>
     <verse num="8" />
     <text>&lt;&lt;Cuando ... primero.&gt;</text>
@@ -6525,7 +6525,7 @@
       <verse num="11" />
       <text>When they received it, they murmured against the master of the household, </text>
       <verse num="12" />
-      <text>saying, ‹These last have spent one hour, and you have made them equal to us, who have borne the burden of the day and the scorching heat!› »</text>
+      <text>saying, ‹These last have spent one hour, and you have made them equal to us, who have borne the burden of the day and the scorching heat!› »</text>
     </ReferenceBlocks>
     <verse num="11" />
     <text>Al ... </text>
@@ -6966,7 +6966,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="16" characterId="Jesus">
-      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
+      <text>«Yes. Did you never read, ‹Out of the mouth of babes and nursing babies you have perfected praise?› »</text>
     </ReferenceBlocks>
     <text>Sí, ... alabanza.&gt;</text>
   </block>
@@ -7272,7 +7272,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="21" initialStartVerse="42" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="21" initialStartVerse="42" characterId="Jesus">
-      <text>«Did you never read in the Scriptures, ‹The stone which the builders rejected, the same was made the head of the corner. This was from the Lord. It is marvelous in our eyes?› »</text>
+      <text>«Did you never read in the Scriptures, ‹The stone which the builders rejected, the same was made the head of the corner. This was from the Lord. It is marvelous in our eyes?› »</text>
     </ReferenceBlocks>
     <text>¿Nunca ... maravillados.&gt;</text>
   </block>
@@ -7347,7 +7347,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="4" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="4" />
-      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» › »</text>
+      <text>Again he sent out other servants, saying, ‹Tell those who are invited, «Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the marriage feast!» › »</text>
     </ReferenceBlocks>
     <verse num="4" />
     <text>Volvió ... banquete.&gt;</text>
@@ -7387,7 +7387,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="9" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="9" />
-      <text>Go therefore to the intersections of the highways, and as many as you may find, invite to the marriage feast.› »</text>
+      <text>Go therefore to the intersections of the highways, and as many as you may find, invite to the marriage feast.› »</text>
     </ReferenceBlocks>
     <verse num="9" />
     <text>Vayan, ... encuentren.&gt;</text>
@@ -7660,7 +7660,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus" multiBlockQuote="Start" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="37" characterId="Jesus" multiBlockQuote="Start">
-      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
+      <text>« ‹You shall love the Lord your God with all your heart, with all your soul, and with all your mind.›</text>
     </ReferenceBlocks>
     <text>&lt;Ama ... mente.&gt;</text>
   </block>
@@ -7735,7 +7735,7 @@
   <block style="p" paragraphStart="true" chapter="22" initialStartVerse="44" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="22" initialStartVerse="44" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="44" />
-      <text>‹The Lord said to my Lord, sit on my right hand, until I make your enemies a footstool for your feet?› »</text>
+      <text>‹The Lord said to my Lord, sit on my right hand, until I make your enemies a footstool for your feet?› »</text>
     </ReferenceBlocks>
     <verse num="44" />
     <text>&lt;El ... pies.&gt;</text>
@@ -8070,7 +8070,7 @@
   <block style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="23" initialStartVerse="39" characterId="Jesus" delivery="rebuking" multiBlockQuote="Continuation">
       <verse num="39" />
-      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
+      <text>For I tell you, you will not see me from now on, until you say, ‹Blessed is he who comes in the name of the Lord!› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>y ... Señor!&gt;!&gt;&gt;</text>
@@ -8674,7 +8674,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="20" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="20" characterId="Jesus">
       <verse num="20" />
-      <text>He who received the five talents came and brought another five talents, saying, ‹Lord, you delivered to me five talents. Behold, I have gained another five talents besides them.› »</text>
+      <text>He who received the five talents came and brought another five talents, saying, ‹Lord, you delivered to me five talents. Behold, I have gained another five talents besides them.› »</text>
     </ReferenceBlocks>
     <verse num="20" />
     <text>Primero ... gané.&gt;</text>
@@ -8682,7 +8682,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="21" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="21" characterId="Jesus">
       <verse num="21" />
-      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
+      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
     </ReferenceBlocks>
     <verse num="21" />
     <text>El ... conmigo.&gt;</text>
@@ -8690,7 +8690,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="22" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="22" characterId="Jesus">
       <verse num="22" />
-      <text>«He also who got the two talents came and said, ‹Lord, you delivered to me two talents. Behold, I have gained another two talents besides them.› »</text>
+      <text>«He also who got the two talents came and said, ‹Lord, you delivered to me two talents. Behold, I have gained another two talents besides them.› »</text>
     </ReferenceBlocks>
     <verse num="22" />
     <text>Después ... gané.&gt;</text>
@@ -8698,7 +8698,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="23" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="23" characterId="Jesus">
       <verse num="23" />
-      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
+      <text>«His lord said to him, ‹Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.› »</text>
     </ReferenceBlocks>
     <verse num="23" />
     <text>El ... conmigo.&gt;</text>
@@ -8714,7 +8714,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="25" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="25" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="25" />
-      <text>I was afraid, and went away and hid your talent in the ground. Behold, you have what is yours.› »</text>
+      <text>I was afraid, and went away and hid your talent in the ground. Behold, you have what is yours.› »</text>
     </ReferenceBlocks>
     <verse num="25" />
     <text>Por ... suyo.&gt;</text>
@@ -8754,7 +8754,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="30" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="30" />
-      <text>Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.› »</text>
+      <text>Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.› »</text>
     </ReferenceBlocks>
     <verse num="30" />
     <text>Y ... desesperación.&gt;</text>
@@ -8802,7 +8802,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="36" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="36" />
-      <text>I was naked, and you clothed me. I was sick, and you visited me. I was in prison, and you came to me.› »</text>
+      <text>I was naked, and you clothed me. I was sick, and you visited me. I was in prison, and you came to me.› »</text>
     </ReferenceBlocks>
     <verse num="36" />
     <text>Estuve ... verme.&gt;</text>
@@ -8826,7 +8826,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="39" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="39" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="39" />
-      <text>When did we see you sick, or in prison, and come to you?› »</text>
+      <text>When did we see you sick, or in prison, and come to you?› »</text>
     </ReferenceBlocks>
     <verse num="39" />
     <text>¿O ... verte?&gt;</text>
@@ -8858,7 +8858,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="43" characterId="Jesus" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="43" characterId="Jesus" multiBlockQuote="Continuation">
       <verse num="43" />
-      <text>I was a stranger, and you didn't take me in; naked, and you didn't clothe me; sick, and in prison, and you didn't visit me.› »</text>
+      <text>I was a stranger, and you didn't take me in; naked, and you didn't clothe me; sick, and in prison, and you didn't visit me.› »</text>
     </ReferenceBlocks>
     <verse num="43" />
     <text>anduve ... visitarme.&gt;</text>
@@ -8866,7 +8866,7 @@
   <block style="p" paragraphStart="true" chapter="25" initialStartVerse="44" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="25" initialStartVerse="44" characterId="Jesus">
       <verse num="44" />
-      <text>«Then they will also answer, saying, ‹Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn't help you?› »</text>
+      <text>«Then they will also answer, saying, ‹Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn't help you?› »</text>
     </ReferenceBlocks>
     <verse num="44" />
     <text>Entonces ... ayudamos?&gt;</text>
@@ -9063,7 +9063,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="18" characterId="Jesus">
-      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
+      <text>«Go into the city to a certain person, and tell him, ‹The Teacher says, «My time is at hand. I will keep the Passover at your house with my disciples.» › »</text>
     </ReferenceBlocks>
     <text>Vayan ... discípulos.&gt;</text>
   </block>
@@ -9555,7 +9555,7 @@
   </block>
   <block style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="26" initialStartVerse="61" characterId="witnesses, false">
-      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
+      <text>«This man said, ‹I am able to destroy the temple of God, and to build it in three days.› »</text>
     </ReferenceBlocks>
     <text>Este ... días.&gt;</text>
   </block>
@@ -10247,7 +10247,7 @@
   <block style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering" multiBlockQuote="Continuation" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="27" initialStartVerse="43" characterId="chief priests/teachers of religious law/elders" delivery="sneering" multiBlockQuote="Continuation">
       <verse num="43" />
-      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
+      <text>He trusts in God. Let God deliver him now, if he wants him; for he said, ‹I am the Son of God.› »</text>
     </ReferenceBlocks>
     <verse num="43" />
     <text>Ha ... Dios?&gt;&gt;</text>


### PR DESCRIPTION
 This only applies to adjacent marks that are facing the same direction (in closing or opening groups).
This is in a separate PR because it is dependent on a decision whether to user 202F or some other space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/724)
<!-- Reviewable:end -->
