### PR TITLE
PG-1360: Implemented "Synchronized scrolling" when user clicks in a reference text row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -->
 
 ## [Unreleased]
+### Added
+
+- AssignCharacterViewModel.GetVerseRefForRow
 
 ## [3.1.0] - 2021-07-27
 

--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -46,6 +46,9 @@ back-up plan.)
 
 # Release Notes
 
+## March 9 2022 Glyssen 3.3.0
+When a reference text row is selected, Paratext is notified so it can sync to that location in the text.
+
 ## January 20 2022 Glyssen 3.1.3
 Added logic to ensure that block numbers in actor- and book-specific Excel exports match the numbers of those same blocks in the master file for the project.
 

--- a/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.Designer.cs
@@ -1152,7 +1152,7 @@ namespace Glyssen.Dialogs
 			this.m_dataGridReferenceText.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.m_dataGridReferenceText_CellPainting);
 			this.m_dataGridReferenceText.CellValidating += new System.Windows.Forms.DataGridViewCellValidatingEventHandler(this.m_dataGridReferenceText_CellValidating);
 			this.m_dataGridReferenceText.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.m_dataGridReferenceText_EditingControlShowing);
-			this.m_dataGridReferenceText.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.UpdateRowSpecificButtonStates);
+			this.m_dataGridReferenceText.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.m_dataGridReferenceText_RowEnter);
 			this.m_dataGridReferenceText.RowHeightChanged += new System.Windows.Forms.DataGridViewRowEventHandler(this.m_dataGridReferenceText_RowHeightChanged);
 			this.m_dataGridReferenceText.Resize += new System.EventHandler(this.CheckRowHeights);
 			// 

--- a/Glyssen/Dialogs/AssignCharacterDlg.cs
+++ b/Glyssen/Dialogs/AssignCharacterDlg.cs
@@ -376,7 +376,7 @@ namespace Glyssen.Dialogs
 			UpdateNavigationIndexLabel();
 			m_chkSingleVoice.Text = Format(m_singleVoiceCheckboxFmt, m_viewModel.CurrentBookId);
 
-			m_viewModel.GetBlockVerseRef().SendScrReference();
+			blockRef.SendScrReference();
 
 			HideCharacterFilter();
 			m_btnAssign.Enabled = false;
@@ -1384,12 +1384,15 @@ namespace Glyssen.Dialogs
 			return true;
 		}
 
-		private void UpdateRowSpecificButtonStates(object sender, DataGridViewCellEventArgs e)
+		private void m_dataGridReferenceText_RowEnter(object sender, DataGridViewCellEventArgs e)
 		{
-			m_btnMoveReferenceTextDown.Enabled = e.RowIndex != m_dataGridReferenceText.RowCount - 1;
-			m_btnMoveReferenceTextUp.Enabled = e.RowIndex != 0;
-			m_menuInsertIntoSelectedRowOnly.Enabled = GetColumnsIntoWhichHeSaidCanBeInserted(m_dataGridReferenceText.Rows[e.RowIndex]).Any();
+			var row = e.RowIndex;
+			m_btnMoveReferenceTextDown.Enabled = row != m_dataGridReferenceText.RowCount - 1;
+			m_btnMoveReferenceTextUp.Enabled = row != 0;
+			m_menuInsertIntoSelectedRowOnly.Enabled = GetColumnsIntoWhichHeSaidCanBeInserted(m_dataGridReferenceText.Rows[row]).Any();
+			m_viewModel.GetVerseRefForRow(row).SendScrReference();
 		}
+
 		private void HandleMoveReferenceTextDown_Click(object sender, EventArgs e) => MoveReferenceText(true);
 
 		private void HandleMoveReferenceTextUp_Click(object sender, EventArgs e) => MoveReferenceText(false);

--- a/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
+++ b/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
@@ -995,5 +995,17 @@ namespace GlyssenEngine.ViewModels
 
 			return i >= 0;
 		}
+
+		public VerseRef GetVerseRefForRow(int i)
+		{
+			// A matchup should never end with something other than a Scripture block,
+			// but the data could be wonky so just to be safe...
+			if (CurrentReferenceTextMatchup != null && TryFindScriptureRowAtOrBelow(ref i))
+			{
+				return new VerseRef(CurrentBookNumber, CurrentBlock.ChapterNumber,
+					CurrentReferenceTextMatchup.CorrelatedBlocks[i].AllVerses.First().StartVerse);
+			}
+			return GetBlockVerseRef();
+		}
 	}
 }


### PR DESCRIPTION
Added AssignCharacterViewModel.GetVerseRefForRow and code in AssignCharacterDlg to send the ref as a "Santa Fe" message so Paratext and other participating apps will go to the current reference when the user clicks in a reference text row.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/glyssen/817)
<!-- Reviewable:end -->
