### PR TITLE
Make SIL.ReleaseTasks a build-only dependency

### DIFF
--- a/GlyssenShared/GlyssenShared.csproj
+++ b/GlyssenShared/GlyssenShared.csproj
@@ -38,7 +38,7 @@ See full changelog at https://github.com/sillsdev/Glyssen/blob/master/CHANGELOG.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Usually there is no need to make the nuget package depend on SIL.ReleaseTasks. It is a build-time dependency that is needed when building the nuget package but isn't required at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/774)
<!-- Reviewable:end -->
