### PR TITLE
TXL-1399: Pause at end of REV reduced to 5 seconds

### DIFF
--- a/GlyssenEngine/Resources/Annotations.txt
+++ b/GlyssenEngine/Resources/Annotations.txt
@@ -1569,4 +1569,4 @@ REV	21	18	0	<Sound startVerse="18" />
 REV	21	27	0	<Pause time="2" />
 REV	22	13	0	<Sound startVerse="13" />
 REV	22	17	0	<Pause time="2" />
-REV	22	21	0	<Pause timeUnits="Minutes" time="1" />
+REV	22	21	0	<Pause time="5" />

--- a/GlyssenEngineTests/Export/ProjectExporterTests.cs
+++ b/GlyssenEngineTests/Export/ProjectExporterTests.cs
@@ -659,11 +659,12 @@ namespace GlyssenEngineTests.Export
 				rowForVerse12.VernacularText);
 
 			//Pause for final verse in book (pauses come after verse text)
+			var annotationForEndOfBook = " " + string.Format(Pause.kPauseSecondsFormat, "5");
 			var rowsForJude25 = data.Where(d => d.BookId == "JUD" && d.ChapterNumber == 1 && d.VerseNumber == 25).ToList();
 			var rowForJude25 = rowsForJude25.Single();
-			var annotationInfo = " " + string.Format(Pause.kPauseSecondsFormat, "5");
-			Assert.IsTrue(rowForJude25.AdditionalReferenceText.EndsWith(annotationInfo));
-			Assert.IsTrue(rowForJude25.EnglishReferenceText.EndsWith(annotationInfo));
+			
+			Assert.IsTrue(rowForJude25.AdditionalReferenceText.EndsWith(annotationForEndOfBook));
+			Assert.IsTrue(rowForJude25.EnglishReferenceText.EndsWith(annotationForEndOfBook));
 			Assert.AreEqual("{25}\u00A0Deyo, dit, loc ki twer ducu obed bot Lubaŋa acel keken, ma Lalarwa, pi Yecu Kricito Rwotwa, " +
 				"cakke ma peya giketo lobo, nio koni, ki kare ma pe gik. Amen.",
 				rowForJude25.VernacularText);
@@ -673,9 +674,9 @@ namespace GlyssenEngineTests.Export
 			Assert.AreEqual(2, rowsForRev1V3.Count);
 			var rowForRev1V3 = rowsForRev1V3[0];
 			var sectionHeadRowForRev1V3 = rowsForRev1V3[1];
-			annotationInfo = " " + string.Format(Pause.kPauseSecondsFormat, "2");
-			Assert.IsTrue(rowForRev1V3.AdditionalReferenceText.EndsWith(annotationInfo));
-			Assert.IsTrue(rowForRev1V3.EnglishReferenceText.EndsWith(annotationInfo));
+			var annotationForTwoSecondPause = " " + string.Format(Pause.kPauseSecondsFormat, "2");
+			Assert.IsTrue(rowForRev1V3.AdditionalReferenceText.EndsWith(annotationForTwoSecondPause));
+			Assert.IsTrue(rowForRev1V3.EnglishReferenceText.EndsWith(annotationForTwoSecondPause));
 			Assert.AreEqual("{3}\u00A0Ŋat ma kwano lok ma gitito i buk man i nyim lwak tye ki gum, jo ma winyo bene tye ki gum, ki jo ma lubo " +
 				"gin ma gicoyo iye bene tye ki gum, pien kare doŋ cok.",
 				rowForRev1V3.VernacularText);
@@ -684,19 +685,17 @@ namespace GlyssenEngineTests.Export
 
 			//Pause for final verse in chapter (pauses come after verse text)
 			var rowForRev1V20 = data.Single(d => d.BookId == "REV" && d.ChapterNumber == 1 && d.VerseNumber == 20);
