### PR TITLE
PG-1462: Added some crash-proofing code to LoadNextRelevantBlock

### DIFF
--- a/GlyssenEngine/Script/BookScript.cs
+++ b/GlyssenEngine/Script/BookScript.cs
@@ -509,8 +509,22 @@ namespace GlyssenEngine.Script
 					if (block.InitialStartVerseNumber == verse || (block.InitialStartVerseNumber < verse && block.InitialEndVerseNumber >= verse))
 						return iFirstBlockToExamine;
 				}
-				if (iFirstBlockToExamine > 0 && m_blocks[iFirstBlockToExamine - 1].LastVerseNum >= verse)
+
+				if (iFirstBlockToExamine > 0 && m_blocks[iFirstBlockToExamine - 1].ChapterNumber == chapter &&
+					m_blocks[iFirstBlockToExamine - 1].LastVerseNum >= verse && m_blocks[iFirstBlockToExamine - 1].IsScripture)
+				{
 					return iFirstBlockToExamine - 1;
+				}
+
+				if (verse == 0)
+				{
+					while (!m_blocks[iFirstBlockToExamine].IsScripture)
+					{
+						if (++iFirstBlockToExamine == m_blocks.Count)
+							return -1;
+					}
+				}
+
 				break;
 			}
 

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -709,11 +709,33 @@ namespace GlyssenEngine.ViewModels
 		{
 			if (IsCurrentLocationRelevant)
 			{
+				int prevIndex = m_currentRelevantIndex;
 				if (BlockGroupingStyle == BlockGroupingType.Quote)
 					m_currentRelevantIndex++;
 				else
 					m_currentRelevantIndex = GetIndexOfNextRelevantBlockNotInCurrentMatchup();
-				SetBlock(m_relevantBookBlockIndices[m_currentRelevantIndex]);
+				try
+				{
+					SetBlock(m_relevantBookBlockIndices[m_currentRelevantIndex]);
+				}
+				catch (ArgumentOutOfRangeException e)
+				{
+					ErrorReport.NotifyUserOfProblem(e, Localizer.GetString(
+						"DialogBoxes.BlockNavigator.LoadNextRelevantBlockIndexOutOfRange",
+						"Sorry! {0} has gotten a little confused and can't go to the next " +
+						"place that matches the filter.\r\n" +
+						"Please click Details and send in a report to notify the developers.\r\n" +
+						"After reporting this error, close the Identify Speaking Parts dialog box " +
+						"and reopen it.", "Parameter is \"Glyssen\" (product name)") +
+						"\r\nInformation for developers (PG-1462):\r\n" +
+						"previous index = {1}\r\n" +
+						"new index = {2}\r\n" +
+						"relevant indices = {3}\r\n" +
+						"grouping style = {4}\r\n" +
+						"current block = {5}",
+						GlyssenInfo.Product, prevIndex, m_currentRelevantIndex, m_relevantBookBlockIndices.Count,
+						BlockGroupingStyle, CurrentBlock);
+				}
 			}
 			else
 				LoadClosestRelevantBlock(false);

--- a/GlyssenEngineTests/Script/BookScriptTests.cs
+++ b/GlyssenEngineTests/Script/BookScriptTests.cs
@@ -376,6 +376,22 @@ namespace GlyssenEngineTests.Script
 			Assert.AreEqual(4, list.Count);
 			Assert.AreEqual(expected, list[0]);
 		}
+
+		[Test]
+		public void GetBlocksForVerse_VerseZero_ReturnsBlocksForVerse()
+		{
+			var blocks = new List<Block>();
+			blocks.Add(NewChapterBlock(4, "ROM"));
+			blocks.Add(NewSingleVersePara(1, "Verse one."));
+			blocks.Add(NewSingleVersePara(20, "Verse twenty"));
+			blocks.Add(NewChapterBlock(5, "ROM"));
+			blocks.Add(new Block("d", 5) {BlockElements = new List<BlockElement>(new BlockElement[] {new ScriptText("(Taema nota pebëxëpanayo.)")})});
+			blocks.Add(NewSingleVersePara(1, "Ka guwoto kacel i yo, ci guo ka ma pii tye iye. Laco ma gikolo owacci, "));
+			blocks.Add(NewBlock("“Nen pii doŋ ene! Gin aŋo ma geŋa limo batija?” "));
+			var bookScript = new BookScript("ROM", blocks, ScrVers.English);
+			var list = bookScript.GetBlocksForVerse(5, 0).ToList();
+			Assert.AreEqual("(Taema nota pebëxëpanayo.)", list.Single().GetText(true));
+		}
 		#endregion
 
 		#region GetScriptBlocks Tests


### PR DESCRIPTION
with details to try to figure out what happened if this error occurs again in the future.
Also (possibly related?) improved GetIndexOfFirstBlockForVerse to handle case of "Scripture" (?) block before v. 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/788)
<!-- Reviewable:end -->
