### PR TITLE
PG-1423: Improvements to ref text matching logic when target has he saids

### DIFF
--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -662,27 +662,18 @@ namespace GlyssenEngine
 						var j = 0;
 						var iLastVernBlockMatchedFromBottomUp = -1;
 						var numberOfUnexpectedReportingClausesMatched = 0;
-						var preMatchedHeSaids = 0;
 						if (numberOfVernBlocksInVerseChunk - i + omittedHeSaids.Count >= 2)
 						{
 							// Look from the bottom up
-							for (; j < numberOfVernBlocksInVerseChunk && j + i < numberOfRefBlocksInVerseChunk + omittedHeSaids.Count + preMatchedHeSaids; j++)
+							for (; j < numberOfVernBlocksInVerseChunk && j + i < numberOfRefBlocksInVerseChunk + omittedHeSaids.Count + numberOfUnexpectedReportingClausesMatched; j++)
 							{
 								var iCurrVernBottomUp = indexOfVernVerseStart + numberOfVernBlocksInVerseChunk - j - 1;
 								vernBlockInVerseChunk = vernBlockList[iCurrVernBottomUp];
 								if (vernBlockInVerseChunk.MatchesReferenceText)
-								{
-									if (vernBlockInVerseChunk.ReferenceBlocks.Single().GetText(false) == HeSaidText)
-									{
-										preMatchedHeSaids++;
-										continue;
-									}
-
 									break;
-								}
 
 								var currBottomUpRefBlockIndex = indexOfRefVerseStart + numberOfRefBlocksInVerseChunk - j
-									- 1 + numberOfUnexpectedReportingClausesMatched + preMatchedHeSaids;
+									- 1 + numberOfUnexpectedReportingClausesMatched;
 								var refBlockInVerseChunk = refBlockList[currBottomUpRefBlockIndex];
 								if ((iCurrVernBottomUp > i || omittedHeSaids.Count == 0) && // PG-1408: Don't match two different vern blocks to the same ref block
 									BlocksMatch(bookNum, vernBlockInVerseChunk, refBlockInVerseChunk, vernacularVersification))

--- a/GlyssenEngineTests/ReferenceTextTests.cs
+++ b/GlyssenEngineTests/ReferenceTextTests.cs
@@ -4890,7 +4890,7 @@ namespace GlyssenEngineTests
 		[TestCase(true)]
 		[TestCase(false)]
 		public void GetBlocksForVerseMatchedToReferenceText_OpeningAndClosingReportingClausesInVerseThatIsAllQuotationInEnglishReferenceText_EntireReferenceTextAssociatedWithQuoteBlock(
-			bool fillInClosingHeSaid)
+			bool includeClosingHeSaidInReportingClauses)
 		{
 			ReferenceText refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
 			var refTextMat = refText.GetBook("MAT");
@@ -4906,21 +4906,21 @@ namespace GlyssenEngineTests
 			Assert.AreEqual(20, refTextBlockForMat2V20.LastVerseNum,
 				"SETUP check - expected English reference text to have have a block break between Mat 2:20 and v. 21.");
 
-			var matchup = GetBlockMatchupForMat2V20(fillInClosingHeSaid, refTextBlockForMat2V20, refText);
+			var matchup = GetBlockMatchupForMat2V20(includeClosingHeSaidInReportingClauses, refTextBlockForMat2V20, refText);
 			var result = matchup.CorrelatedBlocks;
 
 			Assert.AreEqual(4, result.Count);
 			Assert.IsTrue(result[0].MatchesReferenceText);
 			Assert.IsFalse(result[1].MatchesReferenceText);
 			Assert.IsTrue(result[2].MatchesReferenceText);
-			Assert.AreEqual(fillInClosingHeSaid, result[3].MatchesReferenceText);
+			Assert.AreEqual(includeClosingHeSaidInReportingClauses, result[3].MatchesReferenceText);
 			Assert.AreEqual(refTextBlockForMat2V19.GetText(true), result[0].ReferenceBlocks.Single().GetText(true),
 				"Expected the narrator block in the English reference text for Mat 2:19 to be matched to the first block of matchup.");
 			Assert.AreEqual(refTextBlockForMat2V20.GetText(true), result[2].ReferenceBlocks.Single().GetText(true),
 				"Expected the block (angel) in the English reference text for Mat 2:20 to be matched to the third block of matchup.");
 		}
 
-		private static BlockMatchup GetBlockMatchupForMat2V20(bool fillInClosingHeSaid, Block refTextBlockForMat2V20, ReferenceText refText)
+		private static BlockMatchup GetBlockMatchupForMat2V20(bool includeClosingHeSaidInReportingClauses, Block refTextBlockForMat2V20, ReferenceText refText)
 		{
 			var vernacularBlocks = new List<Block>();
 			vernacularBlocks.Add(CreateNarratorBlockForVerse(19,
@@ -4929,15 +4929,15 @@ namespace GlyssenEngineTests
 			// The following is supposed to be spoken by the narrator, but the "closing" (interrupting) dash at the
 			// start of the paragraph is treated as an opener.
 			AddBlockForVerseInProgress(vernacularBlocks, refTextBlockForMat2V20.CharacterId,
-				"—¡Elhatakha, eiantemekha nematka nak kakpota nhan ngken akieto Israel, apkenmaskengvakme apkenmahai'a lhta ennapok nematka nak! ");
+				"—¡Elhatakha, eiantemekha nematka nak kakpota nhan ngken akieto Israel, apkenmaskengvakme apkenmahai'a lhta ennapok nematka nak! ")
+				.Delivery = refTextBlockForMat2V20.Delivery;
 			var closingHeSaid = AddNarratorBlockForVerseInProgress(vernacularBlocks, "—lhna aptemak.");
-			if (fillInClosingHeSaid)
-				closingHeSaid.SetMatchedReferenceBlock(refText.HeSaidText);
+
 			var vernBook = new BookScript("MAT", vernacularBlocks, refText.Versification);
 
-			var reportingClauses = fillInClosingHeSaid ?
-				new List<string>(new[] {"— lhna aptemak ma'a.", "lhna aptemak ma'a.", "—lhna aptemak.", "lhna aptemak."}) :
-				null;
+			var reportingClauses = new List<string>(new[] {"— lhna aptemak ma'a.", "lhna aptemak ma'a.", "lhna aptemak."});
+			if (includeClosingHeSaidInReportingClauses)
+				reportingClauses.Insert(2, "—lhna aptemak.");
 			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 0, reportingClauses);
 			return matchup;
 		}
@@ -4945,7 +4945,7 @@ namespace GlyssenEngineTests
 		[TestCase(true)]
 		[TestCase(false)]
 		public void GetBlocksForVerseMatchedToReferenceText_OpeningAndClosingReportingClausesInVerseThatIsAllQuotationInReferenceText_EntireReferenceTextAssociatedWithQuoteBlock(
-			bool fillInClosingHeSaid)
+			bool includeClosingHeSaidInReportingClauses)
 		{
 			ReferenceText refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.Russian);
 			var refTextMat = refText.GetBook("MAT");
