### PR TITLE
PG-1408: Prevent detection of omissible "he said" reference block when there is additional following text

### DIFF
--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -709,9 +709,9 @@ namespace GlyssenEngine
 										}
 										else
 										{
-											// Since modifiedOmittedHeSaidText is always the English one, the order in
-											// which they get hooked up depends on whether or not this (the primary
-											// reference text) is English or not.
+											// Since the modified "he said" text in omittedHeSaids is always the English
+											// one, the order in which they get hooked up depends on whether or not this
+											// (the primary reference text) is English or not.
 											Block englishRefBlock;
 											if (HasSecondaryReferenceText)
 											{

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -665,8 +665,10 @@ namespace GlyssenEngine
 								vernBlockInVerseChunk = vernBlockList[iCurrVernBottomUp];
 								if (vernBlockInVerseChunk.MatchesReferenceText)
 									break;
+
 								refBlockInVerseChunk = refBlockList[indexOfRefVerseStart + numberOfRefBlocksInVerseChunk - j - 1 + numberOfUnexpectedReportingClausesMatched];
-								if (BlocksMatch(bookNum, vernBlockInVerseChunk, refBlockInVerseChunk, vernacularVersification))
+								if ((iCurrVernBottomUp > i || omittedHeSaids == 0) && // PG-1408: Don't match two different vern blocks to the same ref block
+									BlocksMatch(bookNum, vernBlockInVerseChunk, refBlockInVerseChunk, vernacularVersification))
 								{
 									vernBlockInVerseChunk.SetMatchedReferenceBlock(refBlockInVerseChunk);
 									iLastVernBlockMatchedFromBottomUp = iCurrVernBottomUp;
@@ -679,7 +681,14 @@ namespace GlyssenEngine
 									iLastVernBlockMatchedFromBottomUp = iCurrVernBottomUp;
 								}
 								else
+								{
+									if (omittedHeSaids > 0 && modifiedOmittedHeSaidText != null)
+									{
+										// TODO: This needs to be UNmatched:
+										vernBlockInVerseChunk.SetMatchedReferenceBlock(modifiedOmittedHeSaidText);
+									}
 									break;
+								}
 							}
 						}
 						var numberOfUnmatchedRefBlocks = numberOfRefBlocksInVerseChunk - i - j + numberOfUnexpectedReportingClausesMatched - omittedHeSaids;

--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -155,7 +155,7 @@ namespace GlyssenEngine
 		public string WordSeparator => " ";
 
 		public string HeSaidText => m_metadata.Language.HeSaidText ?? "he said.";
-		private static Regex s_regexEnglishReportingClause = new Regex(@"(?<clause>((?<pronoun>(He)|(She)|(They)) |((\w+ ){1,2}))said\b([^\.\w]*\w+){0,2})[,:]");
+		private static Regex s_regexEnglishReportingClause = new Regex(@"(?<clause>((?<pronoun>(He)|(She)|(They)) |((\w+ ){1,2}))said\b([^\.\w]*\w+){0,2})[,:]\s*$");
 
 		private bool BlockIsOmissibleReportingClause(Block refBlock, out string modifiedOmittedHeSaidText)
 		{

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -588,7 +588,10 @@ namespace GlyssenEngine.Script
 				refBlock.BlockElements.Clear();
 			}
 			else
+			{
 				refBlock = new Block(StyleTag, ChapterNumber, prevVerse.StartVerse, prevVerse.LastVerseOfBridge);
+			}
+
 			refBlock.SetCharacterAndDeliveryInfo(this);
 			return refBlock;
 		}

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -511,6 +511,32 @@ namespace GlyssenEngine.Script
 			return refBlock;
 		}
 