-			annotationInfo = " " + string.Format(Pause.kPauseSecondsFormat, "2");
-			Assert.IsTrue(rowForRev1V20.AdditionalReferenceText.EndsWith(annotationInfo));
-			Assert.IsTrue(rowForRev1V20.EnglishReferenceText.EndsWith(annotationInfo));
+			Assert.IsTrue(rowForRev1V20.AdditionalReferenceText.EndsWith(annotationForTwoSecondPause));
+			Assert.IsTrue(rowForRev1V20.EnglishReferenceText.EndsWith(annotationForTwoSecondPause));
 			Assert.AreEqual("{20}\u00A0Koŋ agonnyi tyen lok me muŋ me lakalatwe abiro ma ineno i ciŋa tuŋ lacuc, ki okar-mac abiro me jabu. " +
 				"Lakalatwe abiro gin aye lumalaika pa lwak muye Kricito ma gitye i kabedo abiro mapatpat, doŋ okar-mac abiro-ni gin " +
 				"aye lwak muye Kricito ma gitye i kabedo abiro mapatpat.”",
 				rowForRev1V20.VernacularText);
 
-			// PG-1399: 1-minute pause at end of book
+			// PG-1399: 5-second pause at end of book
 			var rowForRev22V21 = data.Single(d => d.BookId == "REV" && d.ChapterNumber == 22 && d.VerseNumber >= 21);
-			annotationInfo = " " + Pause.kPauseOneMinute;
-			Assert.IsTrue(rowForRev22V21.AdditionalReferenceText.EndsWith(annotationInfo));
-			Assert.IsTrue(rowForRev22V21.EnglishReferenceText.EndsWith(annotationInfo));
+			Assert.IsTrue(rowForRev22V21.AdditionalReferenceText.EndsWith(annotationForEndOfBook));
+			Assert.IsTrue(rowForRev22V21.EnglishReferenceText.EndsWith(annotationForEndOfBook));
 			Assert.AreEqual("{21}\u00A0Kica pa Rwot Yecu obed ki jo pa Lubaŋa ducu. Amen.", rowForRev22V21.VernacularText);
 		}
 

--- a/GlyssenShared/BlockElement.cs
+++ b/GlyssenShared/BlockElement.cs
@@ -208,11 +208,10 @@ namespace Glyssen.Shared
 	public class Pause : ScriptAnnotation
 	{
 		public const string kPauseSecondsFormat = "||| + {0} SECs |||";
-		public const string kPauseOneMinute = "||| + 1 MINUTE |||";
 
-		[XmlAttribute("timeUnits")]
-		[DefaultValue(TimeUnits.Seconds)]
-		public TimeUnits TimeUnits { get; set; }
+		//[XmlAttribute("timeUnits")]
+		//[DefaultValue(TimeUnits.Seconds)]
+		public TimeUnits TimeUnits => TimeUnits.Seconds;
 
 		[XmlAttribute("time")]
 		public double Time { get; set; }
@@ -221,8 +220,7 @@ namespace Glyssen.Shared
 		{
 			if (TimeUnits == TimeUnits.Seconds)
 				return string.Format(kPauseSecondsFormat, Time);
-			if (Time == 1.0d)
-				return kPauseOneMinute;
+			// "Minute" was only used for a long pause after Revelation. No longer needed. (See comment on PG-1399)
 			Debug.Fail("No code for displaying this annotation: " + ToString());
 			return string.Empty;
 		}

--- a/RefTextDevUtilities/ReferenceTextUtility.cs
+++ b/RefTextDevUtilities/ReferenceTextUtility.cs
@@ -2200,14 +2200,15 @@ namespace Glyssen.RefTextDevUtilities
 			match = s_pauseRegex.Match(text);
 			if (match.Success)
 			{
-				annotation = new Pause { TimeUnits = TimeUnits.Seconds, Time = double.Parse(match.Groups[1].Value) };
+				annotation = new Pause { Time = double.Parse(match.Groups[1].Value) };
 				return true;
 			}
 			match = s_pauseMinuteRegex.Match(text);
 			if (match.Success)
 			{
-				annotation = new Pause { TimeUnits = TimeUnits.Minutes, Time = double.Parse(match.Groups[1].Value) };
-				return true;
+				throw new ArgumentException("Pauses specified in minutes are no longer supported", "text");
+				//annotation = new Pause { TimeUnits = TimeUnits.Minutes, Time = double.Parse(match.Groups[1].Value) };
+				//return true;
 			}
 
 			match = s_musicEndRegex.Match(text);


### PR DESCRIPTION
MarkW (FCBH) inquired and found out that post-processing does not need the 1-minute pause at the end of REV.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/726)
<!-- Reviewable:end -->