@@ -4961,13 +4961,13 @@ namespace GlyssenEngineTests
 			Assert.AreEqual(20, refTextBlockForMat2V20.LastVerseNum,
 				"SETUP check - expected Russian reference text to have have a block break between Mat 2:20 and v. 21.");
 
-			var matchup = GetBlockMatchupForMat2V20(fillInClosingHeSaid, refTextBlockForMat2V20, refText);
+			var matchup = GetBlockMatchupForMat2V20(includeClosingHeSaidInReportingClauses, refTextBlockForMat2V20, refText);
 			var result = matchup.CorrelatedBlocks;
 
 			Assert.AreEqual(3, result.Count);
 			Assert.IsTrue(result[0].MatchesReferenceText);
 			Assert.IsTrue(result[1].MatchesReferenceText);
-			Assert.AreEqual(fillInClosingHeSaid, result[2].MatchesReferenceText);
+			Assert.AreEqual(includeClosingHeSaidInReportingClauses, result[2].MatchesReferenceText);
 			Assert.AreEqual(refTextBlockForMat2V19.GetText(true), result[0].ReferenceBlocks.Single().GetText(true),
 				"Expected the narrator block in the reference text for Mat 2:19 to be matched to the first block of matchup.");
 			Assert.AreEqual(refTextBlockForMat2V20.GetText(true), result[1].ReferenceBlocks.Single().GetText(true),

--- a/GlyssenEngineTests/ReferenceTextTests.cs
+++ b/GlyssenEngineTests/ReferenceTextTests.cs
@@ -4886,6 +4886,95 @@ namespace GlyssenEngineTests
 		}
 		#endregion
 
