### PR TITLE
PG-1468: Prevent errors in three scenarios

### DIFF
--- a/GlyssenEngine/ReferenceText.cs
+++ b/GlyssenEngine/ReferenceText.cs
@@ -1192,7 +1192,7 @@ namespace GlyssenEngine
 		}
 
 		/// <summary>
-		/// Split blocks in the given book to match verse split locations
+		/// Split blocks in the given portion to match verse split locations
 		/// </summary>
 		/// <returns>A value indicating whether any splits were made</returns>
 		private static bool MakesSplits(PortionScript blocksToSplit, int bookNum,

--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -1252,7 +1252,7 @@ namespace GlyssenEngine.Script
 				var refVerses = leadingVerseInNewRowB.AllVerses().Select(v => v.VerseNum).ToList();
 				// If any of the vern blocks at or above the swap position have any of the
 				// verses in the ref verse range, then don't move it.
-				if (vernBlocks.Take(iVernRowA + 1).Any(b => b.AllVerses.Any(v => v.AllVerseNumbers.Any(vn => refVerses.Contains(vn)))) ||
+				if (vernBlocks.Take(iVernRowA + 1).Any(b => b.IsScripture && b.AllVerses.Any(v => v.AllVerseNumbers.Any(vn => refVerses.Contains(vn)))) ||
 					(iVernRowA < vernBlocks.Count - 1 &&
 					vernBlocks[iVernRowA + 1].InitialStartVerseNumber > refVerses.First()))
 				{

--- a/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
+++ b/GlyssenEngine/ViewModels/BlockNavigatorViewModel.cs
@@ -81,10 +81,17 @@ namespace GlyssenEngine.ViewModels
 				var startingBlock = GetBlock(startingIndices);
 				if (startingBlock != null && !CharacterVerseData.IsCharacterExtraBiblical(startingBlock.CharacterId))
 				{
-					SetBlock(startingIndices);
-					m_currentRelevantIndex = m_relevantBookBlockIndices.IndexOf(startingIndices);
+					// Note: we don't want to use the normal BookBlockIndices.Equal to find the requested index because the data
+					// could have changed in a way that causes the extent of the matchup to have changed. In that case, we want
+					// to use the now relevant matchup at the previous block index. Otherwise, we can end up with a crash later.
+					m_currentRelevantIndex = m_relevantBookBlockIndices.FindIndex(bbi => bbi.BookIndex == startingIndices.BookIndex && bbi.BlockIndex == startingIndices.BlockIndex);
 					if (m_currentRelevantIndex < 0)
+					{
+						SetBlock(startingIndices);
 						m_temporarilyIncludedBookBlockIndices = startingIndices;
+					}
+					else
+						SetBlock(m_relevantBookBlockIndices[m_currentRelevantIndex]);
 				}
 			}
 		}

--- a/GlyssenEngineTests/Script/BlockTests.cs
+++ b/GlyssenEngineTests/Script/BlockTests.cs
@@ -1467,10 +1467,19 @@ namespace GlyssenEngineTests.Script
 
 		[TestCase(0)]
 		[TestCase(1)]
+		[TestCase(1, true)]
 		public void GetSwappedReferenceText_RowAHasLeadingVerseNumber_RowBIsEmpty_VernHasCorrespondingVerse_LeadingVerseStaysWithRowA(
-			int vernRowCorrespondingToA)
+			int vernRowCorrespondingToA, bool includeSectionHead = false)
 		{
 			var vernBlocks = new List<Block>();
+			if (includeSectionHead)
+			{
+				vernBlocks.Add(new Block("s", 8, 18)
+				{
+					CharacterId = GetStandardCharacterId("MAT", StandardCharacter.ExtraBiblical),
+					BlockElements = new List<BlockElement>(new [] { new ScriptText("Section head text") })
+				});
+			}
 			vernBlocks.Add(new Block("p", 8, 19).AddVerse("19", "Start of verse 19 text."));
 			vernBlocks.Add(new Block("p", 8, 19).AddText("Rest of verse 19.")
 				.AddVerse("20", "Verse 20 text.").AddVerse("21", "Verse 21 text."));
@@ -1677,6 +1686,7 @@ namespace GlyssenEngineTests.Script
 			Assert.IsTrue(IsNullOrEmpty(newRowAValue));
 			Assert.AreEqual("{21} Verse twenty-one.", newRowBValue);
 		}
+		
 
 		[TestCase("1234567")]
 		[TestCase("This is a pretty basic test")]

--- a/GlyssenEngineTests/ViewModelTests/AssignCharacterViewModelTests.cs
+++ b/GlyssenEngineTests/ViewModelTests/AssignCharacterViewModelTests.cs
@@ -79,6 +79,29 @@ namespace GlyssenEngineTests.ViewModelTests
 		}
 
 		[Test]
+		public void Constructor_Match_FirstUnexpectedBlockLoaded()
+		{
+			m_model.SetMode(BlocksToDisplay.NotAlignedToReferenceText, true);
+			m_model.TryLoadBlock(new VerseRef(41001001, ScrVers.English));
+			m_model.LoadNextRelevantBlock();
+			while (m_model.CurrentReferenceTextMatchup.OriginalBlockCount < 3 && m_model.CanNavigateToNextRelevantBlock)
+				m_model.LoadNextRelevantBlock();
+
+			Assert.IsTrue(m_model.CurrentReferenceTextMatchup.OriginalBlockCount > 2, "Setup condition not met!");
+
+			var expectedBook = m_model.CurrentBookId;
+			var expectedBlock = m_model.CurrentBlockIndexInBook;
+			var expectedNumberOfBlocks = m_model.CurrentReferenceTextMatchup.OriginalBlockCount;
+
+			m_model = new AssignCharacterViewModel(m_testProject, m_model.Mode, new BookBlockIndices(m_testProject.AvailableBooks.IndexOf(b => b.Code == expectedBook), expectedBlock, 2));
+			Assert.AreEqual(expectedBook, m_model.CurrentBookId);
+			Assert.AreEqual(expectedBlock, m_model.CurrentBlockIndexInBook);
+			Assert.AreEqual(expectedNumberOfBlocks, m_model.CurrentReferenceTextMatchup.OriginalBlockCount);
+			Assert.AreEqual(expectedNumberOfBlocks, m_model.BlockAccessor.GetIndices().MultiBlockCount);
+			Assert.IsTrue(m_model.IsCurrentLocationRelevant);
+		}
+
+		[Test]
 		public void Narrator_CurrentBookIsMark_ToStringIncludesBookName()
 		{
 			Assert.AreEqual("narrator (MRK)", AssignCharacterViewModel.Character.Narrator.ToString());


### PR DESCRIPTION
1. when matchup is applied but the block remains relevant

2. when project is updated (or the user leaves and comes back into the ISP dialog) and the number of blocks in previously selected matchup has changed

3. when moving contents of reference text cell and a preceding row is a section head

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/790)
<!-- Reviewable:end -->
