### PR TITLE
Make SIL.ReleaseTasks  a build-only dependency

### DIFF
--- a/GlyssenEngine/GlyssenEngine.csproj
+++ b/GlyssenEngine/GlyssenEngine.csproj
@@ -83,7 +83,7 @@ See full changelog at https://github.com/sillsdev/Glyssen/blob/master/CHANGELOG.
     <PackageReference Include="ParatextData" Version="9.1.9-beta" />
     <PackageReference Include="SIL.Core" Version="8.0.0" />
     <PackageReference Include="SIL.DblBundle" Version="8.0.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="true" />
     <PackageReference Include="SIL.Scripture" Version="8.0.0" />
     <PackageReference Include="SIL.WritingSystems" Version="8.0.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />


### PR DESCRIPTION
Usually there is no need to make the nuget package depend on SIL.ReleaseTasks. It is a build-time dependency that is needed when building the nuget package but isn't required at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/773)
<!-- Reviewable:end -->
