### PR TITLE
PG-1408: Improvements to prevent loss of reference text.

### DIFF
--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -1,5 +1,4 @@
 ﻿using Glyssen.Shared;
-using Glyssen.Shared.Bundle;
 using GlyssenEngine.Analysis;
 using GlyssenEngine.Bundle;
 using GlyssenEngine.Casting;

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -399,6 +399,11 @@ namespace GlyssenEngine.Script
 		/// that the user might actually wish to review.</remarks>
 		public bool TryMatchToReportingClause(IReadOnlyCollection<string> reportingClauses, ReferenceText referenceText, int bookNum, ScrVers vernacularVersification)
 		{
+			// ENHANCE: To better support languages that consistently use punctuation (e.g., a
+			// leading dash) to indicate a reporting clause, we could either add a new (quotation
+			// mark?) setting or guess at it (e.g., if there are two or more known reporting
+			// clauses and they all start with the same punctuation) and use that as a pattern for
+			// other probably reporting clauses.
 			if (MatchesReferenceText || reportingClauses == null ||
 				!reportingClauses.Contains(BlockElements.OfType<ScriptText>().OnlyOrDefault()?.Content.Trim()))
 			{


### PR DESCRIPTION
Also added code to move verse number to preceding English reference block when moving it for a non-English reference block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/775)
<!-- Reviewable:end -->