+		#region PG-1423
+		[TestCase(true)]
+		[TestCase(false)]
+		public void GetBlocksForVerseMatchedToReferenceText_OpeningAndClosingReportingClausesInVerseThatIsAllQuotationInEnglishReferenceText_EntireReferenceTextAssociatedWithQuoteBlock(
+			bool fillInClosingHeSaid)
+		{
+			ReferenceText refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.English);
+			var refTextMat = refText.GetBook("MAT");
+			var refTextBlockForMat2V19 = refTextMat.GetBlocksForVerse(2, 19).Single();
+			Assert.IsTrue(CharacterVerseData.IsCharacterOfType(refTextBlockForMat2V19.CharacterId, CharacterVerseData.StandardCharacter.Narrator),
+				"SETUP check - expected English reference text to have narrator speak in block for Mat 2:19.");
+			Assert.AreEqual(19, refTextBlockForMat2V19.LastVerseNum,
+				"SETUP check - expected English reference text to have have a block break between Mat 2:19 and v. 20.");
+
+			var refTextBlockForMat2V20 = refTextMat.GetBlocksForVerse(2, 20).Last();
+			Assert.AreEqual("angel", refTextBlockForMat2V20.CharacterId,
+				"SETUP check - expected English reference text to have angel speak in block for Mat 2:20.");
+			Assert.AreEqual(20, refTextBlockForMat2V20.LastVerseNum,
+				"SETUP check - expected English reference text to have have a block break between Mat 2:20 and v. 21.");
+
+			var matchup = GetBlockMatchupForMat2V20(fillInClosingHeSaid, refTextBlockForMat2V20, refText);
+			var result = matchup.CorrelatedBlocks;
+
+			Assert.AreEqual(4, result.Count);
+			Assert.IsTrue(result[0].MatchesReferenceText);
+			Assert.IsFalse(result[1].MatchesReferenceText);
+			Assert.IsTrue(result[2].MatchesReferenceText);
+			Assert.AreEqual(fillInClosingHeSaid, result[3].MatchesReferenceText);
+			Assert.AreEqual(refTextBlockForMat2V19.GetText(true), result[0].ReferenceBlocks.Single().GetText(true),
+				"Expected the narrator block in the English reference text for Mat 2:19 to be matched to the first block of matchup.");
+			Assert.AreEqual(refTextBlockForMat2V20.GetText(true), result[2].ReferenceBlocks.Single().GetText(true),
+				"Expected the block (angel) in the English reference text for Mat 2:20 to be matched to the third block of matchup.");
+		}
+
+		private static BlockMatchup GetBlockMatchupForMat2V20(bool fillInClosingHeSaid, Block refTextBlockForMat2V20, ReferenceText refText)
+		{
+			var vernacularBlocks = new List<Block>();
+			vernacularBlocks.Add(CreateNarratorBlockForVerse(19,
+					"Apnengkek mokhom Jose m'a iokhalhma Egipto, apveske Herodes. Neksa apteianma lhnak Jose m'a,mokhom angel apkapaskama Apveske,", true, 2)
+				.AddVerse(20, "lhna aptemak:"));
+			// The following is supposed to be spoken by the narrator, but the "closing" (interrupting) dash at the
+			// start of the paragraph is treated as an opener.
+			AddBlockForVerseInProgress(vernacularBlocks, refTextBlockForMat2V20.CharacterId,
+				"—¡Elhatakha, eiantemekha nematka nak kakpota nhan ngken akieto Israel, apkenmaskengvakme apkenmahai'a lhta ennapok nematka nak! ");
+			var closingHeSaid = AddNarratorBlockForVerseInProgress(vernacularBlocks, "—lhna aptemak.");
+			if (fillInClosingHeSaid)
+				closingHeSaid.SetMatchedReferenceBlock(refText.HeSaidText);
+			var vernBook = new BookScript("MAT", vernacularBlocks, refText.Versification);
+
+			var reportingClauses = fillInClosingHeSaid ?
+				new List<string>(new[] {"— lhna aptemak ma'a.", "lhna aptemak ma'a.", "—lhna aptemak.", "lhna aptemak."}) :
+				null;
+			var matchup = refText.GetBlocksForVerseMatchedToReferenceText(vernBook, 0, reportingClauses);
+			return matchup;
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public void GetBlocksForVerseMatchedToReferenceText_OpeningAndClosingReportingClausesInVerseThatIsAllQuotationInReferenceText_EntireReferenceTextAssociatedWithQuoteBlock(
+			bool fillInClosingHeSaid)
+		{
+			ReferenceText refText = ReferenceText.GetStandardReferenceText(ReferenceTextType.Russian);
+			var refTextMat = refText.GetBook("MAT");
+			var refTextBlockForMat2V19 = refTextMat.GetBlocksForVerse(2, 19).Single();
+			Assert.IsTrue(CharacterVerseData.IsCharacterOfType(refTextBlockForMat2V19.CharacterId, CharacterVerseData.StandardCharacter.Narrator),
+				"SETUP check - expected Russian reference text to have narrator speak in block for Mat 2:19.");
+			Assert.AreEqual(20, refTextBlockForMat2V19.LastVerseNum,
+				"SETUP check - expected Russian reference text to have have the start of Mat 2:20 included in block for v. 19.");
+
+			var refTextBlockForMat2V20 = refTextMat.GetBlocksForVerse(2, 20).Last();
+			Assert.AreEqual("angel", refTextBlockForMat2V20.CharacterId,
+				"SETUP check - expected Russian reference text to have angel speak in block for Mat 2:20.");
+			Assert.AreEqual(20, refTextBlockForMat2V20.LastVerseNum,
+				"SETUP check - expected Russian reference text to have have a block break between Mat 2:20 and v. 21.");
+
+			var matchup = GetBlockMatchupForMat2V20(fillInClosingHeSaid, refTextBlockForMat2V20, refText);
+			var result = matchup.CorrelatedBlocks;
+
+			Assert.AreEqual(3, result.Count);
+			Assert.IsTrue(result[0].MatchesReferenceText);
+			Assert.IsTrue(result[1].MatchesReferenceText);
+			Assert.AreEqual(fillInClosingHeSaid, result[2].MatchesReferenceText);
+			Assert.AreEqual(refTextBlockForMat2V19.GetText(true), result[0].ReferenceBlocks.Single().GetText(true),
+				"Expected the narrator block in the reference text for Mat 2:19 to be matched to the first block of matchup.");
+			Assert.AreEqual(refTextBlockForMat2V20.GetText(true), result[1].ReferenceBlocks.Single().GetText(true),
+				"Expected the block (angel) in the reference text for Mat 2:20 to be matched to the third block of matchup.");
+		}
+		#endregion
+
 		#region private helper methods
 		private Block NewChapterBlock(string bookId, int chapterNum, string text = null)
 		{


### PR DESCRIPTION
Added logic to allow bottom-up matching to proceed when a trailing he-said has been pre-matched.
Added logic to find and use an exact match (if any) if multiple vern blocks are unmatched and there is only one remaining unmatched ref block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/737)
<!-- Reviewable:end -->
