### PR TITLE
PG-1427: prevented NullReferenceException when in Split Mode

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1888,19 +1888,23 @@ namespace Glyssen.Dialogs
 			var textBeforeInsertionPoint = editingCtrl.Text.Substring(0, editingCtrl.SelectionStart);
 			var textAfterInsertionPoint = editingCtrl.Text.Substring(editingCtrl.SelectionStart);
 			var destCell = GetSplitTextDestination();
-			if (destCell.RowIndex < currCell.RowIndex)
-			{
-				destCell.Value = textBeforeInsertionPoint;
-				currCell.Value = textAfterInsertionPoint;
-			}
+			if (destCell == null)
+				editingCtrl.Click -= HandleClickToSplitRefText;
 			else
 			{
-				currCell.Value = textBeforeInsertionPoint;
-				destCell.Value = textAfterInsertionPoint;
+				if (destCell.RowIndex < currCell.RowIndex)
+				{
+					destCell.Value = textBeforeInsertionPoint;
+					currCell.Value = textAfterInsertionPoint;
+				}
+				else
+				{
+					currCell.Value = textBeforeInsertionPoint;
+					destCell.Value = textAfterInsertionPoint;
+				}
+
+				m_dataGridReferenceText.CurrentCell = destCell;
 			}
-			m_dataGridReferenceText.CurrentCell = destCell;
-			if (GetSplitTextDestination() == null)
-				editingCtrl.Click -= HandleClickToSplitRefText;
 		}
 
 		private DataGridViewCell GetSplitTextDestination()


### PR DESCRIPTION
This could happen when a selection was made in a reference text cell that cannot be split.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/744)
<!-- Reviewable:end -->