+		public Block SetUnmatchedNarratorReferenceBlock(string plainTextWithNoVerseNumbers, string bookId)
+		{
+			var refBlock = GetEmptyReferenceBlock((InitialVerseNumberBridgeFromBlock)this);
+			refBlock.CharacterId = CharacterVerseData.GetStandardCharacterId(bookId, CharacterVerseData.StandardCharacter.Narrator);
+			//if (StartsAtVerseStart)
+			//{
+			//	// TODO: Deal with versification difference
+			//	refBlock.BlockElements.Add(new Verse(BlockElements.OfType<Verse>().ToString()));
+			//}
+
+			refBlock.BlockElements.Add(new ScriptText(plainTextWithNoVerseNumbers));
+			//if (!refBlock.StartsAtVerseStart && refBlock.InitialEndVerseNumber > 0)
+			//{
+			//	// If we don't have a preceding ref block that can be used to imply the starting verse number/bridge
+			//	// for this ref block, we at least want to prevent it from looking like it starts at or before the
+			//	// first verse number it actually contains, so we infer that it starts at the preceding verse. This
+			//	// is not a common scenario, and it is really somewhat of a guess as to what is actually happening.
+			//	var firstVerseInRefBlock = refBlock.BlockElements.OfType<Verse>().FirstOrDefault();
+			//	if (firstVerseInRefBlock != null && firstVerseInRefBlock.StartVerse <= refBlock.InitialEndVerseNumber)
+			//		refBlock.InitialEndVerseNumber = firstVerseInRefBlock.StartVerse - 1;
+			//}
+			SetUnmatchedReferenceBlocks(new [] {refBlock});
+
+			return refBlock;
+		}
+
 		public void SetUnmatchedReferenceBlocks(IEnumerable<Block> referenceBlocks)
 		{
 			if (referenceBlocks == null)
@@ -604,8 +630,7 @@ namespace GlyssenEngine.Script
 						BlockElements.Add(new Verse(match.Result("${verse}").Replace(',', '-')));
 					else
 					{
-						var prevText = BlockElements.LastOrDefault() as ScriptText;
-						if (prevText != null && prevText.Content.Last() != ' ')
+						if (BlockElements.LastOrDefault() is ScriptText prevText && prevText.Content.Last() != ' ')
 							prevText.Content += " ";
 						BlockElements.Add(Sound.CreateFromMatchedRegex(match));
 						prependSpace = " ";

--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -332,7 +332,7 @@ namespace GlyssenEngine.Script
 			return OriginalBlocks.Contains(block) || CorrelatedBlocks.Contains(block);
 		}
 
-		public void MatchAllBlocks()
+		public void MatchAllBlocks(string dialogueDash = null)
 		{
 			var versification = m_vernacularBook.Versification;
 			int bookNum = BCVRef.BookToNumber(BookId);
@@ -354,7 +354,12 @@ namespace GlyssenEngine.Script
 				else
 				{
 					block.SetMatchedReferenceBlock(bookNum, versification, m_referenceLanguageInfo);
-					if (block.CharacterIsUnclear)
+					if (block.CharacterIsUnclear ||
+						(dialogueDash != null && // See PG-1408 (and corresponding unit tests)
+						block.CharacterId == prevBlock?.CharacterId &&
+						!block.IsContinuationOfPreviousBlockQuote &&
+						CharacterVerseData.IsCharacterOfType(block.ReferenceBlocks.Single().CharacterId, CharacterVerseData.StandardCharacter.Narrator) &&
+						block.BlockElements.OfType<ScriptText>().First().Content.StartsWith(dialogueDash)))
 						block.SetCharacterAndDeliveryInfo(block.ReferenceBlocks.Single(), bookNum, versification);
 				}
 

--- a/GlyssenEngine/Script/BookScript.cs
+++ b/GlyssenEngine/Script/BookScript.cs
@@ -992,7 +992,7 @@ namespace GlyssenEngine.Script
 				else if (numUniqueCharacterDeliveries <= numUniqueCharacters)
 				{
 					// Only one real character (and delivery). Set to that character (and delivery).
-					var realCharacter = uniqueCharacterDeliveries.Single(c => c.Character != CharacterVerseData.kAmbiguousCharacter && c.Character != CharacterVerseData.kUnexpectedCharacter);
+					var realCharacter = uniqueCharacterDeliveries.Single(c => !CharacterVerseData.IsCharacterUnclear(c.Character));
 					foreach (Block block in multiBlockQuote)
 					{
 						block.SetCharacterIdAndCharacterIdInScript(realCharacter.Character, bookNum, versification);

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -838,7 +838,7 @@ namespace GlyssenEngine.ViewModels
 				currentIndices.BlockIndex, m_project.ReportingClauses, currentIndices.MultiBlockCount);
 			if (m_currentRefBlockMatchups != null)
 			{
-				m_currentRefBlockMatchups.MatchAllBlocks();
+				m_currentRefBlockMatchups.MatchAllBlocks(m_project.QuoteSystem.QuotationDashMarker);
 				// We might have gotten here by ad-hoc navigation (clicking or using the Verse Reference control). Since we are in "rainbow mode"
 				// the filter holds *groups* of relevant blocks (rather than individual ones), so if the new current matchup corresponds to one
 				// of those groups (i.e., it is relevant), we need to set indices based on the group rather than the individual block. Otherwise,

--- a/GlyssenEngineTests/ReferenceTextTests.cs
+++ b/GlyssenEngineTests/ReferenceTextTests.cs
@@ -4660,17 +4660,17 @@ namespace GlyssenEngineTests
 			var refText = ReferenceText.GetStandardReferenceText(type);
 			var refTextMrk = refText.GetBook("MRK");
 			var refTextBlocksForMrk15V14 = refTextMrk.GetBlocksForVerse(15, 14).ToList();
-			Assert.AreEqual(4, refTextBlocksForMrk15V14.Count, "SETUP check - expected English reference text to have two blocks for Mark 15:14.");
+			Assert.AreEqual(4, refTextBlocksForMrk15V14.Count, "SETUP check - expected reference text to have four blocks for Mark 15:14.");
 			Assert.AreEqual(narrator, refTextBlocksForMrk15V14[0].CharacterId,
-				"SETUP check - expected English reference text to have narrator speak in first block for Mark 15:14.");
+				"SETUP check - expected reference text to have narrator speak in first block for Mark 15:14.");
 			Assert.AreEqual("Pilate", refTextBlocksForMrk15V14[1].CharacterId,
-				"SETUP check - expected English reference text to have Pilate speak in second block for Mark 15:14.");
+				"SETUP check - expected reference text to have Pilate speak in second block for Mark 15:14.");
 			Assert.AreEqual(narrator, refTextBlocksForMrk15V14[2].CharacterId,
-				"SETUP check - expected English reference text to have narrator speak in third block for Mark 15:14.");
+				"SETUP check - expected reference text to have narrator speak in third block for Mark 15:14.");
 			Assert.AreEqual("crowd before Pilate", refTextBlocksForMrk15V14[3].CharacterId,
-				"SETUP check - expected English reference text to have the crowd before Pilate speak in last block for Mark 15:14.");
+				"SETUP check - expected reference text to have the crowd before Pilate speak in last block for Mark 15:14.");
 			Assert.AreEqual(14, refTextBlocksForMrk15V14.Last().LastVerseNum,
-				"SETUP check - expected English reference text to have have a block break between Mark 15:14 and v. 15.");
+				"SETUP check - expected reference text to have have a block break between Mark 15:14 and v. 15.");
 
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(CreateBlockForVerse(CharacterVerseData.kAmbiguousCharacter, 14,
@@ -4734,11 +4734,8 @@ namespace GlyssenEngineTests
 
 			if (refText.HasSecondaryReferenceText)
 			{
-				var t = allReferenceBlocks.Select(b => b.ReferenceBlocks.Single());
-				var u = t.Single(b => b.StartsAtVerseStart);
-				var v = u.BlockElements.OfType<Verse>();
-				var w = v.Single();
-				Assert.AreEqual(14, w.AllVerseNumbers.Single());
+				Assert.AreEqual(14, allReferenceBlocks.Select(b => b.ReferenceBlocks.Single()).Single(b => b.StartsAtVerseStart)
+					.BlockElements.OfType<Verse>().Single().AllVerseNumbers.Single());
 
 				var firstRefBlock = allReferenceBlocks[0];
 				Assert.IsTrue(firstRefBlock.MatchesReferenceText);
@@ -4746,6 +4743,90 @@ namespace GlyssenEngineTests
 				Assert.AreEqual(firstRefBlock.StartsAtVerseStart, secondaryRefBlock.StartsAtVerseStart);
 				Assert.AreEqual(firstRefBlock.InitialStartVerseNumber, secondaryRefBlock.InitialStartVerseNumber);
 				Assert.AreEqual(firstRefBlock.LastVerseNum, secondaryRefBlock.LastVerseNum);
+			}
+		}
+
+		[TestCase(ReferenceTextType.English)]
+		[TestCase(ReferenceTextType.Russian)]
+		public void GetBlocksForVerseMatchedToReferenceText_ClosingDashAtStartOfShortHeSaidParagraphNotIdentifiedAsDialogueCloserInSameOrderAsRefText_UnmodifiedRefBlocksAlignedWithOneUnmatched(
+			ReferenceTextType type)
+		{
+			var narrator = CharacterVerseData.GetStandardCharacterId("MRK", CharacterVerseData.StandardCharacter.Narrator);
+			var refText = ReferenceText.GetStandardReferenceText(type);
+			var refTextMrk = refText.GetBook("MRK");
+			var refTextBlocksForMrk10V39And40 = refTextMrk.GetBlocksForVerse(10, 39).ToList();
+			Assert.AreEqual(4, refTextBlocksForMrk10V39And40.Count, "SETUP check - expected reference text to have four blocks for Mark 10:39.");
+			Assert.AreEqual(narrator, refTextBlocksForMrk10V39And40[0].CharacterId,
+				"SETUP check - expected reference text to have narrator speak in first block for Mark 10:39.");
+			Assert.AreEqual("James, the disciple/John", refTextBlocksForMrk10V39And40[1].CharacterId,
+				"SETUP check - expected reference text to have James and John speak in second block for Mark 10:39.");
+			Assert.AreEqual(narrator, refTextBlocksForMrk10V39And40[2].CharacterId,
+				"SETUP check - expected reference text to have narrator speak in third block for Mark 10:39.");
+			Assert.AreEqual("Jesus", refTextBlocksForMrk10V39And40[3].CharacterId,
+				"SETUP check - expected reference text to have Jesus speak in last block for Mark 10:39.");
+			Assert.AreEqual(39, refTextBlocksForMrk10V39And40.Last().LastVerseNum,
+				"SETUP check - expected reference text to have have a block break between Mark 10:39 and v. 40.");
+			var refTextBlocksForMrk10V40 = refTextMrk.GetBlocksForVerse(10, 40).Single();
+			Assert.AreEqual("Jesus", refTextBlocksForMrk10V40.CharacterId,
+				"SETUP check - expected reference text to have Jesus speak in block for Mark 10:40.");
+			Assert.AreEqual("40", refTextBlocksForMrk10V40.BlockElements.OfType<Verse>().Single().Number,
+				"SETUP check - expected reference text to have have a block break between Mark 10:40 and v. 41.");
+			refTextBlocksForMrk10V39And40.Add(refTextBlocksForMrk10V40);
+
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(CreateBlockForVerse(CharacterVerseData.kAmbiguousCharacter, 39,
+				"—Ku̱an=ni", true, 10));
+			// The following is supposed to be spoken by the narrator, but the "closing" dash at the start of the
+			// paragraph is treated as an opener.
+			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kAmbiguousCharacter,
+				"—kitsingojo ngojó.");
+			AddNarratorBlockForVerseInProgress(vernacularBlocks, "ꞌBa Jesús kitsure:", "MRK");
+			AddBlockForVerseInProgress(vernacularBlocks, CharacterVerseData.kAmbiguousCharacter,
+				"—Sꞌiu nda sja xi kꞌuia̱ an, ꞌba sa̱tendo ko kjuanima jotsaꞌen sa̱tendaa̱; ")
+				.AddVerse(40, "tunga tsa ngate kixina̱ asa ngate skjunna̱ kuetsubo, tu kui= xuta xi je kisꞌendare ngaꞌndebiu kuaꞌere.");
+			var vernBook = new BookScript("MRK", vernacularBlocks, refText.Versification);
+
+			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 0);
+			var result = matchup.CorrelatedBlocks;
+
+			Assert.AreEqual(5, result.Count);
+			Assert.AreEqual("39", ((Verse)result[0].BlockElements[0]).Number);
+			Assert.IsFalse(result.Take(2).All(b => b.MatchesReferenceText),
+				"One or both of the first two blocks should not match the reference text.");
+			Assert.IsTrue(result[2].MatchesReferenceText);
+			Assert.IsTrue(result[3].MatchesReferenceText);
+			Assert.IsTrue(result[4].MatchesReferenceText);
+
+			var allReferenceBlocks = result.SelectMany(b => b.ReferenceBlocks).ToList();
+			Assert.AreEqual(5, allReferenceBlocks.Count,
+				"There should be no extra or missing reference blocks");
+
+			Assert.IsTrue(refTextBlocksForMrk10V39And40.Select(b => b.CharacterId)
+				.SetEquals(allReferenceBlocks.Select(b => b.CharacterId)),
+				"The resulting reference blocks should have the same characters as the original reference blocks");
+
+			var blockComparer = new BlockComparer();
+
+			Assert.AreEqual(5, allReferenceBlocks.Distinct(blockComparer).Count(),
+				"There should be no duplicate reference blocks");
+
+			Assert.IsTrue(allReferenceBlocks.SelectMany(b => b.BlockElements).OfType<Verse>().Select(v => v.Number)
+				.SetEquals(new [] {"39", "40"}));
+
+			Assert.IsTrue(allReferenceBlocks.SequenceEqual(refTextBlocksForMrk10V39And40, blockComparer));
+
+			if (refText.HasSecondaryReferenceText)
+			{
+				Assert.IsTrue(allReferenceBlocks.All(b => b.MatchesReferenceText));
+				var englishRefBlocks = allReferenceBlocks.Select(b => b.ReferenceBlocks.Single()).ToList();
+
+				Assert.AreEqual(5, englishRefBlocks.Distinct(blockComparer).Count(),
+					"There should be no duplicate English reference blocks");
+
+				Assert.IsTrue(englishRefBlocks.SelectMany(b => b.BlockElements).OfType<Verse>().Select(v => v.Number)
+					.SetEquals(new [] {"39", "40"}));
+
+				Assert.IsTrue(englishRefBlocks.SequenceEqual(refTextBlocksForMrk10V39And40.Select(b => b.ReferenceBlocks.Single()), blockComparer));
 			}
 		}
 		#endregion

