### PR TITLE
PG-1407/PG-1466: Reset button state after applying changes…

### DIFF
--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -1194,13 +1194,19 @@ namespace Glyssen.Dialogs
 			Block blockToSplit;
 			if (m_viewModel.BlockGroupingStyle == BlockGroupingType.BlockCorrelation)
 			{
+				if (m_dataGridReferenceText.IsCurrentCellInEditMode)
+					m_dataGridReferenceText.EndEdit(DataGridViewDataErrorContexts.LeaveControl);
+
 				if (IsDirty && m_btnApplyReferenceTextMatches.Enabled && m_userMadeChangesToReferenceTextMatchup)
 				{
 					string msg = LocalizationManager.GetString("DialogBoxes.AssignCharacterDlg.UnsavedReferenceTextChangesBeforeSplitting",
 						"The alignment of the reference text to the vernacular script has not been applied. Do you want to save the alignment before splitting this block?");
 					if (MessageBox.Show(this, msg, UnsavedChangesMessageBoxTitle, MessageBoxButtons.YesNo) == DialogResult.Yes)
+					{
 						if (!CheckRefTextValuesAndApplyMatchup())
 							return;
+						UpdateAssignOrApplyAndResetButtonState();
+					}
 				}
 
 				var matchup = m_viewModel.CurrentReferenceTextMatchup;
@@ -1220,7 +1226,7 @@ namespace Glyssen.Dialogs
 				blockToSplit = m_viewModel.CurrentBlock;
 			using (var dlg = new SplitBlockDlg(new SplitBlockViewModel(m_viewModel, blockToSplit)))
 			{
-				MainForm.LogDialogDisplay(dlg);
+				MainForm.LogDialogDisplay(dlg, m_viewModel);
 				if (dlg.ShowDialog(this) == DialogResult.OK)
 				{
 					Logger.WriteMinorEvent($"Split block in {m_scriptureReference.VerseControl.VerseRef} into {dlg.SplitLocations.Count + 1} parts. " +
@@ -1376,6 +1382,7 @@ namespace Glyssen.Dialogs
 				}
 			}
 			m_viewModel.ApplyCurrentReferenceTextMatchup();
+			m_userMadeChangesToReferenceTextMatchup = false;
 			return true;
 		}
 

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -356,7 +356,7 @@ namespace Glyssen
 		internal static void LogDialogDisplay(Form dlg, object modelDetails = null)
 		{
 			Logger.WriteEvent($"Displaying dialog box: {dlg.Text}" + (modelDetails == null ? "" :
-				$"for {modelDetails}"));
+				$" for {modelDetails}"));
 		}
 
 		private void ShowOpenProjectDialog()

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -353,9 +353,10 @@ namespace Glyssen
 			return result;
 		}
 
-		internal static void LogDialogDisplay(Form dlg)
+		internal static void LogDialogDisplay(Form dlg, object modelDetails = null)
 		{
-			Logger.WriteEvent($"Displaying dialog box: {dlg.Text}");
+			Logger.WriteEvent($"Displaying dialog box: {dlg.Text}" + (modelDetails == null ? "" :
+				$"for {modelDetails}"));
 		}
 
 		private void ShowOpenProjectDialog()

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -895,7 +895,11 @@ namespace GlyssenEngine.ViewModels
 				throw new InvalidOperationException("No current reference text block matchup!");
 			Debug.Assert(m_currentRefBlockMatchups != null);
 			if (!m_currentRefBlockMatchups.HasOutstandingChangesToApply)
-				throw new InvalidOperationException("Current reference text block matchup has no outstanding changes!");
+			{
+				throw new InvalidOperationException("Current reference text block matchup has no outstanding changes!\r\n" +
+					m_currentRefBlockMatchups);
+			}
+
 			var insertions = m_currentRefBlockMatchups.CountOfBlocksAddedBySplitting;
 			var insertionIndex = m_currentRelevantIndex;
 

--- a/GlyssenEngine/ViewModels/SplitBlockViewModel.cs
+++ b/GlyssenEngine/ViewModels/SplitBlockViewModel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Web;
 using Glyssen.Shared;
-using GlyssenEngine;
 using GlyssenEngine.Character;
 using GlyssenEngine.Script;
 using GlyssenEngine.Utilities;
@@ -274,5 +273,7 @@ namespace GlyssenEngine.ViewModels
 
 			return false;
 		}
+
+		public override string ToString() => $"{OriginalBlockCount} starting with {m_originalBlocks.First()}";
 	}
 }

--- a/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
@@ -1234,7 +1234,7 @@ namespace GlyssenEngineTests.ViewModelTests
 			m_model.CurrentReferenceTextMatchup.SetReferenceText(0, "Some random text: " + Guid.NewGuid());
 			m_model.ApplyCurrentReferenceTextMatchup();
 			var e = Assert.Throws<InvalidOperationException>(() => m_model.ApplyCurrentReferenceTextMatchup());
-			Assert.AreEqual("Current reference text block matchup has no outstanding changes!", e.Message);
+			Assert.That(e.Message, Does.StartWith("Current reference text block matchup has no outstanding changes!");
 		}
 
 		[Test]

--- a/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/BlockNavigatorViewModelTests.cs
@@ -1234,7 +1234,7 @@ namespace GlyssenEngineTests.ViewModelTests
 			m_model.CurrentReferenceTextMatchup.SetReferenceText(0, "Some random text: " + Guid.NewGuid());
 			m_model.ApplyCurrentReferenceTextMatchup();
 			var e = Assert.Throws<InvalidOperationException>(() => m_model.ApplyCurrentReferenceTextMatchup());
-			Assert.That(e.Message, Does.StartWith("Current reference text block matchup has no outstanding changes!");
+			Assert.That(e.Message, Does.StartWith("Current reference text block matchup has no outstanding changes!"));
 		}
 
 		[Test]


### PR DESCRIPTION
…before showing split dialog to prevent InvalidOperationException if user cancels the split and then clicks Apply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/789)
<!-- Reviewable:end -->
