### PR TITLE
PG-1436: Changed when UpdateFollowingContinuationBlocks gets called

### DIFF
--- a/GlyssenEngine/Script/BlockMatchup.cs
+++ b/GlyssenEngine/Script/BlockMatchup.cs
@@ -185,7 +185,8 @@ namespace GlyssenEngine.Script
 
 			if (CountOfBlocksAddedBySplitting > 0)
 			{
-				m_vernacularBook.ReplaceBlocks(IndexOfStartBlockInBook, OriginalBlockCount, CorrelatedBlocks.Select(b => b.Clone()).ToList());
+				m_vernacularBook.ReplaceBlocks(IndexOfStartBlockInBook, OriginalBlockCount,
+					CorrelatedBlocks.Select(b => b.Clone()).ToList(), false);
 			}
 			int bookNum = BCVRef.BookToNumber(BookId);
 			var origBlocks = m_vernacularBook.GetScriptBlocks();
@@ -210,12 +211,9 @@ namespace GlyssenEngine.Script
 					vernBlock.UserConfirmed = true;
 				vernBlock.SplitId = CorrelatedBlocks[i].SplitId;
 			}
-			// No need to update following continuation blocks here if m_numberOfBlocksAddedBySplitting > 0 because the call to
-			// ReplaceBlocks (above) already did it.
-			if (CountOfBlocksAddedBySplitting == 0)
-				m_vernacularBook.UpdateFollowingContinuationBlocks(IndexOfStartBlockInBook + OriginalBlockCount - 1);
-			else
-				CountOfBlocksAddedBySplitting = 0;
+
+			m_vernacularBook.UpdateFollowingContinuationBlocks(IndexOfStartBlockInBook + OriginalBlockCount + CountOfBlocksAddedBySplitting - 1);
+			CountOfBlocksAddedBySplitting = 0;
 
 			for (int i = IndexOfStartBlockInBook; i < IndexOfStartBlockInBook + CorrelatedBlocks.Count; i++)
 			{


### PR DESCRIPTION
when applying the correlated blocks of a BlockMatchup to ensure preceding blocks are in a valid state. This avoids an exception caused by calling it prematurely before trailing narrator blocks have their MultiBlockQuote property set to None.
 Note: issue is duplicated by: PG-1437 and PG-1438.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/776)
<!-- Reviewable:end -->