--- a/GlyssenEngineTests/Script/BlockMatchupTests.cs
+++ b/GlyssenEngineTests/Script/BlockMatchupTests.cs
@@ -468,6 +468,31 @@ namespace GlyssenEngineTests.Script
 			Assert.AreEqual("said Jesus. To which Matthew replied, “We knew that.”", matchup.CorrelatedBlocks[1].ReferenceBlocks.Single().GetPrimaryReferenceText());
 		}
 
+		#region PG-1408
+		/// <summary>
+		/// This covers the special case where a vernacular block is misinterpreted as a quote
+		/// block because it starts with a dialogue dash that was actually intended to be a closer
+		/// for the previous speech. It could be argued that this case should be handled by the
+		/// quote parser since it might be able to correctly detect the case where the preceding
+		/// block already has a character speaking and then a dash occurs at the start of a new
+		/// paragraph in a verse where only one character is known to speak. However, because
+		/// the final determination depends on the matchup to the reference text, doing it in
+		/// MatchAllBlocks is more likely to produce a reliable result. Arguably, this logic
+		/// should only apply when the user has indicated that the dialogue dash serves as both
+		/// an opener and a closer.
+		/// </summary>
+		[TestCase("—", ExpectedResult = true)] // the real dialogue character (in the actual text)
+		[TestCase("-", ExpectedResult = false)] // any other character
+		public bool MatchAllBlocks_MismatchedDialogueDashAtStartOfParagraphCorrespondsToSingleNarratorRefBlock_VernBlockCharacterSetToNarrator(string dialogueChar)
+		{
+			var matchup = ReferenceTextTests.GetBlockMatchupForJohn12V35And36ForPg1408();
+			matchup.MatchAllBlocks(dialogueChar);
+			var lastBlock = matchup.CorrelatedBlocks.Last();
+			// In the case where the block starts with the dialogue quote, we expect the last block's character ID to be changed to narrator
+			return lastBlock.ReferenceBlocks.Single().CharacterId == lastBlock.CharacterId;
+		}
+		#endregion
+
 		[TestCase(0)]
 		[TestCase(1)]
 		[TestCase(2)]

