### PR TITLE
Prevent spurious warning about changing the character for a continuation block

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1458,6 +1458,9 @@ namespace Glyssen.Dialogs
 				if (correlatedBlock.IsContinuationOfPreviousBlockQuote)
 				{
 					var index = e.RowIndex - 1;
+					if (index >= 0 && m_dataGridReferenceText.CurrentCell.EditedFormattedValue == m_dataGridReferenceText.Rows[index].Cells[colCharacter.Index].FormattedValue)
+						return;
+
 					while (index >= 0 && matchup.CorrelatedBlocks[index].IsContinuationOfPreviousBlockQuote)
 						index--;
 					int verseWhereQuoteStarts;


### PR DESCRIPTION
When it is being "changed" to the same value it had, for some reason the grid is considering it to be "dirty" and in need of validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/750)
<!-- Reviewable:end -->
