### PR TITLE
Fixed incorrect character ID in LUK 9:8 in reference texts

### DIFF
--- a/DistFiles/reference_texts/English/LUK.xml
+++ b/DistFiles/reference_texts/English/LUK.xml
@@ -2115,7 +2115,7 @@
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="narrator-LUK">
     <text>and still others said,</text>
   </block>
-  <block style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="people, other">
+  <block style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="people, still others">
     <text>«One of the old prophets had risen again.»</text>
   </block>
   <block style="p" paragraphStart="true" chapter="9" initialStartVerse="9" characterId="narrator-LUK">

--- a/DistFiles/reference_texts/Russian/LUK.xml
+++ b/DistFiles/reference_texts/Russian/LUK.xml
@@ -4231,7 +4231,7 @@
     </ReferenceBlocks>
     <text>что</text>
   </block>
-  <block style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="people, other" matchesReferenceText="true">
+  <block style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="people, still others" matchesReferenceText="true">
     <ReferenceBlocks style="p" paragraphStart="true" chapter="9" initialStartVerse="8" characterId="people, other">
       <text>«One of the old prophets had risen again.»</text>
     </ReferenceBlocks>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/805)
<!-- Reviewable:end -->