--- a/GlyssenEngineTests/Script/BlockTests.cs
+++ b/GlyssenEngineTests/Script/BlockTests.cs
@@ -1391,6 +1391,64 @@ namespace GlyssenEngineTests.Script
 			Assert.AreEqual(@"demons (Legion)", refBlock.CharacterIdOverrideForScript);
 		}
 
+		[Test]
+		public void RemoveVerseNumbers_EmptyCollection_NoChange()
+		{
+			var block = new Block("p", 8, 29)
+				.AddVerse("29", "Verse 29 text. ")
+				.AddVerse("30", "Verse 30 text.");
+			block.BlockElements.Add(new Sound {EndVerse = 31});
+			var expected = block.GetText(true, true);
+
+			block.RemoveVerseNumbers(new Verse[0]);
+			Assert.AreEqual(expected, block.GetText(true, true));
+		}
+
+		[Test]
+		public void RemoveVerseNumbers_CollectionContainsVersesNotInBlock_NoChange()
+		{
+			var block = new Block("p", 8, 29)
+				.AddVerse("29", "Verse 29 text. ")
+				.AddVerse("30", "Verse 30 text.");
+			block.BlockElements.Add(new Sound {EndVerse = 31});
+			var expected = block.GetText(true, true);
+
+			block.RemoveVerseNumbers(new [] {new Verse("42"), new Verse("43")});
+			Assert.AreEqual(expected, block.GetText(true, true));
+		}
+
+		[Test]
+		public void RemoveVerseNumbers_CollectionContainsOneVerseInBlock_VerseRemovedAndAdjacentTextJoinedIntoSingleElement()
+		{
+			var block = new Block("p", 8, 29)
+				.AddVerse("29", "Verse 29 text. ")
+				.AddVerse("30", "Verse 30 text.");
+
+			block.RemoveVerseNumbers(new [] {new Verse("30")});
+			Assert.AreEqual("{29}\u00A0Verse 29 text. Verse 30 text.", block.GetText(true, true));
+		}
+
+		[Test]
+		public void RemoveVerseNumbers_CollectionContainsAllVersesInBlock_VersesRemovedAndAdjacentTextJoinedIntoSingleElement()
+		{
+			var block = new Block("p", 8, 29)
+				.AddVerse("29", "Verse 29 text. ")
+				.AddVerse("30", "Verse 30 text.");
+
+			block.RemoveVerseNumbers(new [] {new Verse("29"), new Verse("30")});
+			Assert.AreEqual("Verse 29 text. Verse 30 text.", block.GetText(true, true));
+		}
+
+		[Test]
+		public void RemoveVerseNumbers_CollectionContainsSingleStartingVerse_VerseRemoved()
+		{
+			var block = new Block("p", 8, 29)
+				.AddVerse("29", "Verse 29 text. ");
+
+			block.RemoveVerseNumbers(new [] {new Verse("29"), new Verse("30")});
+			Assert.AreEqual("Verse 29 text. ", block.GetText(true, true));
+		}
+
 		[TestCase("")]
 		[TestCase(" ")]
 		[TestCase("\u00A0")]

--- a/GlyssenShared/BlockElement.cs
+++ b/GlyssenShared/BlockElement.cs
@@ -166,19 +166,13 @@ namespace Glyssen.Shared
 		/// Gets the verse number as an integer. If the Verse number represents a verse bridge, this will be the
 		/// starting number in the bridge.
 		/// </summary>
-		public int StartVerse
-		{
-			get { return BCVRef.VerseToIntStart(Number); }
-		}
+		public int StartVerse => BCVRef.VerseToIntStart(Number);
 
 		/// <summary>
 		/// Gets the verse number as an integer. If the Verse number represents a verse bridge, this will be the
 		/// ending number in the bridge.
 		/// </summary>
-		public int EndVerse
-		{
-			get { return BCVRef.VerseToIntEnd(Number); }
-		}
+		public int EndVerse => BCVRef.VerseToIntEnd(Number);
 
 		/// <summary>
 		/// If the Verse number represents a verse bridge, this will be the ending number in the bridge; otherwise 0.


### PR DESCRIPTION
PG-1408 [Part 1]: Prevent detection of omissible "he said" reference block when there is additional following text.
Also, improve block matchup logic to assign narrator to the correlated block when the vernacular text starts with an apparent dialogue closing dash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/729)
<!-- Reviewable:end -->
