### PR TITLE
Stripped off the meaningless "Unspecified" quote position for Potential speech

### DIFF
--- a/ControlDataIntegrityTests/CharacterVerseDataTests.cs
+++ b/ControlDataIntegrityTests/CharacterVerseDataTests.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Glyssen.Shared;
 using GlyssenCharacters;
 using NUnit.Framework;
+using SIL.Extensions;
 using SIL.Scripture;
 using static System.String;
 using NarratorOverrides = GlyssenCharacters.NarratorOverrides;
@@ -114,6 +115,9 @@ namespace ControlDataIntegrityTests
 						Assert.That(type, Is.Not.EqualTo(QuoteType.Implicit)
 							.And.Not.EqualTo(QuoteType.ImplicitWithPotentialSelfQuote), "Line: " + line);
 					}
+
+					Assert.False(type.IsOneOf(QuoteType.Potential, QuoteType.Rare, QuoteType.Alternate,
+						QuoteType.Indirect, QuoteType.Interruption), "Line: " + line);
 				}
 
 				var extraSpacesMatch = extraSpacesRegex.Match(line);

--- a/DevTools/CharacterVerseUpdater.cs
+++ b/DevTools/CharacterVerseUpdater.cs
@@ -75,6 +75,7 @@ namespace DevTools
 				var cv = ControlCharacterVerseData.Singleton.ProcessLine(items, line.Number).Single();
 				if (cv.QuoteType == QuoteType.Indirect || cv.QuoteType == QuoteType.Interruption ||
 				    cv.QuoteType == QuoteType.Implicit || cv.QuoteType == QuoteType.Rare ||
+				    cv.QuoteType == QuoteType.Potential ||
 				    NarratorOverrides.GetCharacterOverrideDetailsForRefRange(new VerseRef(cv.BcvRef.BBCCCVVV, ScrVers.English),
 					    cv.Verse).Any() ||
 				    ControlCharacterVerseData.Singleton.GetCharacters(cv.Book, cv.Chapter, cv.Verse)

--- a/GlyssenCharacters/Resources/CharacterVerse.txt
+++ b/GlyssenCharacters/Resources/CharacterVerse.txt
@@ -99,7 +99,7 @@ GEN	9	15	God		God (Yahweh)	Implicit
 GEN	9	16	God		God (Yahweh)	Implicit			
 GEN	9	17	God		God (Yahweh)	Normal			Unspecified
 GEN	9	22	Ham			Rare			
-GEN	9	22	Needs Review			Potential			Unspecified
+GEN	9	22	Needs Review			Potential			
 GEN	9	25	Noah			Normal			EndOfVerse
 GEN	9	26	Noah			Normal			Unspecified
 GEN	9	27	Noah			Implicit			
@@ -126,7 +126,7 @@ GEN	13	16	God		God (Yahweh)	Implicit
 GEN	13	17	God		God (Yahweh)	Implicit			
 GEN	14	4	Bera, king of Sodom/Birsha, king of Gomorrah/Shinab, king of Admah/Shemeber, king of Zeboiim/king of Bela			Indirect	Bera, king of Sodom		
 GEN	14	13	one who had escaped			Rare			
-GEN	14	13	Needs Review			Potential			Unspecified
+GEN	14	13	Needs Review			Potential			
 GEN	14	17	narrator-GEN			Quotation			EndOfVerse
 GEN	14	19	Melchizedek, king of Salem (priest of God Most High)			Normal			EndOfVerse
 GEN	14	20	Melchizedek, king of Salem (priest of God Most High)			Normal			StartOfVerse
@@ -598,7 +598,7 @@ GEN	37	14	Jacob (Israel)			Normal			ContainedWithinVerse
 GEN	37	15	man (at Shechem)			Normal			EndOfVerse
 GEN	37	16	Joseph			Normal			Unspecified
 GEN	37	17	man (at Shechem)			Normal			Unspecified
-GEN	37	18	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Potential	Levi		Unspecified
+GEN	37	18	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Potential	Levi		
 GEN	37	19	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Levi		EndOfVerse
 GEN	37	20	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Implicit	Levi		EntireVerse
 GEN	37	21	Reuben			Normal			Unspecified
@@ -749,7 +749,7 @@ GEN	43	13	Jacob (Israel)			Implicit			EntireVerse
 GEN	43	14	Jacob (Israel)			Implicit			EntireVerse
 GEN	43	16	Joseph			Normal			EndOfVerse
 GEN	43	18	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher	thought	Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		EndOfVerse
-GEN	43	19	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Potential	Dan		Unspecified
+GEN	43	19	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Potential	Dan		
 GEN	43	20	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		Unspecified
 GEN	43	21	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Implicit	Dan		EntireVerse
 GEN	43	22	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Implicit	Dan		EntireVerse
@@ -1061,8 +1061,8 @@ EXO	9	29	Moses			Normal			Unspecified
 EXO	9	30	Moses			Implicit			EntireVerse
 # Almost all translators agree that vv. 31-32 are commentary by the narrator, but at least one project
 # continues the quote and has Moses speak these words to Pharaoh.
-EXO	9	31	Moses			Potential			Unspecified
-EXO	9	32	Moses			Potential			Unspecified
+EXO	9	31	Moses			Potential			
+EXO	9	32	Moses			Potential			
 EXO	10	1	God		God (Yahweh)	Normal			EndOfVerse
 EXO	10	2	God		God (Yahweh)	Implicit			EntireVerse
 EXO	10	3	Moses/Aaron			Normal	Aaron		EndOfVerse
@@ -1190,13 +1190,13 @@ EXO	16	7	Moses/Aaron			Implicit	Aaron		EntireVerse
 EXO	16	8	Moses			Normal			EndOfVerse
 EXO	16	9	Moses			Normal			EndOfVerse
 EXO	16	10	Aaron			Rare			
-EXO	16	10	Needs Review			Potential			Unspecified
+EXO	16	10	Needs Review			Potential			
 EXO	16	12	God		God (Yahweh)	Implicit			EntireVerse
 EXO	16	15	Israelites	questioning		Normal			
 EXO	16	15	Moses			Normal			
 EXO	16	16	Moses			Implicit			EntireVerse
 EXO	16	19	Moses			Normal			Unspecified
-EXO	16	22	elders of Israel		rulers of the congregation	Potential			Unspecified
+EXO	16	22	elders of Israel		rulers of the congregation	Potential			
 EXO	16	23	Moses			Normal			Unspecified
 EXO	16	25	Moses			Normal			Unspecified
 EXO	16	26	Moses			Implicit			EntireVerse
@@ -1219,7 +1219,7 @@ EXO	17	16	Moses			Normal			EndOfVerse
 EXO	18	3	Moses			Normal			Unspecified
 EXO	18	4	Moses			Normal			Unspecified
 EXO	18	6	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
-EXO	18	8	Moses			Potential			Unspecified
+EXO	18	8	Moses			Potential			
 EXO	18	10	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
 EXO	18	11	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
 EXO	18	14	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
@@ -1965,8 +1965,8 @@ LEV	11	42	God		God (Yahweh)	Implicit
 LEV	11	43	God		God (Yahweh)	Implicit			
 LEV	11	44	God		God (Yahweh)	Implicit			
 LEV	11	45	God		God (Yahweh)	Implicit			
-LEV	11	46	God		God (Yahweh)	Potential			Unspecified
-LEV	11	47	God		God (Yahweh)	Potential			Unspecified
+LEV	11	46	God		God (Yahweh)	Potential			
+LEV	11	47	God		God (Yahweh)	Potential			
 LEV	12	2	God		God (Yahweh)	Implicit			
 LEV	12	3	God		God (Yahweh)	Implicit			
 LEV	12	4	God		God (Yahweh)	Implicit			
@@ -2031,7 +2031,7 @@ LEV	13	55	God		God (Yahweh)	Implicit
 LEV	13	56	God		God (Yahweh)	Implicit			
 LEV	13	57	God		God (Yahweh)	Implicit			
 LEV	13	58	God		God (Yahweh)	Implicit			
-LEV	13	59	God		God (Yahweh)	Potential			Unspecified
+LEV	13	59	God		God (Yahweh)	Potential			
 LEV	14	2	God		God (Yahweh)	Implicit			
 LEV	14	3	God		God (Yahweh)	Implicit			
 LEV	14	4	God		God (Yahweh)	Implicit			
@@ -2061,8 +2061,8 @@ LEV	14	27	God		God (Yahweh)	Implicit
 LEV	14	28	God		God (Yahweh)	Implicit			
 LEV	14	29	God		God (Yahweh)	Implicit			
 LEV	14	30	God		God (Yahweh)	Implicit			
-LEV	14	31	God		God (Yahweh)	Potential			Unspecified
-LEV	14	32	God		God (Yahweh)	Potential			Unspecified
+LEV	14	31	God		God (Yahweh)	Potential			
+LEV	14	32	God		God (Yahweh)	Potential			
 LEV	14	34	God		God (Yahweh)	Implicit			
 LEV	14	35	God		God (Yahweh)	Implicit			
 LEV	14	36	God		God (Yahweh)	Implicit			
@@ -2083,10 +2083,10 @@ LEV	14	50	God		God (Yahweh)	Implicit
 LEV	14	51	God		God (Yahweh)	Implicit			
 LEV	14	52	God		God (Yahweh)	Implicit			
 LEV	14	53	God		God (Yahweh)	Implicit			
-LEV	14	54	God		God (Yahweh)	Potential			Unspecified
-LEV	14	55	God		God (Yahweh)	Potential			Unspecified
-LEV	14	56	God		God (Yahweh)	Potential			Unspecified
-LEV	14	57	God		God (Yahweh)	Potential			Unspecified
+LEV	14	54	God		God (Yahweh)	Potential			
+LEV	14	55	God		God (Yahweh)	Potential			
+LEV	14	56	God		God (Yahweh)	Potential			
+LEV	14	57	God		God (Yahweh)	Potential			
 LEV	15	2	God		God (Yahweh)	Implicit			
 LEV	15	3	God		God (Yahweh)	Implicit			
 LEV	15	4	God		God (Yahweh)	Implicit			
@@ -2117,8 +2117,8 @@ LEV	15	28	God		God (Yahweh)	Implicit
 LEV	15	29	God		God (Yahweh)	Implicit			
 LEV	15	30	God		God (Yahweh)	Implicit			
 LEV	15	31	God		God (Yahweh)	Implicit			
-LEV	15	32	God		God (Yahweh)	Potential			Unspecified
-LEV	15	33	God		God (Yahweh)	Potential			Unspecified
+LEV	15	32	God		God (Yahweh)	Potential			
+LEV	15	33	God		God (Yahweh)	Potential			
 LEV	16	2	God		God (Yahweh)	Normal			Unspecified
 LEV	16	3	God		God (Yahweh)	Implicit			
 LEV	16	4	God		God (Yahweh)	Implicit			
@@ -2357,7 +2357,7 @@ LEV	24	7	God		God (Yahweh)	Implicit
 LEV	24	8	God		God (Yahweh)	Implicit			
 LEV	24	9	God		God (Yahweh)	Implicit			
 LEV	24	11	son of Shelomith (whose father was an Egyptian)			Rare			
-LEV	24	11	Needs Review			Potential			Unspecified
+LEV	24	11	Needs Review			Potential			
 LEV	24	14	God		God (Yahweh)	Implicit			
 LEV	24	15	God		God (Yahweh)	Implicit			
 LEV	24	16	God		God (Yahweh)	Implicit			
@@ -2517,7 +2517,7 @@ NUM	1	13	God		God (Yahweh)	Implicit
 NUM	1	14	God		God (Yahweh)	Implicit			
 NUM	1	15	God		God (Yahweh)	Implicit			
 # The following verse is unlikely to be quoted speech by God, but some projects may include it.
-NUM	1	16	God		God (Yahweh)	Potential			Unspecified
+NUM	1	16	God		God (Yahweh)	Potential			
 NUM	1	49	God		God (Yahweh)	Implicit			
 NUM	1	50	God		God (Yahweh)	Implicit			
 NUM	1	51	God		God (Yahweh)	Implicit			
@@ -2718,7 +2718,7 @@ NUM	11	23	God		God (Yahweh)	Normal			EndOfVerse
 NUM	11	27	young man	excited		Normal			Unspecified
 NUM	11	28	Joshua			Normal			EndOfVerse
 NUM	11	29	Moses			Normal			EndOfVerse
-NUM	12	1	Miriam/Aaron			Potential	Miriam		Unspecified
+NUM	12	1	Miriam/Aaron			Potential	Miriam		
 NUM	12	2	Miriam/Aaron			Normal	Miriam		ContainedWithinVerse
 NUM	12	4	God		God (Yahweh)	Normal			Unspecified
 NUM	12	6	God		God (Yahweh)	Normal			EndOfVerse
@@ -3301,9 +3301,9 @@ DEU	2	7	Moses			Implicit
 DEU	2	8	Moses			Implicit			
 DEU	2	9	Moses			Implicit			
 DEU	2	9	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	10	Moses			Potential			Unspecified
-DEU	2	11	Moses			Potential			Unspecified
-DEU	2	12	Moses			Potential			Unspecified
+DEU	2	10	Moses			Potential			
+DEU	2	11	Moses			Potential			
+DEU	2	12	Moses			Potential			
 DEU	2	13	Moses			Implicit			
 DEU	2	13	God		God (Yahweh)	Quotation			Unspecified
 DEU	2	14	Moses			Implicit			
@@ -3314,10 +3314,10 @@ DEU	2	18	Moses			Implicit
 DEU	2	18	God		God (Yahweh)	Quotation			Unspecified
 DEU	2	19	Moses			Implicit			
 DEU	2	19	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	20	Moses			Potential			Unspecified
-DEU	2	21	Moses			Potential			Unspecified
-DEU	2	22	Moses			Potential			Unspecified
-DEU	2	23	Moses			Potential			Unspecified
+DEU	2	20	Moses			Potential			
+DEU	2	21	Moses			Potential			
+DEU	2	22	Moses			Potential			
+DEU	2	23	Moses			Potential			
 DEU	2	24	Moses			Implicit			
 DEU	2	24	God		God (Yahweh)	Quotation			Unspecified
 DEU	2	25	Moses			Implicit			
@@ -3344,12 +3344,12 @@ DEU	3	5	Moses			Implicit
 DEU	3	6	Moses			Implicit			
 DEU	3	7	Moses			Implicit			
 DEU	3	8	Moses			Implicit			
-DEU	3	9	Moses			Potential			Unspecified
+DEU	3	9	Moses			Potential			
 DEU	3	10	Moses			Implicit			
-DEU	3	11	Moses			Potential			Unspecified
+DEU	3	11	Moses			Potential			
 DEU	3	12	Moses			Implicit			
 DEU	3	13	Moses			Normal			Unspecified
-DEU	3	14	Moses			Potential			Unspecified
+DEU	3	14	Moses			Potential			
 DEU	3	15	Moses			Implicit			
 DEU	3	16	Moses			Implicit			
 DEU	3	17	Moses			Implicit			
@@ -4549,7 +4549,7 @@ JDG	4	7	Deborah		Deborah, prophetess	Implicit			EntireVerse
 JDG	4	8	Barak			Normal			Unspecified
 JDG	4	9	Deborah		Deborah, prophetess	Normal			Unspecified
 JDG	4	12	person who informed Sisera			Rare			
-JDG	4	12	Needs Review			Potential			Unspecified
+JDG	4	12	Needs Review			Potential			
 JDG	4	14	Deborah		Deborah, prophetess	Normal			ContainedWithinVerse
 JDG	4	18	Jael			Normal			ContainedWithinVerse
 JDG	4	19	Sisera			Normal			Unspecified
@@ -4674,7 +4674,7 @@ JDG	9	18	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
 JDG	9	19	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
 JDG	9	20	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
 JDG	9	25	messenger to Abimelech			Rare			
-JDG	9	25	Needs Review			Potential			Unspecified
+JDG	9	25	Needs Review			Potential			
 JDG	9	28	Gaal, son of Ebed			Normal			Unspecified
 JDG	9	29	Gaal, son of Ebed			Normal			Unspecified
 JDG	9	31	Zebul, governor of Shechem			Normal			EndOfVerse
@@ -4685,7 +4685,7 @@ JDG	9	36	Zebul, governor of Shechem			Normal
 JDG	9	37	Gaal, son of Ebed			Normal			Unspecified
 JDG	9	38	Zebul, governor of Shechem			Normal			EndOfVerse
 JDG	9	42	messenger to Abimelech			Rare			
-JDG	9	42	Needs Review			Potential			Unspecified
+JDG	9	42	Needs Review			Potential			
 JDG	9	47	messenger to Abimelech			Indirect			
 JDG	9	48	Abimelech, son of Gideon (Jerubbaal)			Normal			EndOfVerse
 JDG	9	54	Abimelech, son of Gideon (Jerubbaal)			Normal			ContainedWithinVerse
@@ -5133,7 +5133,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	12	24	Samuel			Implicit			EntireVerse
 1SA	12	25	Samuel			Implicit			EntireVerse
 1SA	13	3	Saul			Normal			EndOfVerse
-1SA	13	4	Saul's announcement			Potential			Unspecified
+1SA	13	4	Saul's announcement			Potential			
 1SA	13	9	Saul			Normal			ContainedWithinVerse
 1SA	13	11	Samuel			Normal			
 1SA	13	11	Saul			Normal			
@@ -5230,7 +5230,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	17	10	Goliath, Philistine champion			Normal			Unspecified
 1SA	17	17	Jesse			Normal			EndOfVerse
 1SA	17	18	Jesse			Implicit			EntireVerse
-1SA	17	19	Jesse			Potential			Unspecified
+1SA	17	19	Jesse			Potential			
 1SA	17	25	Israelites (soldiers)			Normal			EndOfVerse
 1SA	17	26	David			Normal			EndOfVerse
 1SA	17	27	men (soldiers) standing near David			Normal			Unspecified
@@ -5439,7 +5439,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	28	2	Achish, king of Gath			Normal			
 1SA	28	2	David			Normal			
 1SA	28	6	Saul			Rare			
-1SA	28	6	Needs Review			Potential			Unspecified
+1SA	28	6	Needs Review			Potential			
 1SA	28	7	Saul			Normal			
 1SA	28	7	Saul's servants			Normal			
 1SA	28	8	Saul			Normal			Unspecified
@@ -5592,7 +5592,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	7	29	David		David, king	Implicit			EntireVerse
 2SA	8	10	Joram, son of Toi			Rare			
 2SA	8	10	Toi, king of Hamath			Rare			
-2SA	8	10	Needs Review			Potential			Unspecified
+2SA	8	10	Needs Review			Potential			
 2SA	9	1	David		David, king	Normal			Unspecified
 2SA	9	2	David		David, king	Dialogue			Unspecified
 2SA	9	2	Ziba, servant of Saul's household			Dialogue			Unspecified
@@ -5679,7 +5679,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	13	33	Jonadab	shrewd		Normal			Unspecified
 2SA	13	34	Jonadab	shrewd		Rare			
 2SA	13	34	watchman			Rare			
-2SA	13	34	Needs Review			Potential			Unspecified
+2SA	13	34	Needs Review			Potential			
 2SA	13	35	Jonadab	shrewd		Normal			EndOfVerse
 2SA	14	2	Joab			Normal			Unspecified
 2SA	14	3	Joab			Normal			Unspecified
@@ -5915,7 +5915,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	22	49	David		David, king	Normal			Unspecified
 2SA	22	50	David		David, king	Normal			Unspecified
 2SA	22	51	David		David, king	Normal			Unspecified
-2SA	23	1	David		David, king	Potential			Unspecified
+2SA	23	1	David		David, king	Potential			
 2SA	23	2	David		David, king	Implicit			
 2SA	23	3	David		David, king	Implicit			
 2SA	23	4	David		David, king	Implicit			
@@ -6205,7 +6205,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	18	5	Ahab, king of Israel			Normal			Unspecified
 1KI	18	6	Ahab, king of Israel			Rare			
 1KI	18	6	Obadiah, manager of Ahab's palace			Rare			
-1KI	18	6	Needs Review			Potential			Unspecified
+1KI	18	6	Needs Review			Potential			
 1KI	18	7	Obadiah, manager of Ahab's palace			Dialogue			EndOfVerse
 1KI	18	8	Elijah			Dialogue			Unspecified
 1KI	18	9	Obadiah, manager of Ahab's palace			Normal			Unspecified
@@ -6757,7 +6757,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	11	3	Israel, all			Rare			
 1CH	11	3	elders of Israel			Rare			
 1CH	11	3	David			Rare			
-1CH	11	3	Needs Review			Potential			Unspecified
+1CH	11	3	Needs Review			Potential			
 1CH	11	5	Jebusites			Normal			ContainedWithinVerse
 1CH	11	6	David			Normal			ContainedWithinVerse
 1CH	11	17	David			Normal			EndOfVerse
@@ -6772,7 +6772,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	14	10	God		God (Yahweh)	Normal			
 1CH	14	11	David			Normal			Unspecified
 1CH	14	12	David			Rare			
-1CH	14	12	Needs Review			Potential			Unspecified
+1CH	14	12	Needs Review			Potential			
 1CH	14	14	God			Normal			
 1CH	14	14	David			Rare			
 1CH	14	14	Needs Review			Rare			
@@ -6844,7 +6844,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	19	12	Joab			Normal			EndOfVerse
 1CH	19	13	Joab			Implicit			EntireVerse
 1CH	21	2	David		David, king	Normal			EndOfVerse
-1CH	21	1	Satan (Devil)			Potential			Unspecified
+1CH	21	1	Satan (Devil)			Potential			
 1CH	21	3	Joab			Normal			EndOfVerse
 1CH	21	8	David		David, king	Normal			EndOfVerse
 1CH	21	10	God		God (Yahweh)	Implicit			EntireVerse
@@ -7067,7 +7067,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	20	2	narrator-2CH			Interruption			
 2CH	20	3	Jehoshaphat, king of Judah	alarmed		Rare			
 2CH	20	3	Jehoshaphat, king of Judah	proclamation		Rare			
-2CH	20	3	Needs Review			Potential			Unspecified
+2CH	20	3	Needs Review			Potential			
 2CH	20	6	Jehoshaphat, king of Judah	praying		Normal			EndOfVerse
 2CH	20	7	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
 2CH	20	8	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
@@ -7098,8 +7098,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	24	5	Joash, king of Judah			Normal			ContainedWithinVerse
 2CH	24	6	Joash, king of Judah			Normal			Unspecified
 2CH	24	7	Joash, king of Judah			Rare			
-2CH	24	7	Needs Review			Potential			Unspecified
-2CH	24	8	Joash, king of Judah			Potential			Unspecified
+2CH	24	7	Needs Review			Potential			
+2CH	24	8	Joash, king of Judah			Potential			
 2CH	24	8	proclamation			Indirect			
 2CH	24	20	Zechariah, son of Jehoiada the priest			Normal			EndOfVerse
 2CH	24	22	Zechariah, son of Jehoiada the priest			Normal			Unspecified
@@ -7187,18 +7187,18 @@ EZR	4	3	Zerubbabel/Jeshua/rest of heads of families			Normal			EndOfVerse
 # Verses 9-10 are not in quotes in most English translations, but verse 8 sometimes ends in a
 # colon, implying that these two verses are part of the letter. They might be heading, salutation
 # or "envelope" information. In the WEB, it is hard to tell what the translators intended.
-EZR	4	9	Rehum, commanding officer/Shimshai, secretary	letter		Potential			Unspecified
+EZR	4	9	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
 EZR	4	9	Needs Review			Implicit			
-EZR	4	10	Rehum, commanding officer/Shimshai, secretary	letter		Potential			Unspecified
+EZR	4	10	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
 EZR	4	10	Needs Review			Implicit			
-EZR	4	11	Rehum, commanding officer/Shimshai, secretary	letter		Potential			Unspecified
+EZR	4	11	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
 EZR	4	11	Needs Review			Implicit			
 EZR	4	12	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
 EZR	4	13	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
 EZR	4	14	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
 EZR	4	15	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
 EZR	4	16	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
-EZR	4	17	Artaxerxes, king of Persia	letter		Potential			Unspecified
+EZR	4	17	Artaxerxes, king of Persia	letter		Potential			
 EZR	4	18	Artaxerxes, king of Persia	letter		Implicit			
 EZR	4	19	Artaxerxes, king of Persia	letter		Implicit			
 EZR	4	20	Artaxerxes, king of Persia	letter		Implicit			
@@ -7212,7 +7212,7 @@ EZR	5	4	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates			Indire
 EZR	5	4	Jews, the			Indirect			
 EZR	5	4	Ezra, priest and teacher			Indirect			
 EZR	5	4	Needs Review			Implicit			
-EZR	5	7	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Potential			Unspecified
+EZR	5	7	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Potential			
 EZR	5	8	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
 EZR	5	9	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
 EZR	5	10	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
@@ -7223,13 +7223,13 @@ EZR	5	14	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter	
 EZR	5	15	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
 EZR	5	16	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
 EZR	5	17	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	6	1	Darius, king of Medes and Persians	decree		Potential			Unspecified
-EZR	6	2	Darius, king of Medes and Persians	decree		Potential			Unspecified
-EZR	6	3	royal record		written record on scroll	Potential			Unspecified
+EZR	6	1	Darius, king of Medes and Persians	decree		Potential			
+EZR	6	2	Darius, king of Medes and Persians	decree		Potential			
+EZR	6	3	royal record		written record on scroll	Potential			
 EZR	6	3	Cyrus, king of Persia	decree		Quotation			Unspecified
-EZR	6	4	royal record		written record on scroll	Potential			Unspecified
+EZR	6	4	royal record		written record on scroll	Potential			
 EZR	6	4	Cyrus, king of Persia	decree		Quotation			Unspecified
-EZR	6	5	royal record		written record on scroll	Potential			Unspecified
+EZR	6	5	royal record		written record on scroll	Potential			
 EZR	6	5	Cyrus, king of Persia	decree		Quotation			Unspecified
 EZR	6	6	Darius, king of Medes and Persians	decree		Implicit			
 EZR	6	7	Darius, king of Medes and Persians	decree		Implicit			
@@ -8881,7 +8881,7 @@ PRO	25	7	king			Hypothetical
 PRO	26	13	sluggard			Hypothetical			
 PRO	26	19	man, deceitful			Hypothetical			
 PRO	28	24	one who robs his father or mother			Hypothetical			
-PRO	30	1	Agur			Potential			Unspecified
+PRO	30	1	Agur			Potential			
 # Because of the difficult textual/translation issue in v. 1, if there are not explicit
 # quotes, it should be reviewed. The English reference text takes the traditional interpretation,
 # but even in that interpretation, the portion following the colon could be spoken by Agur
@@ -8893,9 +8893,9 @@ PRO	30	15	leech's two daughters			Hypothetical
 PRO	30	15	narrator-PRO			Quotation			
 PRO	30	16	narrator-PRO			Quotation			
 PRO	30	20	immoral woman			Hypothetical			
-PRO	31	1	King Lemuel			Potential			Unspecified
+PRO	31	1	King Lemuel			Potential			
 # Including this for now since that's how FCBH dramatizes this:
-PRO	31	1	Solomon, king			Potential			Unspecified
+PRO	31	1	Solomon, king			Potential			
 PRO	31	2	King Lemuel's mother			Potential			
 PRO	31	2	King Lemuel			Alternate			
 PRO	31	3	King Lemuel's mother			Potential			
@@ -8977,21 +8977,21 @@ SNG	1	4	beloved			Potential
 SNG	1	4	Solomon, king		Solomon (lover)	Quotation			
 SNG	1	4	maidens			Potential			
 SNG	1	4	Needs Review			Implicit			
-SNG	1	8	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	1	8	maidens			Potential			Unspecified
+SNG	1	8	Solomon, king		Solomon (lover)	Potential			
+SNG	1	8	maidens			Potential			
 SNG	1	8	Needs Review			Implicit			
 SNG	1	9	Solomon, king		Solomon (lover)	Potential			
 SNG	1	10	Solomon, king		Solomon (lover)	Potential			
-SNG	1	11	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	1	11	maidens			Potential			Unspecified
+SNG	1	11	Solomon, king		Solomon (lover)	Potential			
+SNG	1	11	maidens			Potential			
 SNG	1	11	Needs Review			Implicit			
 SNG	1	12	beloved			Potential			
 SNG	1	13	beloved			Potential			
 SNG	1	14	beloved			Potential			
 SNG	1	15	Solomon, king		Solomon (lover)	Potential			
 SNG	1	16	beloved			Potential			
-SNG	1	17	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	1	17	beloved			Potential			Unspecified
+SNG	1	17	Solomon, king		Solomon (lover)	Potential			
+SNG	1	17	beloved			Potential			
 SNG	1	17	Needs Review			Implicit			
 SNG	2	1	beloved			Potential			
 SNG	2	2	Solomon, king		Solomon (lover)	Potential			
@@ -9022,18 +9022,18 @@ SNG	3	1	beloved			Potential
 SNG	3	2	beloved			Potential			
 SNG	3	3	beloved			Potential			
 SNG	3	4	beloved			Potential			
-SNG	3	5	beloved			Potential			Unspecified
-SNG	3	5	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	3	6	beloved			Potential			Unspecified
-SNG	3	6	maidens			Potential			Unspecified
-SNG	3	7	beloved			Potential			Unspecified
-SNG	3	7	maidens			Potential			Unspecified
-SNG	3	8	beloved			Potential			Unspecified
-SNG	3	8	maidens			Potential			Unspecified
-SNG	3	9	beloved			Potential			Unspecified
-SNG	3	9	maidens			Potential			Unspecified
-SNG	3	10	beloved			Potential			Unspecified
-SNG	3	10	maidens			Potential			Unspecified
+SNG	3	5	beloved			Potential			
+SNG	3	5	Solomon, king		Solomon (lover)	Potential			
+SNG	3	6	beloved			Potential			
+SNG	3	6	maidens			Potential			
+SNG	3	7	beloved			Potential			
+SNG	3	7	maidens			Potential			
+SNG	3	8	beloved			Potential			
+SNG	3	8	maidens			Potential			
+SNG	3	9	beloved			Potential			
+SNG	3	9	maidens			Potential			
+SNG	3	10	beloved			Potential			
+SNG	3	10	maidens			Potential			
 SNG	3	11	beloved			Potential			
 SNG	4	1	Solomon, king		Solomon (lover)	Potential			
 SNG	4	2	Solomon, king		Solomon (lover)	Potential			
@@ -9052,9 +9052,9 @@ SNG	4	14	Solomon, king		Solomon (lover)	Potential
 SNG	4	15	Solomon, king		Solomon (lover)	Potential			
 SNG	4	16	Solomon, king		Solomon (lover)	Potential			
 SNG	4	16	beloved			Potential			
-SNG	5	1	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	5	1	maidens			Potential			Unspecified
-SNG	5	1	God			Potential			Unspecified
+SNG	5	1	Solomon, king		Solomon (lover)	Potential			
+SNG	5	1	maidens			Potential			
+SNG	5	1	God			Potential			
 SNG	5	1	Needs Review			Implicit			
 SNG	5	2	beloved			Potential			
 SNG	5	2	Solomon, king		Solomon (lover)	Quotation			
@@ -9081,15 +9081,15 @@ SNG	6	6	Solomon, king		Solomon (lover)	Potential
 SNG	6	7	Solomon, king		Solomon (lover)	Potential			
 SNG	6	8	Solomon, king		Solomon (lover)	Potential			
 SNG	6	9	Solomon, king		Solomon (lover)	Potential			
-SNG	6	10	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	6	10	maidens			Potential			Unspecified
+SNG	6	10	Solomon, king		Solomon (lover)	Potential			
+SNG	6	10	maidens			Potential			
 SNG	6	10	queens and concubines			Quotation			Unspecified
 SNG	6	10	Needs Review			Implicit			
-SNG	6	11	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	6	11	beloved			Potential			Unspecified
+SNG	6	11	Solomon, king		Solomon (lover)	Potential			
+SNG	6	11	beloved			Potential			
 SNG	6	11	Needs Review			Implicit			
-SNG	6	12	Solomon, king		Solomon (lover)	Potential			Unspecified
-SNG	6	12	beloved			Potential			Unspecified
+SNG	6	12	Solomon, king		Solomon (lover)	Potential			
+SNG	6	12	beloved			Potential			
 SNG	6	12	Needs Review			Implicit			
 SNG	6	13	Solomon, king		Solomon (lover)	Potential			
 SNG	6	13	maidens			Potential			
@@ -9118,13 +9118,13 @@ SNG	8	5	maidens			Potential
 SNG	8	6	beloved			Potential			
 SNG	8	7	beloved			Potential			
 SNG	8	7	maidens			Potential			
-SNG	8	8	brothers of beloved			Potential			Unspecified
-SNG	8	8	sisters of beloved			Potential			Unspecified
-SNG	8	8	maidens			Potential			Unspecified
+SNG	8	8	brothers of beloved			Potential			
+SNG	8	8	sisters of beloved			Potential			
+SNG	8	8	maidens			Potential			
 SNG	8	8	Needs Review			Implicit			
-SNG	8	9	brothers of beloved			Potential			Unspecified
-SNG	8	9	sisters of beloved			Potential			Unspecified
-SNG	8	9	maidens			Potential			Unspecified
+SNG	8	9	brothers of beloved			Potential			
+SNG	8	9	sisters of beloved			Potential			
+SNG	8	9	maidens			Potential			
 SNG	8	9	Needs Review			Implicit			
 SNG	8	10	beloved			Potential			
 SNG	8	11	beloved			Potential			
@@ -9332,14 +9332,14 @@ ISA	7	16	Needs Review			Alternate
 ISA	7	17	Isaiah			Normal			Unspecified
 ISA	7	17	God		God (Yahweh)	Alternate			
 ISA	7	17	Needs Review			Alternate			
-ISA	7	18	Isaiah			Potential			Unspecified
-ISA	7	19	Isaiah			Potential			Unspecified
-ISA	7	20	Isaiah			Potential			Unspecified
-ISA	7	21	Isaiah			Potential			Unspecified
-ISA	7	22	Isaiah			Potential			Unspecified
-ISA	7	23	Isaiah			Potential			Unspecified
-ISA	7	24	Isaiah			Potential			Unspecified
-ISA	7	25	Isaiah			Potential			Unspecified
+ISA	7	18	Isaiah			Potential			
+ISA	7	19	Isaiah			Potential			
+ISA	7	20	Isaiah			Potential			
+ISA	7	21	Isaiah			Potential			
+ISA	7	22	Isaiah			Potential			
+ISA	7	23	Isaiah			Potential			
+ISA	7	24	Isaiah			Potential			
+ISA	7	25	Isaiah			Potential			
 ISA	8	1	God		God (Yahweh)	Normal			
 ISA	8	2	God		God (Yahweh)	Normal			
 ISA	8	3	God		God (Yahweh)	Normal			
@@ -9388,22 +9388,22 @@ ISA	10	3	Isaiah			Potential
 ISA	10	4	Isaiah			Potential			
 ISA	10	5	God		God (Yahweh)	Implicit			
 ISA	10	6	God		God (Yahweh)	Implicit			
-ISA	10	7	God		God (Yahweh)	Potential			Unspecified
+ISA	10	7	God		God (Yahweh)	Potential			
 ISA	10	8	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
-ISA	10	8	God		God (Yahweh)	Potential			Unspecified
+ISA	10	8	God		God (Yahweh)	Potential			
 ISA	10	9	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
-ISA	10	9	God		God (Yahweh)	Potential			Unspecified
+ISA	10	9	God		God (Yahweh)	Potential			
 ISA	10	10	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
-ISA	10	10	God		God (Yahweh)	Potential			Unspecified
+ISA	10	10	God		God (Yahweh)	Potential			
 ISA	10	10	Needs Review			Normal			
 ISA	10	11	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
-ISA	10	11	God		God (Yahweh)	Potential			Unspecified
+ISA	10	11	God		God (Yahweh)	Potential			
 ISA	10	11	Needs Review			Normal			
 ISA	10	12	Needs Review			Implicit			
-ISA	10	12	God		God (Yahweh)	Potential			Unspecified
+ISA	10	12	God		God (Yahweh)	Potential			
 ISA	10	13	Needs Review			Implicit			
-ISA	10	13	God		God (Yahweh)	Potential			Unspecified
-ISA	10	13	Isaiah			Potential			Unspecified
+ISA	10	13	God		God (Yahweh)	Potential			
+ISA	10	13	Isaiah			Potential			
 ISA	10	13	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
 ISA	10	14	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
 ISA	10	14	Isaiah			Alternate			
@@ -10933,7 +10933,7 @@ JER	10	7	Jeremiah			Potential
 JER	10	8	Jeremiah			Potential			
 JER	10	9	Jeremiah			Potential			
 JER	10	10	Jeremiah			Potential			
-JER	10	11	God		God (Yahweh)	Potential			Unspecified
+JER	10	11	God		God (Yahweh)	Potential			
 JER	10	11	Jeremiah			Normal			
 JER	10	12	Jeremiah			Implicit			
 JER	10	12	God		God (Yahweh)	Alternate			
@@ -11059,14 +11059,14 @@ JER	14	5	God		God (Yahweh)	Alternate
 JER	14	5	Jeremiah			Potential			
 JER	14	6	God		God (Yahweh)	Alternate			
 JER	14	6	Jeremiah			Potential			
-JER	14	7	Jeremiah			Potential			Unspecified
-JER	14	7	people, repentant			Potential			Unspecified
+JER	14	7	Jeremiah			Potential			
+JER	14	7	people, repentant			Potential			
 JER	14	7	Needs Review			Implicit			
-JER	14	8	Jeremiah			Potential			Unspecified
-JER	14	8	people, repentant			Potential			Unspecified
+JER	14	8	Jeremiah			Potential			
+JER	14	8	people, repentant			Potential			
 JER	14	8	Needs Review			Implicit			
-JER	14	9	Jeremiah			Potential			Unspecified
-JER	14	9	people, repentant			Potential			Unspecified
+JER	14	9	Jeremiah			Potential			
+JER	14	9	people, repentant			Potential			
 JER	14	9	Needs Review			Implicit			
 JER	14	10	God		God (Yahweh)	Normal			
 JER	14	11	God		God (Yahweh)	Normal			
@@ -11473,14 +11473,14 @@ JER	26	18	elders of the land			Normal
 JER	26	18	Micah, prophet			Quotation			Unspecified
 JER	26	19	elders of the land			Implicit			
 # Most translations (including WEB) do not have vv. 20-23 in quotes. It is a commentary by the narrator (some make it parenthetical).
-JER	26	20	elders of the land			Potential			Unspecified
-JER	26	20	Needs Review			Potential			Unspecified
-JER	26	21	elders of the land			Potential			Unspecified
-JER	26	21	Needs Review			Potential			Unspecified
-JER	26	22	elders of the land			Potential			Unspecified
-JER	26	22	Needs Review			Potential			Unspecified
-JER	26	23	elders of the land			Potential			Unspecified
-JER	26	23	Needs Review			Potential			Unspecified
+JER	26	20	elders of the land			Potential			
+JER	26	20	Needs Review			Potential			
+JER	26	21	elders of the land			Potential			
+JER	26	21	Needs Review			Potential			
+JER	26	22	elders of the land			Potential			
+JER	26	22	Needs Review			Potential			
+JER	26	23	elders of the land			Potential			
+JER	26	23	Needs Review			Potential			
 JER	27	2	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	2	God		God (Yahweh)	Normal			
 JER	27	3	God		God (Yahweh)	Implicit			
@@ -11799,7 +11799,7 @@ JER	33	17	Jeremiah		Jeremiah (Yahweh says)	Potential
 JER	33	17	God		God (Yahweh)	Normal			
 JER	33	18	God		God (Yahweh)	Implicit			
 JER	33	18	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	33	20	Jeremiah		Jeremiah (Yahweh says)	Potential			Unspecified
+JER	33	20	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	33	20	God		God (Yahweh)	Normal			
 JER	33	21	God		God (Yahweh)	Normal			
 JER	33	21	Jeremiah		Jeremiah (Yahweh says)	Normal			
@@ -11881,7 +11881,7 @@ JER	36	26	Zedekiah, king of Judah			Indirect
 JER	36	28	God		God (Yahweh)	Implicit			
 JER	36	29	God		God (Yahweh)	Normal			
 JER	36	29	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	36	30	Jeremiah		Jeremiah (Yahweh says)	Potential			Unspecified
+JER	36	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	36	30	God		God (Yahweh)	Normal			
 JER	36	31	God		God (Yahweh)	Implicit			
 JER	36	31	Jeremiah		Jeremiah (Yahweh says)	Alternate			
@@ -13053,10 +13053,10 @@ EZK	19	12	God	lament	God (Yahweh)	Implicit
 EZK	19	12	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
 EZK	19	13	God	lament	God (Yahweh)	Implicit			
 EZK	19	13	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	14	God	lament	God (Yahweh)	Potential			Unspecified
-EZK	19	14	God	instructing	God (Yahweh)	Potential			Unspecified
-EZK	19	14	Ezekiel	lament	Ezekiel (Yahweh says)	Potential			Unspecified
-EZK	19	14	Ezekiel	instructing	Ezekiel (Yahweh says)	Potential			Unspecified
+EZK	19	14	God	lament	God (Yahweh)	Potential			
+EZK	19	14	God	instructing	God (Yahweh)	Potential			
+EZK	19	14	Ezekiel	lament	Ezekiel (Yahweh says)	Potential			
+EZK	19	14	Ezekiel	instructing	Ezekiel (Yahweh says)	Potential			
 EZK	19	14	Needs Review			Implicit			
 EZK	20	3	God		God (Yahweh)	Normal			
 EZK	20	3	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -14306,7 +14306,7 @@ DAN	2	11	astrologers			Implicit			EntireVerse
 DAN	2	12	Nebuchadnezzar, king of Babylon			Indirect			
 DAN	2	15	Daniel			Normal			ContainedWithinVerse
 DAN	2	16	Daniel			Indirect			
-DAN	2	17	Daniel			Potential			Unspecified
+DAN	2	17	Daniel			Potential			
 DAN	2	18	Daniel			Indirect			
 DAN	2	20	Daniel			Normal			Unspecified
 DAN	2	21	Daniel			Implicit			
@@ -14336,9 +14336,9 @@ DAN	2	44	Daniel			Implicit
 DAN	2	45	Daniel			Implicit			
 DAN	2	46	Nebuchadnezzar, king of Babylon			Indirect			
 DAN	2	47	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
-DAN	2	48	Nebuchadnezzar, king of Babylon			Potential			Unspecified
+DAN	2	48	Nebuchadnezzar, king of Babylon			Potential			
 DAN	2	49	Daniel	requesting		Indirect			
-DAN	3	2	Nebuchadnezzar, king of Babylon			Potential			Unspecified
+DAN	3	2	Nebuchadnezzar, king of Babylon			Potential			
 DAN	3	4	herald			Normal			EndOfVerse
 DAN	3	5	herald			Implicit			EntireVerse
 DAN	3	6	herald			Implicit			EntireVerse
@@ -14406,8 +14406,8 @@ DAN	4	26	Daniel		Belteshazzar (Daniel)	Implicit
 DAN	4	26	Nebuchadnezzar, king of Babylon	letter		Alternate			
 DAN	4	27	Daniel		Belteshazzar (Daniel)	Implicit			
 DAN	4	27	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	28	Nebuchadnezzar, king of Babylon	letter		Potential			Unspecified
-DAN	4	29	Nebuchadnezzar, king of Babylon	letter		Potential			Unspecified
+DAN	4	28	Nebuchadnezzar, king of Babylon	letter		Potential			
+DAN	4	29	Nebuchadnezzar, king of Babylon	letter		Potential			
 DAN	4	30	Nebuchadnezzar, king of Babylon	boasting		Normal			Unspecified
 DAN	4	30	Nebuchadnezzar, king of Babylon	letter		Alternate			
 DAN	4	31	voice from heaven (angel?)			Normal			
@@ -14416,7 +14416,7 @@ DAN	4	31	Nebuchadnezzar, king of Babylon	letter		Alternate
 DAN	4	32	voice from heaven (angel?)			Normal			
 DAN	4	32	God		voice from heaven (God?)	Normal			
 DAN	4	32	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	33	Nebuchadnezzar, king of Babylon	letter		Potential			Unspecified
+DAN	4	33	Nebuchadnezzar, king of Babylon	letter		Potential			
 DAN	4	34	Nebuchadnezzar, king of Babylon	letter		Implicit			
 DAN	4	35	Nebuchadnezzar, king of Babylon	letter		Implicit			
 DAN	4	36	Nebuchadnezzar, king of Babylon	letter		Implicit			
@@ -14707,9 +14707,9 @@ HOS	1	5	God		God (Yahweh)	Implicit			EntireVerse
 HOS	1	6	God		God (Yahweh)	Normal			EndOfVerse
 HOS	1	7	God		God (Yahweh)	Implicit			EntireVerse
 HOS	1	9	God		God (Yahweh)	Normal			Unspecified
-HOS	1	10	God		God (Yahweh)	Potential			Unspecified
+HOS	1	10	God		God (Yahweh)	Potential			
 HOS	1	10	narrator-HOS			Quotation			Unspecified
-HOS	1	11	God		God (Yahweh)	Potential			Unspecified
+HOS	1	11	God		God (Yahweh)	Potential			
 HOS	2	1	God		God (Yahweh)	Normal			
 HOS	2	1	narrator-HOS			Quotation			Unspecified
 HOS	2	2	God		God (Yahweh)	Implicit			
@@ -15209,7 +15209,7 @@ OBA	1	19	God		God (Yahweh)	Potential
 OBA	1	20	God		God (Yahweh)	Potential			
 OBA	1	21	God		God (Yahweh)	Potential			
 JON	1	2	God		God (Yahweh)	Normal			Unspecified
-JON	1	5	sailors on ship to Tarshish	fearful	sailors	Potential			Unspecified
+JON	1	5	sailors on ship to Tarshish	fearful	sailors	Potential			
 JON	1	6	captain of ship to Tarshish		captain	Normal			Unspecified
 JON	1	7	sailors on ship to Tarshish		sailors	Normal			
 JON	1	7	captain of ship to Tarshish			Normal			
@@ -15224,8 +15224,8 @@ JON	1	11	captain of ship to Tarshish			Normal
 JON	1	12	Jonah			Normal			Unspecified
 JON	1	14	sailors on ship to Tarshish	praying	sailors	Normal			
 JON	1	14	captain of ship to Tarshish	praying		Normal			
-JON	1	16	sailors on ship to Tarshish	vowing	sailors	Potential			Unspecified
-JON	1	17	God		God (Yahweh)	Potential			Unspecified
+JON	1	16	sailors on ship to Tarshish	vowing	sailors	Potential			
+JON	1	17	God		God (Yahweh)	Potential			
 JON	2	2	Jonah	praying		Normal			Unspecified
 JON	2	3	Jonah	praying		Normal			Unspecified
 JON	2	4	Jonah	praying		Normal			Unspecified
@@ -15234,7 +15234,7 @@ JON	2	6	Jonah	praying		Normal			Unspecified
 JON	2	7	Jonah	praying		Normal			Unspecified
 JON	2	8	Jonah	praying		Normal			Unspecified
 JON	2	9	Jonah	praying		Normal			Unspecified
-JON	2	10	God		God (Yahweh)	Potential			Unspecified
+JON	2	10	God		God (Yahweh)	Potential			
 JON	3	2	God		God (Yahweh)	Normal			Unspecified
 JON	3	4	Jonah			Normal			EndOfVerse
 JON	3	7	king of Nineveh	proclamation		Normal			EndOfVerse
@@ -15766,7 +15766,7 @@ ZEC	7	6	God			Implicit
 ZEC	7	6	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	7	7	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	7	7	God			Potential			
-ZEC	7	8	Zechariah the prophet, son of Berechiah			Potential			Unspecified
+ZEC	7	8	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	7	9	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	7	9	God			Normal			
 ZEC	7	10	God			Implicit			
@@ -16030,7 +16030,7 @@ MAL	4	6	God		God (Yahweh)	Implicit
 MAT	1	1	narrator-MAT			Quotation			Unspecified
 MAT	1	16	narrator-MAT			Quotation			Unspecified
 MAT	1	19	Joseph, the carpenter	thinking		Rare			
-MAT	1	19	Needs Review			Potential			Unspecified
+MAT	1	19	Needs Review			Potential			
 MAT	1	20	angel		angel of the Lord	Normal			EndOfVerse
 MAT	1	21	angel		angel of the Lord	Implicit			EntireVerse
 MAT	1	23	narrator-MAT			Quotation			Unspecified
@@ -16060,7 +16060,7 @@ MAT	2	23	scripture			Quotation			Unspecified
 MAT	3	2	John the Baptist	proclaim		Normal			Unspecified
 MAT	3	3	scripture			Quotation	Isaiah		EndOfVerse
 MAT	3	6	people from Jerusalem, Judea and the region around the Jordan			Rare			
-MAT	3	6	Needs Review			Potential			Unspecified
+MAT	3	6	Needs Review			Potential			
 MAT	3	7	John the Baptist	rebuking		Normal			EndOfVerse
 MAT	3	8	John the Baptist	rebuking		Implicit			EntireVerse
 MAT	3	9	John the Baptist	rebuking		Implicit			EntireVerse
@@ -16079,7 +16079,7 @@ MAT	4	7	Jesus			Dialogue			Unspecified
 MAT	4	9	Satan (Devil)			Dialogue			Unspecified
 MAT	4	10	Jesus	rebuking		Dialogue			Unspecified
 MAT	4	12	messenger to Jesus	reporting		Rare			
-MAT	4	12	Needs Review			Potential			Unspecified
+MAT	4	12	Needs Review			Potential			
 MAT	4	15	scripture			Implicit	Isaiah		EntireVerse
 MAT	4	16	scripture			Implicit	Isaiah		EntireVerse
 MAT	4	17	Jesus	preaching		Normal			ContainedWithinVerse
@@ -16193,14 +16193,14 @@ MAT	7	25	Jesus	preaching		Implicit
 MAT	7	26	Jesus	preaching		Implicit			
 MAT	7	27	Jesus	preaching		Implicit			
 MAT	7	28	crowd			Rare			
-MAT	7	28	Needs Review			Potential			Unspecified
+MAT	7	28	Needs Review			Potential			
 MAT	7	29	crowd			Rare			
-MAT	7	29	Needs Review			Potential			Unspecified
+MAT	7	29	Needs Review			Potential			
 MAT	8	2	leper	pleading		Dialogue		MAT 8.2;MRK 1.40;LUK 5.12	Unspecified
 MAT	8	3	Jesus			Dialogue			ContainedWithinVerse
 MAT	8	4	Jesus	giving orders		Dialogue			Unspecified
 MAT	8	5	centurion with great faith	entreating		Rare			
-MAT	8	5	Needs Review			Potential			Unspecified
+MAT	8	5	Needs Review			Potential			
 MAT	8	6	centurion with great faith	entreating		Implicit			EntireVerse
 MAT	8	7	Jesus			Dialogue			Unspecified
 MAT	8	8	centurion with great faith	humbly		Dialogue		MAT 8.8-9;LUK 7.6-8	Unspecified
@@ -16301,7 +16301,7 @@ MAT	10	41	Jesus	instructing		Implicit
 MAT	10	42	Jesus	instructing		Implicit			
 MAT	11	2	disciples of John the Baptist			Rare		MAT 11.2;LUK 7.18	
 MAT	11	2	John the Baptist			Rare			
-MAT	11	2	Needs Review			Potential			Unspecified
+MAT	11	2	Needs Review			Potential			
 MAT	11	3	disciples of John the Baptist	puzzled		Dialogue		MAT 11.3;LUK 7.20	Unspecified
 MAT	11	4	Jesus			Normal			EndOfVerse
 MAT	11	5	Jesus			Implicit			EntireVerse
@@ -16371,7 +16371,7 @@ MAT	12	45	Jesus			Implicit
 MAT	12	46	Jesus			Indirect			
 MAT	12	46	Jesus' family		Jesus' mother and brothers	Indirect	Mary, Jesus' mother		
 # MAT 12:47 is not contained in early manuscripts.
-MAT	12	47	crowd	announcing	someone	Potential		MAT 12.47;MRK 3.32;LUK 8.20	Unspecified
+MAT	12	47	crowd	announcing	someone	Potential		MAT 12.47;MRK 3.32;LUK 8.20	
 MAT	12	48	Jesus	questioning		Dialogue			Unspecified
 MAT	12	49	Jesus			Dialogue			EndOfVerse
 MAT	12	50	Jesus			Implicit			EntireVerse
@@ -16433,18 +16433,18 @@ MAT	14	2	Herod Antipas (the tetrarch)	fearful		Normal			EndOfVerse
 MAT	14	4	John the Baptist	rebuking		Normal			EndOfVerse
 MAT	14	5	Herod Antipas (the tetrarch)			Rare			
 MAT	14	5	people			Rare			
-MAT	14	5	Needs Review			Potential			Unspecified
+MAT	14	5	Needs Review			Potential			
 MAT	14	6	Herod Antipas (the tetrarch)			Rare			
-MAT	14	6	Needs Review			Potential			Unspecified
+MAT	14	6	Needs Review			Potential			
 MAT	14	7	Herod Antipas (the tetrarch)			Indirect			
 MAT	14	8	Herodias' daughter			Normal			
 MAT	14	8	Herodias			Indirect			
 MAT	14	9	Herod Antipas (the tetrarch)			Indirect			
 MAT	14	10	Herod Antipas (the tetrarch)			Indirect			
-MAT	14	12	disciples of John the Baptist			Potential			Unspecified
+MAT	14	12	disciples of John the Baptist			Potential			
 MAT	14	13	disciples of John the Baptist			Rare			
 MAT	14	13	report about Jesus			Rare			
-MAT	14	13	Needs Review			Potential			Unspecified
+MAT	14	13	Needs Review			Potential			
 MAT	14	15	disciples	taking charge		Dialogue		MAT 14.15;MRK 6.35-36;LUK 9.12	EndOfVerse
 MAT	14	16	Jesus			Dialogue			Unspecified
 MAT	14	17	Andrew		disciples	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9	EndOfVerse
@@ -16511,7 +16511,7 @@ MAT	16	11	Jesus			Implicit			EntireVerse
 # review by a speaker of the target language.
 MAT	16	12	Jesus			Rare			
 MAT	16	12	narrator-MAT			Rare			
-MAT	16	12	Needs Review			Potential			Unspecified
+MAT	16	12	Needs Review			Potential			
 MAT	16	13	Jesus	questioning		Dialogue			Unspecified
 MAT	16	14	disciples	excited		Dialogue			Unspecified
 MAT	16	15	Jesus			Dialogue			Unspecified
@@ -16542,7 +16542,7 @@ MAT	17	13	Jesus			Rare
 MAT	17	13	disciples	comprehending		Rare			
 MAT	17	13	disciples	thinking		Rare			
 MAT	17	13	disciples	saying to each other		Rare			
-MAT	17	13	Needs Review			Potential			Unspecified
+MAT	17	13	Needs Review			Potential			
 MAT	17	15	father of demon-possessed boy	distraught	a man (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	Unspecified
 MAT	17	16	father of demon-possessed boy	distraught	a man (father of demon-possessed boy)	Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
 MAT	17	17	Jesus	exasperated		Dialogue			Unspecified
@@ -16550,7 +16550,7 @@ MAT	17	17	Jesus	giving orders		Dialogue			Unspecified
 MAT	17	18	Jesus	rebuking		Indirect			
 MAT	17	19	disciples	upset		Dialogue		MAT 17.19;MRK 9.28	EndOfVerse
 MAT	17	20	Jesus			Dialogue			Unspecified
-MAT	17	21	Jesus			Potential			Unspecified
+MAT	17	21	Jesus			Potential			
 MAT	17	22	Jesus			Normal			EndOfVerse
 MAT	17	23	Jesus			Normal			StartOfVerse
 MAT	17	24	collectors of temple tax	demanding		Dialogue			EndOfVerse
@@ -16568,7 +16568,7 @@ MAT	18	7	Jesus			Implicit			EntireVerse
 MAT	18	8	Jesus			Implicit			EntireVerse
 MAT	18	9	Jesus			Normal			StartOfVerse
 MAT	18	10	Jesus	warning		Implicit			EntireVerse
-MAT	18	11	Jesus			Potential			Unspecified
+MAT	18	11	Jesus			Potential			
 MAT	18	12	Jesus			Implicit			EntireVerse
 MAT	18	13	Jesus			Implicit			EntireVerse
 MAT	18	14	Jesus			Normal			StartOfVerse
@@ -16712,7 +16712,7 @@ MAT	22	12	Jesus			Normal			Unspecified
 MAT	22	13	Jesus			Implicit			EntireVerse
 MAT	22	14	Jesus			Normal			StartOfVerse
 MAT	22	15	Pharisees			Rare			
-MAT	22	15	Needs Review			Potential			Unspecified
+MAT	22	15	Needs Review			Potential			
 MAT	22	16	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EndOfVerse
 MAT	22	17	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Implicit		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
 MAT	22	18	Jesus	rebuking		Dialogue			EndOfVerse
@@ -16721,7 +16721,7 @@ MAT	22	20	Jesus	questioning		Dialogue			Unspecified
 MAT	22	21	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Dialogue		MAT 22.21;MRK 12.16;LUK 20.24	Unspecified
 MAT	22	21	Jesus			Dialogue			Unspecified
 MAT	22	22	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Rare		MAT 22.22;MRK 12.17;LUK 20.26	
-MAT	22	22	Needs Review			Potential			Unspecified
+MAT	22	22	Needs Review			Potential			
 MAT	22	23	Sadducees			Hypothetical			Unspecified
 MAT	22	24	Sadducees			Dialogue			Unspecified
 MAT	22	25	Sadducees			Implicit			EntireVerse
@@ -16736,9 +16736,9 @@ MAT	22	32	Jesus			Implicit			EntireVerse
 # reaction of some of the scribes in Luke's account, so it's best to allow for both possibilities here.
 MAT	22	33	crowd			Rare			
 MAT	22	33	expert in religious law			Rare			
-MAT	22	33	Needs Review			Potential			Unspecified
+MAT	22	33	Needs Review			Potential			
 MAT	22	34	report about Jesus			Rare			
-MAT	22	34	Needs Review			Potential			Unspecified
+MAT	22	34	Needs Review			Potential			
 MAT	22	36	Pharisee (expert in religious law)	testing		Implicit			EntireVerse
 MAT	22	37	Jesus			Dialogue			Unspecified
 MAT	22	38	Jesus			Normal			Unspecified
@@ -16921,7 +16921,7 @@ MAT	26	42	Jesus	deeply distressed		Normal			EndOfVerse
 MAT	26	45	Jesus	resigned		Normal			EndOfVerse
 MAT	26	46	Jesus			Normal			StartOfVerse
 MAT	26	47	Jesus			Rare			
-MAT	26	47	Needs Review			Potential			Unspecified
+MAT	26	47	Needs Review			Potential			
 MAT	26	48	Judas Iscariot	plotting		Normal			EndOfVerse
 MAT	26	49	Judas Iscariot	fake respect		Dialogue			ContainedWithinVerse
 MAT	26	50	Jesus			Dialogue			Unspecified
@@ -16931,7 +16931,7 @@ MAT	26	54	Jesus			Implicit			EntireVerse
 MAT	26	55	Jesus			Dialogue			EndOfVerse
 MAT	26	56	Jesus			Normal			StartOfVerse
 MAT	26	59	chief priests/Sanhedrin			Rare		MAT 26.59; MRK 14.55	
-MAT	26	59	Needs Review			Potential			Unspecified
+MAT	26	59	Needs Review			Potential			
 MAT	26	61	witnesses, false		two false witnesses	Dialogue		MAT 26.61;MRK 14.58	EndOfVerse
 MAT	26	62	Caiaphas, the high priest	demanding		Dialogue			EndOfVerse
 MAT	26	63	Caiaphas, the high priest	demanding		Dialogue			EndOfVerse
@@ -16962,7 +16962,7 @@ MAT	27	11	Jesus			Dialogue			Unspecified
 MAT	27	11	Pilate	to Jesus		Dialogue			Unspecified
 MAT	27	13	Pilate	to Jesus		Dialogue			Unspecified
 MAT	27	14	Pilate	amazed		Rare			
-MAT	27	14	Needs Review			Potential			Unspecified
+MAT	27	14	Needs Review			Potential			
 MAT	27	17	Pilate	to crowd		Dialogue			EndOfVerse
 MAT	27	19	Pilate's wife			Normal			EndOfVerse
 MAT	27	20	chief priests/elders			Indirect			
@@ -16978,14 +16978,14 @@ MAT	27	26	Pilate			Indirect
 MAT	27	29	soldiers, Roman	mocking		Dialogue			EndOfVerse
 MAT	27	32	soldiers, Roman	giving orders		Indirect			
 MAT	27	33	narrator-MAT			Quotation			Unspecified
-MAT	27	35	scripture			Potential	David		Unspecified
+MAT	27	35	scripture			Potential	David		
 MAT	27	37	narrator-MAT			Quotation			Unspecified
 MAT	27	37	sign on the cross			Quotation	narrator-MAT		Unspecified
-MAT	27	39	passers by	mocking		Potential			Unspecified
+MAT	27	39	passers by	mocking		Potential			
 MAT	27	40	passers by	mocking		Dialogue			Unspecified
 MAT	27	42	chief priests/teachers of religious law/elders	sneering		Dialogue		MAT 27.42;MRK 15.31-32;LUK 23.35	Unspecified
 MAT	27	43	chief priests/teachers of religious law/elders	sneering		Implicit			EntireVerse
-MAT	27	44	criminal on cross, insulting		the robbers who were crucified with Jesus	Potential		MAT 27.44;LUK 23.39	Unspecified
+MAT	27	44	criminal on cross, insulting		the robbers who were crucified with Jesus	Potential		MAT 27.44;LUK 23.39	
 MAT	27	46	Jesus	deeply distressed		Normal			
 MAT	27	46	narrator-MAT			Quotation			Unspecified
 MAT	27	47	bystanders at Calvary, some	misunderstanding	some of the bystanders	Dialogue		MAT 27.47;MRK 15.35	EndOfVerse
@@ -17002,17 +17002,17 @@ MAT	28	6	angels in white, two		angel	Implicit		MAT 28.5-6;MRK 16.6;LUK 24.6	Enti
 MAT	28	7	angels in white, two		angel	Implicit		MAT 28.7;MRK 16.7	EntireVerse
 MAT	28	9	Jesus			Normal			Unspecified
 MAT	28	10	Jesus			Dialogue			Unspecified
-MAT	28	11	soldiers, Roman		some of the guard	Potential			Unspecified
+MAT	28	11	soldiers, Roman		some of the guard	Potential			
 MAT	28	13	chief priests/elders	bribing		Normal			EndOfVerse
 MAT	28	14	chief priests/elders	bribing		Implicit			EntireVerse
 MAT	28	15	saying (lie about disciples stealing Jesus' body)			Rare			
 MAT	28	15	chief priests/elders			Rare			
 MAT	28	15	Jews, the			Rare			
-MAT	28	15	Needs Review			Potential			Unspecified
+MAT	28	15	Needs Review			Potential			
 MAT	28	16	Jesus			Rare			
-MAT	28	16	Needs Review			Potential			Unspecified
+MAT	28	16	Needs Review			Potential			
 MAT	28	17	disciples			Rare			
-MAT	28	17	Needs Review			Potential			Unspecified
+MAT	28	17	Needs Review			Potential			
 MAT	28	18	Jesus			Dialogue			EndOfVerse
 MAT	28	19	Jesus			Implicit			EntireVerse
 MAT	28	20	Jesus			Implicit			EntireVerse
@@ -17020,7 +17020,7 @@ MRK	1	2	scripture			Quotation	Isaiah		EndOfVerse
 MRK	1	3	scripture			Implicit	Isaiah		EntireVerse
 MRK	1	4	John the Baptist			Indirect			
 MRK	1	5	people from Jerusalem, Judea and the region around the Jordan			Rare			
-MRK	1	5	Needs Review			Potential			Unspecified
+MRK	1	5	Needs Review			Potential			
 MRK	1	7	John the Baptist			Normal			EndOfVerse
 MRK	1	8	John the Baptist			Normal			StartOfVerse
 MRK	1	11	God		voice from heaven (God)	Normal			Unspecified
@@ -17028,14 +17028,14 @@ MRK	1	15	Jesus			Normal			Unspecified
 MRK	1	17	Jesus			Dialogue			Unspecified
 MRK	1	20	Jesus			Indirect			
 MRK	1	22	people in Capernaum synagogue	amazed		Rare			
-MRK	1	22	Needs Review			Potential			Unspecified
+MRK	1	22	Needs Review			Potential			
 MRK	1	24	man possessed by evil spirit			Implicit			EntireVerse
 MRK	1	25	Jesus	giving orders		Dialogue			Unspecified
 MRK	1	27	men in Capernaum synagogue	amazed		Normal			Unspecified
 MRK	1	30	people in Capernaum			Indirect			
 MRK	1	34	Jesus			Rare			
 MRK	1	34	evil spirits			Rare			
-MRK	1	34	Needs Review			Potential			Unspecified
+MRK	1	34	Needs Review			Potential			
 MRK	1	37	Peter (Simon)	exclaimed	Peter (Simon) and companions	Dialogue			EndOfVerse
 MRK	1	38	Jesus			Dialogue			EndOfVerse
 MRK	1	40	leper	pleading		Dialogue		MAT 8.2;MRK 1.40;LUK 5.12	EndOfVerse
@@ -17043,7 +17043,7 @@ MRK	1	41	Jesus	compassionately		Dialogue			EndOfVerse
 MRK	1	43	Jesus	warning		Indirect			
 MRK	1	44	Jesus			Normal			Unspecified
 MRK	1	45	leper	proclaim		Rare			
-MRK	1	45	Needs Review			Potential			Unspecified
+MRK	1	45	Needs Review			Potential			
 MRK	2	1	people in Capernaum			Indirect			
 MRK	2	5	Jesus			Dialogue			EndOfVerse
 MRK	2	7	teachers of religious law/Pharisees	thinking	teachers of religious law	Implicit		MRK 2.7;LUK 5.21	EntireVerse
@@ -17067,18 +17067,18 @@ MRK	2	26	Jesus			Implicit			EntireVerse
 MRK	2	27	Jesus			Normal			Unspecified
 MRK	2	28	Jesus			Implicit			EntireVerse
 MRK	3	2	Pharisees	accusing		Rare			
-MRK	3	2	Needs Review			Potential			Unspecified
+MRK	3	2	Needs Review			Potential			
 MRK	3	3	Jesus	giving orders		Dialogue			Unspecified
 MRK	3	4	Jesus			Dialogue			ContainedWithinVerse
 MRK	3	5	Jesus	giving orders		Dialogue			ContainedWithinVerse
 MRK	3	6	Pharisees			Rare			
-MRK	3	6	Needs Review			Potential			Unspecified
+MRK	3	6	Needs Review			Potential			
 MRK	3	7	report about Jesus			Rare			
-MRK	3	7	Needs Review			Potential			Unspecified
+MRK	3	7	Needs Review			Potential			
 MRK	3	9	Jesus	giving orders		Indirect			
 MRK	3	11	evil spirits			Normal			EndOfVerse
 MRK	3	12	Jesus			Indirect			
-MRK	3	13	Jesus			Potential			Unspecified
+MRK	3	13	Jesus			Potential			
 MRK	3	14	Jesus			Indirect			
 MRK	3	15	Jesus			Indirect			
 MRK	3	17	narrator-MRK			Quotation			Unspecified
@@ -17149,7 +17149,7 @@ MRK	5	10	demons (Legion)/man delivered from Legion of demons	begging		Indirect		
 MRK	5	12	demons (Legion)/man delivered from Legion of demons	begging	demons (Legion)	Dialogue		MAT 8:29,31; MRK 5.7,9,10,12; LUK 8.28,30,32	Unspecified
 MRK	5	13	Jesus			Indirect			
 MRK	5	14	herdsmen of pigs		those that saw demon-possessed man cured	Rare			
-MRK	5	14	Needs Review			Potential			Unspecified
+MRK	5	14	Needs Review			Potential			
 MRK	5	15	narrator-MRK			Quotation			Unspecified
 MRK	5	16	herdsmen of pigs		those that saw demon-possessed man cured	Indirect			
 MRK	5	17	Gadarene (or Gerasenes) people	pleading	the people (of the region of the Gerasenes)	Indirect		MAT 8.34;MRK 5.17;LUK 8.37	
@@ -17159,7 +17159,7 @@ MRK	5	20	man delivered from Legion of demons			Indirect
 MRK	5	23	Jairus (synagogue leader)	pleading		Dialogue		MAT 9.18;MRK 5.23;LUK 8.41	EndOfVerse
 MRK	5	28	woman, bleeding for twelve years	thinking		Normal		MAT 9.21;MRK 5.28,33;LUK 8.47	EndOfVerse
 MRK	5	29	woman, bleeding for twelve years	feeling or thinking		Rare			
-MRK	5	29	Needs Review			Potential			Unspecified
+MRK	5	29	Needs Review			Potential			
 MRK	5	30	Jesus	feeling or thinking		Rare			
 MRK	5	30	Needs Review			Rare			
 MRK	5	30	Jesus	questioning		Dialogue			EndOfVerse
@@ -17170,7 +17170,7 @@ MRK	5	33	Needs Review			Rare
 MRK	5	34	Jesus	giving orders		Dialogue			Unspecified
 MRK	5	35	men from Jairus' house	sad		Dialogue		MRK 5.35;LUK 8.49	EndOfVerse
 MRK	5	36	Jesus			Dialogue			EndOfVerse
-MRK	5	37	Jesus			Potential			Unspecified
+MRK	5	37	Jesus			Potential			
 MRK	5	38	crowd			Indirect			
 MRK	5	39	Jesus	questioning		Dialogue			EndOfVerse
 MRK	5	40	crowd			Indirect			
@@ -17178,14 +17178,14 @@ MRK	5	40	Jesus			Indirect
 MRK	5	41	Jesus	giving orders		Dialogue			Unspecified
 MRK	5	41	narrator-MRK			Quotation			Unspecified
 MRK	5	42	Jairus (synagogue leader)/Jairus' wife/disciples	amazed	father and mother of the girl, and those who were with him	Rare			
-MRK	5	42	Needs Review			Potential			Unspecified
+MRK	5	42	Needs Review			Potential			
 MRK	5	43	Jesus			Indirect		MRK 5.43; LUK 8.55,56	
 MRK	6	2	men in Nazareth synagogue	amazed		Dialogue			EndOfVerse
-MRK	6	2	Needs Review			Potential			Unspecified
+MRK	6	2	Needs Review			Potential			
 MRK	6	3	men in Nazareth synagogue	amazed		Dialogue			StartOfVerse
 MRK	6	4	Jesus			Dialogue			Unspecified
 MRK	6	6	Jesus	amazed		Rare			
-MRK	6	6	Needs Review			Potential			Unspecified
+MRK	6	6	Needs Review			Potential			
 MRK	6	7	Jesus	giving orders		Indirect			
 MRK	6	8	Jesus			Indirect			
 MRK	6	9	Jesus			Indirect			
@@ -17201,9 +17201,9 @@ MRK	6	16	Herod Antipas (the tetrarch)	fearful		Normal			EndOfVerse
 MRK	6	17	Herod Antipas (the tetrarch)			Indirect			
 MRK	6	18	John the Baptist	rebuking		Normal			Unspecified
 MRK	6	19	Herodias			Rare			
-MRK	6	19	Needs Review			Potential			Unspecified
+MRK	6	19	Needs Review			Potential			
 MRK	6	20	Herod Antipas (the tetrarch)			Rare			
-MRK	6	20	Needs Review			Potential			Unspecified
+MRK	6	20	Needs Review			Potential			
 MRK	6	22	Herod Antipas (the tetrarch)	drunk		Dialogue			Unspecified
 MRK	6	23	Herod Antipas (the tetrarch)	drunk		Dialogue			Unspecified
 MRK	6	24	Herodias			Dialogue			Unspecified
@@ -17212,14 +17212,14 @@ MRK	6	25	Herodias' daughter			Dialogue			EndOfVerse
 MRK	6	26	Herod Antipas (the tetrarch)			Indirect			
 MRK	6	27	Herod Antipas (the tetrarch)			Indirect			
 MRK	6	29	report about John the Baptist			Rare			
-MRK	6	29	Needs Review			Potential			Unspecified
+MRK	6	29	Needs Review			Potential			
 MRK	6	30	disciples			Rare			
-MRK	6	30	Needs Review			Potential			Unspecified
+MRK	6	30	Needs Review			Potential			
 MRK	6	31	Jesus			Dialogue			Unspecified
 MRK	6	33	crowd, many in the			Rare			
-MRK	6	33	Needs Review			Potential			Unspecified
+MRK	6	33	Needs Review			Potential			
 MRK	6	34	Jesus			Rare			
-MRK	6	34	Needs Review			Potential			Unspecified
+MRK	6	34	Needs Review			Potential			
 MRK	6	35	disciples	taking charge		Dialogue		MAT 14.15;MRK 6.35-36;LUK 9.12	EndOfVerse
 MRK	6	36	disciples	taking charge		Implicit			EntireVerse
 MRK	6	37	Jesus			Dialogue			Unspecified
@@ -17233,7 +17233,7 @@ MRK	6	45	Jesus			Indirect
 MRK	6	49	disciples	terrified		Indirect			
 MRK	6	50	Jesus	reassuring		Normal			EndOfVerse
 MRK	6	51	disciples	amazed		Rare			
-MRK	6	51	Needs Review			Potential			Unspecified
+MRK	6	51	Needs Review			Potential			
 MRK	6	54	crowd		people	Indirect			
 MRK	6	55	crowd		people	Indirect			
 MRK	6	56	people at Gennesaret (sick)			Indirect		MAT 14.36;MRK 6.56	
@@ -17250,7 +17250,7 @@ MRK	7	12	Jesus	rebuking		Implicit			EntireVerse
 MRK	7	13	Jesus	rebuking		Normal			Unspecified
 MRK	7	14	Jesus			Normal			Unspecified
 MRK	7	15	Jesus			Implicit			EntireVerse
-MRK	7	16	Jesus			Potential			Unspecified
+MRK	7	16	Jesus			Potential			
 MRK	7	17	disciples	puzzled		Indirect			
 MRK	7	18	Jesus			Dialogue			Unspecified
 MRK	7	19	Jesus			Dialogue			StartOfVerse
@@ -17260,7 +17260,7 @@ MRK	7	21	Jesus	instructing		Implicit			EntireVerse
 MRK	7	22	Jesus	instructing		Implicit			EntireVerse
 MRK	7	23	Jesus	instructing		Normal			StartOfVerse
 MRK	7	24	Jesus			Rare			
-MRK	7	24	Needs Review			Potential			Unspecified
+MRK	7	24	Needs Review			Potential			
 MRK	7	26	Canaanite (Syrophoenician) mother of possessed girl			Indirect		MAT 15.22;MRK 7.26	
 MRK	7	27	Jesus	instructing		Dialogue			Unspecified
 MRK	7	28	Canaanite (Syrophoenician) mother of possessed girl			Dialogue			Unspecified
@@ -17379,7 +17379,7 @@ MRK	10	30	Jesus			Implicit			EntireVerse
 MRK	10	31	Jesus			Normal			StartOfVerse
 MRK	10	32	disciples	amazed and afraid		Rare			
 MRK	10	32	Jesus			Rare			
-MRK	10	32	Needs Review			Potential			Unspecified
+MRK	10	32	Needs Review			Potential			
 MRK	10	33	Jesus			Normal			Unspecified
 MRK	10	34	Jesus			Normal			StartOfVerse
 MRK	10	35	James, the disciple/John	boldly	James/John (sons of Zebedee)	Dialogue	John		Unspecified
@@ -17412,7 +17412,7 @@ MRK	11	6	people			Indirect
 MRK	11	9	crowd preparing for Passover Feast	praising	crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EndOfVerse
 MRK	11	10	crowd preparing for Passover Feast	praising	crowd	Implicit		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EntireVerse
 MRK	11	13	Jesus			Rare			
-MRK	11	13	Needs Review			Potential			Unspecified
+MRK	11	13	Needs Review			Potential			
 MRK	11	14	Jesus			Normal			Unspecified
 MRK	11	17	Jesus			Normal			EndOfVerse
 MRK	11	21	Peter (Simon)	amazed		Dialogue			EndOfVerse
@@ -17440,7 +17440,7 @@ MRK	12	9	Jesus	preaching		Normal			Unspecified
 MRK	12	10	Jesus	preaching		Implicit			EntireVerse
 MRK	12	11	Jesus	preaching		Implicit			EntireVerse
 MRK	12	12	chief priests/teachers of religious law/elders			Rare			
-MRK	12	12	Needs Review			Potential			Unspecified
+MRK	12	12	Needs Review			Potential			
 MRK	12	14	spies (from Pharisees and Herodians)		Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EndOfVerse
 MRK	12	15	spies (from Pharisees and Herodians)		Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	Unspecified
 MRK	12	15	Jesus			Dialogue			Unspecified
@@ -17548,15 +17548,15 @@ MRK	14	38	Jesus			Implicit			EntireVerse
 MRK	14	41	Jesus			Normal			EndOfVerse
 MRK	14	42	Jesus			Normal			StartOfVerse
 MRK	14	43	Jesus			Rare			
-MRK	14	43	Needs Review			Potential			Unspecified
+MRK	14	43	Needs Review			Potential			
 MRK	14	44	Judas Iscariot	plotting		Normal			EndOfVerse
 MRK	14	45	Judas Iscariot	fake respect		Dialogue			ContainedWithinVerse
 MRK	14	48	Jesus	questioning		Dialogue			Unspecified
 MRK	14	49	Jesus			Implicit			EntireVerse
 MRK	14	55	chief priests/Sanhedrin			Rare		MAT 26.59; MRK 14.55	
-MRK	14	55	Needs Review			Potential			Unspecified
+MRK	14	55	Needs Review			Potential			
 MRK	14	56	false witnesses, many			Rare			
-MRK	14	56	Needs Review			Potential			Unspecified
+MRK	14	56	Needs Review			Potential			
 MRK	14	58	witnesses, false	mocking		Implicit		MAT 26.61;MRK 14.58	EntireVerse
 MRK	14	60	Caiaphas, the high priest	demanding		Dialogue			EndOfVerse
 MRK	14	61	Caiaphas, the high priest	demanding		Dialogue			Unspecified
@@ -17576,13 +17576,13 @@ MRK	14	72	Jesus			Quotation	narrator-MRK		Unspecified
 MRK	14	72	rooster	crowing		Rare			
 MRK	14	72	Needs Review			Rare			
 MRK	15	1	chief priests/all the elders/expert in religious law/Sanhedrin			Rare			
-MRK	15	1	Needs Review			Potential			Unspecified
+MRK	15	1	Needs Review			Potential			
 MRK	15	2	Jesus			Dialogue			Unspecified
 MRK	15	2	Pilate	to Jesus		Dialogue			Unspecified
 MRK	15	3	chief priests	accusing		Indirect			
 MRK	15	4	Pilate	to Jesus		Dialogue			Unspecified
 MRK	15	5	Pilate	amazed		Rare			
-MRK	15	5	Needs Review			Potential			Unspecified
+MRK	15	5	Needs Review			Potential			
 MRK	15	8	crowd before Pilate			Indirect			
 MRK	15	9	Pilate	to crowd		Dialogue			Unspecified
 MRK	15	11	chief priests			Indirect			
@@ -17619,12 +17619,12 @@ MRK	16	10	Mary Magdalene			Indirect
 MRK	16	11	Mary Magdalene			Indirect			
 MRK	16	11	disciples		those who had been with him	Indirect			
 MRK	16	14	Jesus			Indirect			
-MRK	16	15	Jesus			Potential			EndOfVerse
-MRK	16	16	Jesus			Implicit			EntireVerse
-MRK	16	17	Jesus			Implicit			EntireVerse
-MRK	16	18	Jesus			Potential			Unspecified
+MRK	16	15	Jesus			Potential			
+MRK	16	16	Jesus			Potential			
+MRK	16	17	Jesus			Potential			
+MRK	16	18	Jesus			Potential			
 MRK	16	20	disciples			Rare			
-MRK	16	20	Needs Review			Potential			Unspecified
+MRK	16	20	Needs Review			Potential			
 LUK	1	13	Gabriel		angel of the Lord	Dialogue			EndOfVerse
 LUK	1	14	Gabriel		angel of the Lord	Implicit			EntireVerse
 LUK	1	15	Gabriel		angel of the Lord	Implicit			EntireVerse
@@ -17665,12 +17665,12 @@ LUK	1	53	Mary, Jesus' mother			Normal			Unspecified
 LUK	1	54	Mary, Jesus' mother			Normal			Unspecified
 LUK	1	55	Mary, Jesus' mother			Normal			Unspecified
 LUK	1	58	report of God's mercy to Elizabeth			Rare			
-LUK	1	58	neighbors and relatives of Elizabeth and Zacharias (Zechariah)	rejoicing		Potential			Unspecified
+LUK	1	58	neighbors and relatives of Elizabeth and Zacharias (Zechariah)	rejoicing		Potential			
 LUK	1	58	Needs Review			Rare			
 # There is a potential speaking part in v. 59 because some translations will render this using direct
 # speech instead of indirect. Something like:
-# The neighbors and relatives of Elizabeth and Zachariah said, Â«He should be called â€¹Zachariahâ€º like his father.Â»
-# Of course, if only the name Â«ZachariahÂ» is in quotes, it should just be spoken by the narrator, but
+# The neighbors and relatives of Elizabeth and Zachariah said, «He should be called ‹Zachariah› like his father.»
+# Of course, if only the name «Zachariah» is in quotes, it should just be spoken by the narrator, but
 # the quote parser isn't smart enough to automatically distinguish between those two cases.
 LUK	1	59	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Indirect			
 LUK	1	59	narrator-LUK			Quotation			Unspecified
@@ -17680,10 +17680,10 @@ LUK	1	61	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Dialog
 # they were making signs m(as opposed to speaking), it most likely should be spoken by the narrator.
 # Also, including a "Needs Review" option, since a scripter who does not know the vernacular would
 # likely be unable to detect a case where it was translated something like: The neighbors asked,
-# â€œWhat is his name?â€ and they made signs to his father to inquire of him.
+# “What is his name?” and they made signs to his father to inquire of him.
 LUK	1	62	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Indirect			
 LUK	1	62	narrator-LUK			Quotation			Unspecified
-LUK	1	62	Needs Review			Potential			Unspecified
+LUK	1	62	Needs Review			Potential			
 LUK	1	63	narrator-LUK			Quotation			Unspecified
 LUK	1	64	Zacharias (Zechariah)			Indirect			
 LUK	1	65	everyone in Judean hills who heard			Indirect			
@@ -17707,12 +17707,12 @@ LUK	2	12	angel		angel of the Lord	Implicit			EntireVerse
 LUK	2	14	great company of heavenly host			Implicit			EntireVerse
 LUK	2	15	shepherds outside Bethlehem	awe		Normal			EndOfVerse
 LUK	2	17	shepherds outside Bethlehem			Rare			
-LUK	2	17	Needs Review			Potential			Unspecified
+LUK	2	17	Needs Review			Potential			
 LUK	2	18	shepherds outside Bethlehem			Rare			
 LUK	2	18	people who heard about Jesus' birth	amazed		Rare			
-LUK	2	18	Needs Review			Potential			Unspecified
+LUK	2	18	Needs Review			Potential			
 LUK	2	22	scripture			Rare	Moses		
-LUK	2	22	Needs Review			Potential			Unspecified
+LUK	2	22	Needs Review			Potential			
 LUK	2	23	scripture			Quotation	God		EndOfVerse
 LUK	2	24	scripture			Quotation	God		Unspecified
 LUK	2	26	Holy Spirit, the			Indirect			
@@ -17721,13 +17721,13 @@ LUK	2	30	Simeon, devout man in Jerusalem			Implicit
 LUK	2	31	Simeon, devout man in Jerusalem			Implicit			
 LUK	2	32	Simeon, devout man in Jerusalem			Implicit			
 LUK	2	33	Joseph, the carpenter/Mary, Jesus' mother	amazed		Rare			
-LUK	2	33	Needs Review			Potential			Unspecified
+LUK	2	33	Needs Review			Potential			
 LUK	2	34	Simeon, devout man in Jerusalem			Normal			EndOfVerse
 LUK	2	35	Simeon, devout man in Jerusalem			Normal			Unspecified
 LUK	2	38	Anna, prophetess			Indirect			
 LUK	2	44	Mary, Jesus' mother	thinking		Rare			
 LUK	2	44	Joseph, the carpenter/Mary, Jesus' mother			Rare			
-LUK	2	44	Needs Review			Potential			Unspecified
+LUK	2	44	Needs Review			Potential			
 LUK	2	48	Mary, Jesus' mother			Dialogue			Unspecified
 LUK	2	49	Jesus (child)			Dialogue			Unspecified
 LUK	3	3	John the Baptist			Indirect			
@@ -17768,7 +17768,7 @@ LUK	4	25	Jesus			Implicit			EntireVerse
 LUK	4	26	Jesus			Implicit			EntireVerse
 LUK	4	27	Jesus			Implicit			EntireVerse
 LUK	4	32	men in Capernaum synagogue	amazed		Rare			
-LUK	4	32	Needs Review			Potential			Unspecified
+LUK	4	32	Needs Review			Potential			
 LUK	4	34	man possessed by evil spirit			Implicit			EntireVerse
 LUK	4	35	Jesus	giving orders		Dialogue			Unspecified
 LUK	4	36	men in Capernaum synagogue	amazed		Normal			Unspecified
@@ -17854,7 +17854,7 @@ LUK	7	13	Jesus	compassionately		Dialogue			EndOfVerse
 LUK	7	14	Jesus	giving orders		Dialogue			EndOfVerse
 LUK	7	15	Jesus			Indirect			
 LUK	7	16	crowd, large (witnessed healing of widow's son)	praising		Dialogue			Unspecified
-LUK	7	18	disciples of John the Baptist			Potential		MAT 11.2;LUK 7.18	Unspecified
+LUK	7	18	disciples of John the Baptist			Potential		MAT 11.2;LUK 7.18	
 LUK	7	19	John the Baptist	discouraged		Normal			Unspecified
 LUK	7	20	disciples of John the Baptist	puzzled	John's disciples, two	Dialogue		MAT 11.3;LUK 7.20	EndOfVerse
 LUK	7	22	Jesus			Dialogue			EndOfVerse
@@ -17872,7 +17872,7 @@ LUK	7	34	Jesus			Normal			Unspecified
 LUK	7	35	Jesus			Normal			Unspecified
 LUK	7	37	sinful woman	thinking		Rare			
 LUK	7	37	report about Jesus			Rare			
-LUK	7	37	Needs Review			Potential			Unspecified
+LUK	7	37	Needs Review			Potential			
 LUK	7	39	Pharisee (Simon)	judgmental		Normal			EndOfVerse
 LUK	7	40	Jesus			Dialogue			Unspecified
 LUK	7	40	Pharisee (Simon)			Dialogue			Unspecified
@@ -17946,10 +17946,10 @@ LUK	9	8	people, still others			Indirect
 LUK	9	9	Herod Antipas (the tetrarch)			Normal			ContainedWithinVerse
 LUK	9	10	disciples			Rare			
 LUK	9	10	Jesus			Rare			
-LUK	9	10	Needs Review			Potential			Unspecified
+LUK	9	10	Needs Review			Potential			
 LUK	9	11	crowd			Rare			
 LUK	9	11	Jesus			Rare			
-LUK	9	11	Needs Review			Potential			Unspecified
+LUK	9	11	Needs Review			Potential			
 LUK	9	12	disciples	taking charge	the Twelve (disciples)	Dialogue		MAT 14.15;MRK 6.35-36;LUK 9.12	EndOfVerse
 LUK	9	13	Andrew	frustrated	the Twelve (disciples)	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9	Unspecified
 LUK	9	13	Jesus	giving orders		Dialogue			Unspecified
@@ -17982,12 +17982,12 @@ LUK	9	48	Jesus			Dialogue			Unspecified
 LUK	9	49	John		John (disciple whom Jesus loved)	Dialogue			Unspecified
 LUK	9	50	Jesus			Dialogue			Unspecified
 LUK	9	51	Jesus			Rare			
-LUK	9	51	Needs Review			Potential			Unspecified
-LUK	9	52	Jesus			Potential			Unspecified
+LUK	9	51	Needs Review			Potential			
+LUK	9	52	Jesus			Potential			
 LUK	9	54	James, the disciple/John		James/John	Dialogue	John		EndOfVerse
 # textual variant in Luke 9:55-56
-LUK	9	55	Jesus	rebuking		Potential			Unspecified
-LUK	9	56	Jesus	rebuking		Potential			Unspecified
+LUK	9	55	Jesus	rebuking		Potential			
+LUK	9	56	Jesus	rebuking		Potential			
 LUK	9	57	teacher of religious law	eager	someone	Dialogue		MAT 8.19;LUK 9.57	EndOfVerse
 LUK	9	58	Jesus			Dialogue			Unspecified
 LUK	9	59	disciple who wanted to bury his father	making excuse	another man	Dialogue		MAT 8.21;LUK 9.59	Unspecified
@@ -18034,7 +18034,7 @@ LUK	10	36	Jesus	questioning		Normal			Unspecified
 LUK	10	37	expert in religious law			Dialogue	Good Priest		Unspecified
 LUK	10	37	Jesus			Dialogue			Unspecified
 LUK	10	38	Martha			Rare			
-LUK	10	38	Needs Review			Potential			Unspecified
+LUK	10	38	Needs Review			Potential			
 LUK	10	40	Martha			Dialogue			EndOfVerse
 LUK	10	41	Jesus	compassionately		Dialogue			Unspecified
 LUK	10	42	Jesus	compassionately		Implicit			EntireVerse
@@ -18054,7 +18054,7 @@ LUK	11	13	Jesus			Normal			StartOfVerse
 LUK	11	14	Jesus			Rare			
 LUK	11	14	formerly mute demon-possessed man			Rare			
 LUK	11	14	crowd after mute healed			Rare			
-LUK	11	14	Needs Review			Potential			Unspecified
+LUK	11	14	Needs Review			Potential			
 LUK	11	15	crowd, some in			Normal			EndOfVerse
 LUK	11	16	others (testing Jesus)			Indirect			
 LUK	11	17	Jesus			Normal			Unspecified
@@ -18079,7 +18079,7 @@ LUK	11	35	Jesus			Implicit			EntireVerse
 LUK	11	36	Jesus			Normal			StartOfVerse
 LUK	11	37	Pharisees, other		Pharisee	Indirect			
 LUK	11	38	Pharisees, other		Pharisee	Rare			
-LUK	11	38	Needs Review			Potential			Unspecified
+LUK	11	38	Needs Review			Potential			
 LUK	11	39	Jesus			Dialogue			Unspecified
 LUK	11	40	Jesus			Implicit			EntireVerse
 LUK	11	41	Jesus			Implicit			EntireVerse
@@ -18096,9 +18096,9 @@ LUK	11	51	Jesus	rebuking		Implicit			EntireVerse
 LUK	11	52	Jesus	rebuking		Implicit			EntireVerse
 LUK	11	53	Jesus			Rare			
 LUK	11	53	scribes/Pharisees			Rare			
-LUK	11	53	Needs Review			Potential			Unspecified
+LUK	11	53	Needs Review			Potential			
 LUK	11	54	scribes/Pharisees			Rare			
-LUK	11	54	Needs Review			Potential			Unspecified
+LUK	11	54	Needs Review			Potential			
 LUK	12	1	Jesus			Normal			EndOfVerse
 LUK	12	2	Jesus			Implicit			EntireVerse
 LUK	12	3	Jesus			Normal			Unspecified
@@ -18314,7 +18314,7 @@ LUK	17	32	Jesus			Implicit			EntireVerse
 LUK	17	33	Jesus			Implicit			EntireVerse
 LUK	17	34	Jesus			Implicit			EntireVerse
 LUK	17	35	Jesus			Implicit			EntireVerse
-LUK	17	36	Jesus			Potential			Unspecified
+LUK	17	36	Jesus			Potential			
 LUK	17	37	disciples	puzzled		Dialogue			Unspecified
 LUK	17	37	Jesus			Dialogue			Unspecified
 LUK	18	1	Jesus			Indirect			
@@ -18326,7 +18326,7 @@ LUK	18	6	Jesus			Normal			EndOfVerse
 LUK	18	7	Jesus			Implicit			EntireVerse
 LUK	18	8	Jesus			Normal			StartOfVerse
 LUK	18	9	people, self-righteous			Rare			
-LUK	18	9	Needs Review			Potential			Unspecified
+LUK	18	9	Needs Review			Potential			
 LUK	18	10	Jesus			Normal			Unspecified
 LUK	18	11	Jesus			Normal			Unspecified
 LUK	18	12	Jesus			Implicit			EntireVerse
@@ -18363,7 +18363,7 @@ LUK	18	42	Jesus			Dialogue			Unspecified
 LUK	18	43	Bartimaeus (a blind man)	praising		Indirect			
 LUK	18	43	people	praising		Indirect			
 LUK	19	4	Zacchaeus			Rare			
-LUK	19	4	Needs Review			Potential			Unspecified
+LUK	19	4	Needs Review			Potential			
 LUK	19	5	Jesus	giving orders		Dialogue			EndOfVerse
 LUK	19	7	people in Jericho, all the	complaining		Normal			Unspecified
 LUK	19	8	Zacchaeus			Dialogue			EndOfVerse
@@ -18399,7 +18399,7 @@ LUK	19	43	Jesus			Implicit			EntireVerse
 LUK	19	44	Jesus			Normal			Unspecified
 LUK	19	46	Jesus			Dialogue			Unspecified
 LUK	19	47	chief priests/scribes/leaders			Rare			
-LUK	19	47	Needs Review			Potential			Unspecified
+LUK	19	47	Needs Review			Potential			
 LUK	20	2	chief priests/teachers of religious law/elders	challenging		Dialogue		MAT 21.23;MRK 11.28;LUK 20.2	Unspecified
 LUK	20	3	Jesus			Dialogue			Unspecified
 LUK	20	4	Jesus			Implicit			EntireVerse
@@ -18419,7 +18419,7 @@ LUK	20	16	people in the temple			Dialogue			Unspecified
 LUK	20	17	Jesus			Dialogue			EndOfVerse
 LUK	20	18	Jesus			Normal			Unspecified
 LUK	20	19	chief priests/scribes			Rare			
-LUK	20	19	Needs Review			Potential			Unspecified
+LUK	20	19	Needs Review			Potential			
 LUK	20	21	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	Unspecified
 LUK	20	22	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Implicit		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
 LUK	20	23	Jesus			Indirect			
@@ -18428,7 +18428,7 @@ LUK	20	24	Jesus			Dialogue			Unspecified
 LUK	20	24	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Dialogue		MAT 22.21;MRK 12.16;LUK 20.24	Unspecified
 LUK	20	25	Jesus			Dialogue			Unspecified
 LUK	20	26	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Rare		MAT 22.22;MRK 12.17;LUK 20.26	
-LUK	20	26	Needs Review			Potential			Unspecified
+LUK	20	26	Needs Review			Potential			
 LUK	20	27	Sadducees			Hypothetical			Unspecified
 LUK	20	28	Sadducees			Dialogue			Unspecified
 LUK	20	29	Sadducees			Implicit			EntireVerse
@@ -18485,7 +18485,7 @@ LUK	21	36	Jesus			Implicit			EntireVerse
 LUK	22	4	Judas Iscariot			Indirect			
 LUK	22	5	chief priests/officers of temple guard			Indirect			
 LUK	22	6	Judas Iscariot			Rare			
-LUK	22	6	Needs Review			Potential			Unspecified
+LUK	22	6	Needs Review			Potential			
 LUK	22	8	Jesus	giving orders		Dialogue			EndOfVerse
 LUK	22	9	Peter (Simon)/John			Dialogue	John	MAT 26.17;MRK 14.12;LUK 22.9	Unspecified
 LUK	22	10	Jesus			Dialogue			Unspecified
@@ -18551,15 +18551,15 @@ LUK	23	5	chief priests/crowd	angry		Dialogue			Unspecified
 LUK	23	6	Pilate			Indirect			
 LUK	23	7	chief priests/crowd			Rare			
 LUK	23	7	Pilate			Rare			
-LUK	23	7	Needs Review			Potential			Unspecified
+LUK	23	7	Needs Review			Potential			
 LUK	23	8	Herod Antipas (the tetrarch)			Indirect			
 LUK	23	9	Herod Antipas (the tetrarch)			Rare			
-LUK	23	9	Needs Review			Potential			Unspecified
+LUK	23	9	Needs Review			Potential			
 LUK	23	10	chief priests/scribes			Rare			
-LUK	23	10	Needs Review			Potential			Unspecified
+LUK	23	10	Needs Review			Potential			
 LUK	23	11	Herod Antipas (the tetrarch)/soldiers, Roman			Rare			
-LUK	23	11	Needs Review			Potential			Unspecified
-LUK	23	13	Pilate			Potential			Unspecified
+LUK	23	11	Needs Review			Potential			
+LUK	23	13	Pilate			Potential			
 LUK	23	14	Pilate	to crowd		Dialogue			EndOfVerse
 LUK	23	15	Pilate	to crowd		Implicit			EntireVerse
 LUK	23	16	Pilate	to crowd		Normal			Unspecified
@@ -18589,9 +18589,9 @@ LUK	23	43	Jesus			Dialogue			Unspecified
 LUK	23	46	Jesus			Dialogue			ContainedWithinVerse
 LUK	23	47	centurion at crucifixion	amazed		Dialogue			EndOfVerse
 LUK	23	50	Joseph of Arimathaea			Rare			
-LUK	23	50	Needs Review			Potential			Unspecified
+LUK	23	50	Needs Review			Potential			
 LUK	23	51	Joseph of Arimathaea			Rare			
-LUK	23	51	Needs Review			Potential			Unspecified
+LUK	23	51	Needs Review			Potential			
 LUK	23	52	Joseph of Arimathaea			Indirect			
 LUK	24	4	Mary Magdalene/Mary mother of James/Salome			Indirect	Mary Magdalene		
 LUK	24	5	angels in white, two		men (angels) in clothes that gleamed like lightning, two	Dialogue			Unspecified
@@ -18601,7 +18601,7 @@ LUK	24	8	Mary Magdalene/Mary mother of James/Salome			Indirect	Mary Magdalene
 LUK	24	11	Mary Magdalene/Mary mother of James/Salome			Indirect			
 LUK	24	11	disciples		apostles	Indirect			
 LUK	24	12	Peter (Simon)			Rare			
-LUK	24	12	Needs Review			Potential			Unspecified
+LUK	24	12	Needs Review			Potential			
 LUK	24	17	Jesus	questioning		Dialogue			Unspecified
 LUK	24	18	Cleopas			Dialogue			EndOfVerse
 LUK	24	19	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Dialogue	Cleopas		EndOfVerse
@@ -18620,7 +18620,7 @@ LUK	24	34	Eleven/those with the Eleven			Dialogue	John		Unspecified
 LUK	24	35	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Indirect			
 LUK	24	36	Jesus			Dialogue			Unspecified
 LUK	24	37	disciples		the eleven (disciples)	Rare			
-LUK	24	37	Needs Review			Potential			Unspecified
+LUK	24	37	Needs Review			Potential			
 LUK	24	38	Jesus			Dialogue			Unspecified
 LUK	24	39	Jesus			Implicit			EntireVerse
 LUK	24	41	Jesus	questioning		Dialogue			EndOfVerse
@@ -18674,7 +18674,7 @@ JHN	2	5	Mary, Jesus' mother			Dialogue			EndOfVerse
 JHN	2	7	Jesus			Dialogue			Unspecified
 JHN	2	8	Jesus			Dialogue			Unspecified
 JHN	2	9	master of the banquet			Rare			
-JHN	2	9	Needs Review			Potential			Unspecified
+JHN	2	9	Needs Review			Potential			
 JHN	2	10	master of the banquet	complimenting		Dialogue			EndOfVerse
 JHN	2	16	Jesus	giving orders		Dialogue			EndOfVerse
 JHN	2	17	scripture			Quotation	David		EndOfVerse
@@ -18684,7 +18684,7 @@ JHN	2	20	Jews, the			Dialogue			Unspecified
 # If there is quoted text here, it wll most likely be a quotation of Jesus' previous words,
 # so it is unlikely that we would want to have him speak them again.
 JHN	2	22	Jesus			Rare			
-JHN	2	22	Needs Review			Potential			Unspecified
+JHN	2	22	Needs Review			Potential			
 JHN	3	2	Nicodemus			Dialogue			Unspecified
 JHN	3	3	Jesus			Dialogue			Unspecified
 JHN	3	4	Nicodemus			Dialogue			Unspecified
@@ -18697,14 +18697,14 @@ JHN	3	10	Jesus			Normal			Unspecified
 JHN	3	11	Jesus			Implicit			EntireVerse
 JHN	3	12	Jesus			Implicit			EntireVerse
 JHN	3	13	Jesus			Normal			Unspecified
-JHN	3	14	Jesus			Implicit			EntireVerse
-JHN	3	15	Jesus			Potential			Unspecified
-JHN	3	16	Jesus			Implicit			EntireVerse
-JHN	3	17	Jesus			Implicit			EntireVerse
-JHN	3	18	Jesus			Implicit			EntireVerse
-JHN	3	19	Jesus			Implicit			EntireVerse
-JHN	3	20	Jesus			Implicit			EntireVerse
-JHN	3	21	Jesus			Potential			StartOfVerse
+JHN	3	14	Jesus			Potential			
+JHN	3	15	Jesus			Potential			
+JHN	3	16	Jesus			Potential			
+JHN	3	17	Jesus			Potential			
+JHN	3	18	Jesus			Potential			
+JHN	3	19	Jesus			Potential			
+JHN	3	20	Jesus			Potential			
+JHN	3	21	Jesus			Potential			
 JHN	3	26	disciples of John the Baptist/a Jew	concerned		Dialogue			EndOfVerse
 JHN	3	27	John the Baptist			Dialogue			Unspecified
 JHN	3	28	John the Baptist			Implicit			EntireVerse
@@ -18737,7 +18737,7 @@ JHN	4	23	Jesus			Implicit			EntireVerse
 JHN	4	24	Jesus			Implicit			EntireVerse
 JHN	4	25	woman, Samaritan			Dialogue			Unspecified
 JHN	4	25	interruption-JHN			Interruption			
-JHN	4	25	Needs Review			Potential			Unspecified
+JHN	4	25	Needs Review			Potential			
 JHN	4	26	Jesus			Dialogue			Unspecified
 JHN	4	27	narrator-JHN			Quotation			Unspecified
 JHN	4	29	woman, Samaritan			Implicit			EntireVerse
@@ -18772,14 +18772,14 @@ JHN	5	10	Jews, the	rebuking		Dialogue			EndOfVerse
 JHN	5	11	invalid for 38 years			Dialogue			Unspecified
 JHN	5	12	Jews, the	angry		Dialogue			Unspecified
 JHN	5	13	invalid for 38 years			Rare			
-JHN	5	13	Needs Review			Potential			Unspecified
+JHN	5	13	Needs Review			Potential			
 JHN	5	14	Jesus			Dialogue			EndOfVerse
 JHN	5	15	invalid for 38 years			Indirect			
 JHN	5	17	Jesus			Dialogue			Unspecified
 JHN	5	18	Jews, the			Rare			
 JHN	5	18	Jesus			Rare			
 JHN	5	18	narrator-JHN			Rare			
-JHN	5	18	Needs Review			Potential			Unspecified
+JHN	5	18	Needs Review			Potential			
 JHN	5	19	Jesus			Normal			EndOfVerse
 JHN	5	20	Jesus			Implicit			EntireVerse
 JHN	5	21	Jesus			Implicit			EntireVerse
@@ -18817,12 +18817,12 @@ JHN	6	11	Jesus			Indirect
 JHN	6	12	Jesus			Dialogue			Unspecified
 JHN	6	14	people in crowd by Sea of Galilee	believing Jesus		Normal			Unspecified
 JHN	6	15	Jesus			Rare			
-JHN	6	15	Needs Review			Potential			Unspecified
+JHN	6	15	Needs Review			Potential			
 JHN	6	20	Jesus			Normal			EndOfVerse
 JHN	6	22	crowd			Rare			
-JHN	6	22	Needs Review			Potential			Unspecified
+JHN	6	22	Needs Review			Potential			
 JHN	6	24	crowd			Rare			
-JHN	6	24	Needs Review			Potential			Unspecified
+JHN	6	24	Needs Review			Potential			
 JHN	6	25	crowd			Dialogue			Unspecified
 JHN	6	26	Jesus			Dialogue			Unspecified
 JHN	6	27	Jesus			Implicit			EntireVerse
@@ -19056,7 +19056,7 @@ JHN	10	41	people near Jordan River			Normal			Unspecified
 JHN	11	3	Mary, sister of Martha/Martha			Normal			Unspecified
 JHN	11	4	Jesus			Normal			EndOfVerse
 JHN	11	6	report about Lazarus			Rare			
-JHN	11	6	Needs Review			Potential			Unspecified
+JHN	11	6	Needs Review			Potential			
 JHN	11	7	Jesus			Dialogue			EndOfVerse
 JHN	11	8	disciples		disciples, Jesus'	Dialogue			Unspecified
 JHN	11	9	Jesus			Dialogue			Unspecified
@@ -19069,7 +19069,7 @@ JHN	11	15	Jesus			Implicit			EntireVerse
 JHN	11	16	Thomas	resigned		Dialogue			ContainedWithinVerse
 JHN	11	17	person near Lazarus' grave who informed Jesus			Indirect			
 JHN	11	20	report to Martha about Jesus			Rare			
-JHN	11	20	Needs Review			Potential			Unspecified
+JHN	11	20	Needs Review			Potential			
 JHN	11	21	Martha			Dialogue			Unspecified
 JHN	11	22	Martha			Implicit			EntireVerse
 JHN	11	23	Jesus	reassuring		Dialogue			Unspecified
@@ -19092,7 +19092,7 @@ JHN	11	42	Jesus	praying		Implicit			EntireVerse
 JHN	11	43	Jesus	giving orders		Dialogue			EndOfVerse
 JHN	11	44	Jesus	giving orders		Dialogue			ContainedWithinVerse
 JHN	11	46	report about Jesus			Rare			
-JHN	11	46	Needs Review			Potential			Unspecified
+JHN	11	46	Needs Review			Potential			
 JHN	11	47	chief priests/Pharisees			Dialogue			Unspecified
 JHN	11	48	chief priests/Pharisees			Implicit			EntireVerse
 JHN	11	49	Caiaphas, the high priest	indignant		Dialogue			EndOfVerse
@@ -19105,17 +19105,17 @@ JHN	12	7	Jesus			Dialogue			Unspecified
 JHN	12	8	Jesus			Normal			Unspecified
 JHN	12	9	report about Jesus			Rare			
 JHN	12	9	crowd			Rare			
-JHN	12	9	Needs Review			Potential			Unspecified
+JHN	12	9	Needs Review			Potential			
 JHN	12	10	chief priests	plotting		Indirect			
 JHN	12	12	report about Jesus			Rare			
-JHN	12	12	Needs Review			Potential			Unspecified
+JHN	12	12	Needs Review			Potential			
 JHN	12	13	crowd preparing for Passover Feast	praising	great crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EndOfVerse
 JHN	12	15	scripture			Implicit	Zechariah the prophet, son of Berechiah	MAT 21:5; JHN 12:15	EntireVerse
 JHN	12	17	Jews who had been with Mary and Martha		multitude that was with Jesus when he raised Lazarus	Rare			
-JHN	12	17	Needs Review			Potential			Unspecified
+JHN	12	17	Needs Review			Potential			
 JHN	12	18	report about Jesus			Rare			
 JHN	12	18	crowd			Rare			
-JHN	12	18	Needs Review			Potential			Unspecified
+JHN	12	18	Needs Review			Potential			
 JHN	12	19	teachers of religious law/Pharisees		Pharisees	Normal			ContainedWithinVerse
 JHN	12	21	Greeks	respectful		Dialogue			EndOfVerse
 JHN	12	23	Jesus			Dialogue			Unspecified
@@ -19132,19 +19132,19 @@ JHN	12	31	Jesus			Implicit			EntireVerse
 JHN	12	32	Jesus			Implicit			EntireVerse
 JHN	12	33	Jesus			Rare			
 JHN	12	33	narrator-JHN			Rare			
-JHN	12	33	Needs Review			Potential			Unspecified
+JHN	12	33	Needs Review			Potential			
 JHN	12	34	crowd preparing for Passover Feast	challenging		Dialogue			Unspecified
 JHN	12	35	Jesus			Dialogue			Unspecified
 JHN	12	36	Jesus			Normal			StartOfVerse
 JHN	12	37	crowd preparing for Passover Feast			Rare			
-JHN	12	37	Needs Review			Potential			Unspecified
+JHN	12	37	Needs Review			Potential			
 JHN	12	38	scripture			Quotation	Isaiah		EndOfVerse
 # PG-1276: A project added in a leading "God says" (the original passage quoted from ISA 6 is God speaking) in v. 39
 JHN	12	39	scripture			Rare	Isaiah		
-JHN	12	39	Needs Review			Potential			Unspecified
+JHN	12	39	Needs Review			Potential			
 JHN	12	40	scripture			Implicit	Isaiah		EntireVerse
 JHN	12	42	leaders, many			Rare			
-JHN	12	42	Needs Review			Potential			Unspecified
+JHN	12	42	Needs Review			Potential			
 JHN	12	44	Jesus			Normal			Unspecified
 JHN	12	45	Jesus			Implicit			EntireVerse
 JHN	12	46	Jesus			Implicit			EntireVerse
@@ -19171,13 +19171,13 @@ JHN	13	19	Jesus			Implicit			EntireVerse
 JHN	13	20	Jesus			Normal			Unspecified
 JHN	13	21	Jesus			Dialogue			EndOfVerse
 JHN	13	22	disciples	perplexed		Rare			
-JHN	13	22	Needs Review			Potential			Unspecified
+JHN	13	22	Needs Review			Potential			
 JHN	13	24	Peter (Simon)	stage whisper		Normal			Unspecified
 JHN	13	25	John	sad	John (disciple whom Jesus loved)	Dialogue			Unspecified
 JHN	13	26	Jesus			Dialogue			Unspecified
 JHN	13	27	Jesus	giving orders		Dialogue			Unspecified
 JHN	13	28	Jesus			Rare			
-JHN	13	28	Needs Review			Potential			Unspecified
+JHN	13	28	Needs Review			Potential			
 JHN	13	29	narrator-JHN			Quotation			Unspecified
 JHN	13	29	disciples			Indirect			
 JHN	13	31	Jesus			Dialogue			Unspecified
@@ -19333,14 +19333,14 @@ JHN	18	27	Peter (Simon)	denial, strongest		Indirect
 JHN	18	27	rooster	crowing		Rare			
 JHN	18	27	Needs Review			Rare			
 JHN	18	28	Jews, the			Rare			
-JHN	18	28	Needs Review			Potential			Unspecified
+JHN	18	28	Needs Review			Potential			
 JHN	18	29	Pilate	to crowd		Dialogue			EndOfVerse
 JHN	18	30	Jews, the	offended		Dialogue			Unspecified
 JHN	18	31	Jews, the			Dialogue			Unspecified
 JHN	18	31	Pilate	to crowd		Dialogue			Unspecified
 JHN	18	32	Jesus			Rare			
 JHN	18	32	narrator-JHN			Rare			
-JHN	18	32	Needs Review			Potential			Unspecified
+JHN	18	32	Needs Review			Potential			
 JHN	18	33	Pilate	to Jesus		Dialogue			Unspecified
 JHN	18	34	Jesus	questioning		Dialogue			Unspecified
 JHN	18	35	Pilate	to Jesus		Dialogue			Unspecified
@@ -19352,7 +19352,7 @@ JHN	18	38	Pilate	to crowd		Dialogue			Unspecified
 JHN	18	39	Pilate	to crowd		Implicit			EntireVerse
 JHN	18	40	Jews, the			Dialogue			Unspecified
 JHN	19	1	Pilate			Rare			
-JHN	19	1	Needs Review			Potential			Unspecified
+JHN	19	1	Needs Review			Potential			
 JHN	19	3	soldiers, Roman	mocking		Dialogue			Unspecified
 JHN	19	4	Pilate	to crowd		Dialogue			Unspecified
 JHN	19	5	Pilate	to crowd		Dialogue			Unspecified
@@ -19387,7 +19387,7 @@ JHN	20	2	Mary Magdalene			Dialogue			EndOfVerse
 JHN	20	13	angels in white, two			Dialogue			Unspecified
 JHN	20	13	Mary Magdalene			Dialogue			Unspecified
 JHN	20	14	Mary Magdalene			Rare			
-JHN	20	14	Needs Review			Potential			Unspecified
+JHN	20	14	Needs Review			Potential			
 JHN	20	15	Jesus			Dialogue			Unspecified
 JHN	20	15	Mary Magdalene			Dialogue			Unspecified
 JHN	20	16	Jesus			Dialogue			Unspecified
@@ -19434,7 +19434,7 @@ JHN	21	20	John		John (who had asked the Lord who was going to betray Him)	Quotat
 JHN	21	21	Peter (Simon)	defensive		Dialogue			Unspecified
 JHN	21	22	Jesus			Dialogue			Unspecified
 JHN	21	23	Jesus			Quotation	narrator-JHN		Unspecified
-JHN	21	23	Needs Review			Potential			Unspecified
+JHN	21	23	Needs Review			Potential			
 JHN	21	23	rumor			Rare			
 JHN	21	23	narrator-JHN			Quotation			Unspecified
 ACT	1	4	Jesus			Dialogue			EndOfVerse
@@ -19447,8 +19447,8 @@ ACT	1	11	men dressed in white, two (angels)			Dialogue			Unspecified
 ACT	1	13	narrator-ACT			Quotation			Unspecified
 ACT	1	16	Peter (Simon)			Normal			Unspecified
 ACT	1	17	Peter (Simon)			Normal			Unspecified
-ACT	1	18	Peter (Simon)			Potential			Unspecified
-ACT	1	19	Peter (Simon)			Potential			Unspecified
+ACT	1	18	Peter (Simon)			Potential			
+ACT	1	19	Peter (Simon)			Potential			
 ACT	1	19	narrator-ACT			Quotation			Unspecified
 ACT	1	20	Peter (Simon)			Normal			Unspecified
 ACT	1	21	Peter (Simon)			Implicit			EntireVerse
@@ -19517,7 +19517,7 @@ ACT	3	26	Peter (Simon)			Implicit			EntireVerse
 ACT	4	1	Peter (Simon)/John			Indirect	Peter (Simon)		
 ACT	4	1	priests/captain of the temple guard/Sadducees			Indirect			
 ACT	4	2	proclamation of the resurrection			Rare			
-ACT	4	2	Needs Review			Potential			Unspecified
+ACT	4	2	Needs Review			Potential			
 ACT	4	7	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Dialogue	Ananias (Annas), the high priest (father-in-law of Caiaphas)		EndOfVerse
 ACT	4	8	Peter (Simon)			Dialogue			Unspecified
 ACT	4	9	Peter (Simon)			Implicit			EntireVerse
@@ -19551,13 +19551,13 @@ ACT	5	8	Peter (Simon)			Dialogue			Unspecified
 ACT	5	8	Sapphira, wife of Ananias of Jerusalem			Dialogue			Unspecified
 ACT	5	9	Peter (Simon)			Dialogue			Unspecified
 ACT	5	20	angel	commanding	angel of the Lord	Implicit			EntireVerse
-ACT	5	22	Needs Review			Potential			Unspecified
+ACT	5	22	Needs Review			Potential			
 ACT	5	22	officers	perplexed		Rare			
 ACT	5	23	officers	perplexed		Implicit			EntireVerse
 ACT	5	24	Ananias (Annas), the high priest (father-in-law of Caiaphas)/captain of the temple guard/chief priests			Indirect			
 ACT	5	25	person who told the guards and priests where the apostles were	excited		Normal			EndOfVerse
 ACT	5	26	captain of the temple guard/officers			Rare			
-ACT	5	26	Needs Review			Potential			Unspecified
+ACT	5	26	Needs Review			Potential			
 ACT	5	28	Ananias (Annas), the high priest (father-in-law of Caiaphas)		high priest	Dialogue			Unspecified
 ACT	5	29	Peter (Simon)/disciples		Peter and the apostles	Dialogue			Unspecified
 ACT	5	30	Peter (Simon)/disciples		Peter and the apostles	Implicit			EntireVerse
@@ -19577,7 +19577,7 @@ ACT	6	2	disciples		the twelve (apostles)	Normal			EndOfVerse
 ACT	6	3	disciples		the twelve (apostles)	Implicit			EntireVerse
 ACT	6	4	disciples		the twelve (apostles)	Implicit			EntireVerse
 ACT	6	5	Grecian Jews		the whole multitude (of believers)	Rare			
-ACT	6	5	Needs Review			Potential			Unspecified
+ACT	6	5	Needs Review			Potential			
 # "Synagogue of the Freed-men"
 ACT	6	9	narrator-ACT			Quotation			Unspecified
 ACT	6	11	Jews of Cyrene, Alexandria, Cilicia & Asia	accusing		Normal			EndOfVerse
@@ -19641,17 +19641,17 @@ ACT	7	57	Sanhedrin/chief priests/Pharisees			Indirect
 ACT	7	59	Stephen			Normal			Unspecified
 ACT	7	60	Stephen	calling out		Normal			ContainedWithinVerse
 ACT	8	5	Philip the evangelist		Philip	Rare			
-ACT	8	5	Needs Review			Potential			Unspecified
+ACT	8	5	Needs Review			Potential			
 ACT	8	9	Simon, sorcerer			Indirect			
 ACT	8	10	people of Samaria, all the			Normal			EndOfVerse
 ACT	8	13	Simon, sorcerer	amazed	Simon	Rare			
-ACT	8	13	Needs Review			Potential			Unspecified
+ACT	8	13	Needs Review			Potential			
 ACT	8	14	disciples		apostles at Jerusalem	Indirect			
 ACT	8	14	informer			Indirect			
 ACT	8	15	Peter (Simon)/John	praying		Rare			
-ACT	8	15	Needs Review			Potential			Unspecified
+ACT	8	15	Needs Review			Potential			
 ACT	8	18	Simon, sorcerer			Rare			
-ACT	8	18	Needs Review			Potential			Unspecified
+ACT	8	18	Needs Review			Potential			
 ACT	8	19	Simon, sorcerer			Normal			EndOfVerse
 ACT	8	20	Peter (Simon)	rebuking		Dialogue			Unspecified
 ACT	8	21	Peter (Simon)	rebuking		Implicit			EntireVerse
@@ -19671,7 +19671,7 @@ ACT	8	34	Ethiopian officer of Queen Candace			Dialogue			Unspecified
 ACT	8	35	Philip the evangelist		Philip	Indirect			
 ACT	8	36	Ethiopian officer of Queen Candace			Dialogue			Unspecified
 ACT	8	37	Ethiopian officer of Queen Candace			Indirect			
-ACT	8	37	Philip the evangelist		Philip	Potential			Unspecified
+ACT	8	37	Philip the evangelist		Philip	Potential			
 ACT	8	38	Ethiopian officer of Queen Candace			Indirect			
 ACT	8	40	Philip the evangelist			Indirect			
 ACT	9	1	Paul		Saul (Paul)	Indirect			
@@ -19680,7 +19680,7 @@ ACT	9	4	Jesus	questioning		Normal			EndOfVerse
 ACT	9	5	Jesus			Normal			
 ACT	9	5	Paul	awe	Saul (Paul)	Normal			
 ACT	9	6	Jesus			Normal			
-ACT	9	6	Paul	trembled	Saul (Paul)	Potential			Unspecified
+ACT	9	6	Paul	trembled	Saul (Paul)	Potential			
 ACT	9	10	Ananias of Damascus	awe		Normal			
 ACT	9	10	Jesus		Lord	Normal			
 ACT	9	11	Jesus		Lord	Normal			Unspecified
@@ -19695,7 +19695,7 @@ ACT	9	21	all who heard (in synagogues)			Normal			Unspecified
 ACT	9	22	Paul		Saul (Paul)	Indirect			
 ACT	9	26	Paul		Saul (Paul)	Rare			
 ACT	9	26	disciples			Rare			
-ACT	9	26	Needs Review			Potential			Unspecified
+ACT	9	26	Needs Review			Potential			
 ACT	9	27	Barnabas			Indirect			
 ACT	9	34	Peter (Simon)			Dialogue			Unspecified
 # as the name may be translated, "Dorcas."
@@ -19704,7 +19704,7 @@ ACT	9	38	disciples, two men (from Joppa)	urgent		Normal			Unspecified
 ACT	9	39	Peter (Simon)			Rare			
 ACT	9	39	disciples, two men (from Joppa)			Rare			
 ACT	9	39	widow	weeping	widows	Rare			
-ACT	9	39	Needs Review			Potential			Unspecified
+ACT	9	39	Needs Review			Potential			
 ACT	9	40	Peter (Simon)			Normal			Unspecified
 ACT	9	41	Peter (Simon)			Indirect			
 # "Italian Regiment"
@@ -19768,21 +19768,21 @@ ACT	11	16	Peter (Simon)			Normal			Unspecified
 ACT	11	17	Peter (Simon)			Normal			Unspecified
 ACT	11	18	believers, circumcised (in Jerusalem)	rejoicing		Dialogue			ContainedWithinVerse
 ACT	11	21	Hellenists in Antioch			Rare			
-ACT	11	21	Needs Review			Potential			Unspecified
+ACT	11	21	Needs Review			Potential			
 ACT	11	22	report concerning new believers in Antioch			Rare			
 ACT	11	22	disciples		assembly in Jerusalem	Rare			
-ACT	11	22	Needs Review			Potential			Unspecified
+ACT	11	22	Needs Review			Potential			
 ACT	11	23	Barnabas			Indirect			
 ACT	11	26	Barnabas/Paul		Barnabas/Paul (Saul)	Indirect			
 ACT	11	26	narrator-ACT			Quotation			Unspecified
 ACT	11	28	Agabus the prophet			Indirect			
 ACT	11	29	disciples			Indirect			
 ACT	12	4	King Herod Agrippa II			Rare			
-ACT	12	4	Needs Review			Potential			Unspecified
+ACT	12	4	Needs Review			Potential			
 ACT	12	7	angel	commanding	angel of the Lord	Normal			ContainedWithinVerse
 ACT	12	8	angel	commanding	angel of the Lord	Normal			Unspecified
 ACT	12	9	Peter (Simon)	thinking to himself		Rare			
-ACT	12	9	Needs Review			Potential			Unspecified
+ACT	12	9	Needs Review			Potential			
 ACT	12	11	Peter (Simon)	speaking or thinking to himself		Normal			EndOfVerse
 ACT	12	13	Rhoda			Indirect			
 ACT	12	14	Rhoda	overjoyed		Normal			Unspecified
@@ -19793,7 +19793,7 @@ ACT	12	18	soldiers	perplexed		Indirect
 ACT	12	19	King Herod Agrippa II			Indirect			
 ACT	12	20	people of Tyre and Sidon			Indirect			
 ACT	12	21	King Herod Agrippa II			Rare			
-ACT	12	21	Needs Review			Potential			Unspecified
+ACT	12	21	Needs Review			Potential			
 ACT	12	22	people of Tyre and Sidon	shouting		Normal			EndOfVerse
 ACT	13	1	narrator-ACT			Quotation			Unspecified
 ACT	13	2	Holy Spirit, the			Normal			EndOfVerse
@@ -19803,7 +19803,7 @@ ACT	13	8	Elymas			Indirect
 ACT	13	10	Paul	rebuking		Normal			Unspecified
 ACT	13	11	Paul	rebuking		Normal			StartOfVerse
 ACT	13	12	Sergius Paulus, proconsul			Rare			
-ACT	13	12	Needs Review			Potential			Unspecified
+ACT	13	12	Needs Review			Potential			
 ACT	13	15	synagogue rulers in Pisidian Antioch	gracious		Normal	Good Priest		EndOfVerse
 ACT	13	16	Paul	preaching		Normal			Unspecified
 ACT	13	17	Paul	preaching		Normal			Unspecified
@@ -19834,44 +19834,44 @@ ACT	13	41	Paul	preaching		Implicit			EntireVerse
 ACT	13	42	people in Pisidian Antioch synagogue			Indirect			
 ACT	13	43	Paul/Barnabas			Indirect	Paul		
 ACT	13	45	Jewish leaders in Pisidian Antioch		the Jews	Rare			
-ACT	13	45	Needs Review			Potential			Unspecified
+ACT	13	45	Needs Review			Potential			
 ACT	13	46	Paul/Barnabas	boldly		Normal	Paul		EndOfVerse
 ACT	13	47	Paul/Barnabas	boldly		Implicit	Paul		EntireVerse
 ACT	13	48	Gentiles			Indirect			
 ACT	13	50	Jewish leaders in Pisidian Antioch		the Jews	Rare			
-ACT	13	50	Needs Review			Potential			Unspecified
+ACT	13	50	Needs Review			Potential			
 ACT	13	51	Paul/Barnabas			Rare			
-ACT	13	51	Needs Review			Potential			Unspecified
+ACT	13	51	Needs Review			Potential			
 ACT	14	5	Gentiles, Jews, and leaders at Iconium			Indirect			
 ACT	14	10	Paul	calling out		Dialogue			ContainedWithinVerse
 ACT	14	11	crowd in Lystra	excited		Dialogue			EndOfVerse
 ACT	14	12	narrator-ACT			Quotation			Unspecified
-ACT	14	12	crowd in Lystra			Potential			Unspecified
+ACT	14	12	crowd in Lystra			Potential			
 ACT	14	13	narrator-ACT			Quotation			Unspecified
-ACT	14	13	priest of Jupiter			Potential			Unspecified
+ACT	14	13	priest of Jupiter			Potential			
 ACT	14	15	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
 ACT	14	16	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
 ACT	14	17	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
 ACT	14	22	Barnabas/Paul			Normal	Paul		Unspecified
 ACT	14	23	Barnabas/Paul			Rare			
-ACT	14	23	Needs Review			Potential			Unspecified
+ACT	14	23	Needs Review			Potential			
 ACT	14	27	Barnabas/Paul			Indirect	Paul		
 ACT	15	1	men from Judea, some	harsh		Normal			Unspecified
 ACT	15	2	Barnabas/Paul			Rare			
 ACT	15	2	brothers at Antioch			Rare			
-ACT	15	2	Needs Review			Potential			Unspecified
+ACT	15	2	Needs Review			Potential			
 ACT	15	3	Barnabas/Paul			Rare			
-ACT	15	3	Needs Review			Potential			Unspecified
+ACT	15	3	Needs Review			Potential			
 ACT	15	4	Barnabas/Paul			Rare			
 ACT	15	4	apostles, elders, and whole church at Jerusalem			Rare			
-ACT	15	4	Needs Review			Potential			Unspecified
+ACT	15	4	Needs Review			Potential			
 ACT	15	5	believers who were Pharisees			Dialogue			EndOfVerse
 ACT	15	7	Peter (Simon)			Dialogue			EndOfVerse
 ACT	15	8	Peter (Simon)			Implicit			EntireVerse
 ACT	15	9	Peter (Simon)			Implicit			EntireVerse
 ACT	15	10	Peter (Simon)			Implicit			EntireVerse
 ACT	15	12	Barnabas/Paul			Rare			
-ACT	15	12	Needs Review			Potential			Unspecified
+ACT	15	12	Needs Review			Potential			
 ACT	15	11	Peter (Simon)			Implicit			EntireVerse
 ACT	15	13	James			Normal			EndOfVerse
 ACT	15	14	James			Implicit			EntireVerse
@@ -19883,15 +19883,15 @@ ACT	15	19	James			Implicit			EntireVerse
 ACT	15	20	James			Implicit			EntireVerse
 ACT	15	21	James			Normal			StartOfVerse
 ACT	15	22	apostles, elders, and whole church at Jerusalem/James		apostles, elders, and whole church at Jerusalem	Indirect	James		
-ACT	15	23	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	24	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	25	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	26	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	27	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	28	letter from apostles and elders			Potential	James		Unspecified
-ACT	15	29	letter from apostles and elders			Potential	James		Unspecified
+ACT	15	23	letter from apostles and elders			Potential	James		
+ACT	15	24	letter from apostles and elders			Potential	James		
+ACT	15	25	letter from apostles and elders			Potential	James		
+ACT	15	26	letter from apostles and elders			Potential	James		
+ACT	15	27	letter from apostles and elders			Potential	James		
+ACT	15	28	letter from apostles and elders			Potential	James		
+ACT	15	29	letter from apostles and elders			Potential	James		
 ACT	15	31	brothers at Antioch	blessing		Rare			
-ACT	15	31	Needs Review			Potential			Unspecified
+ACT	15	31	Needs Review			Potential			
 ACT	15	33	brothers at Antioch	blessing		Indirect			
 ACT	15	34	Silas			Indirect			
 ACT	15	36	Paul			Normal			EndOfVerse
@@ -19901,14 +19901,14 @@ ACT	15	40	brothers at Antioch	blessing		Indirect
 ACT	16	2	brothers at Lystra and Iconium			Indirect			
 ACT	16	6	Holy Spirit, the			Indirect			
 ACT	16	7	Holy Spirit, the			Rare			
-ACT	16	7	Needs Review			Potential			Unspecified
+ACT	16	7	Needs Review			Potential			
 ACT	16	9	Macedonian			Normal			EndOfVerse
 ACT	16	10	God		God (Yahweh)	Indirect			
 ACT	16	15	Lydia			Normal			ContainedWithinVerse
 ACT	16	17	fortune telling slave girl			Dialogue			EndOfVerse
 ACT	16	18	Paul	sternly		Dialogue			ContainedWithinVerse
 ACT	16	19	owners of fortune telling slave girl			Rare			
-ACT	16	19	Needs Review			Potential			Unspecified
+ACT	16	19	Needs Review			Potential			
 ACT	16	20	owners of fortune telling slave girl	angry		Dialogue			EndOfVerse
 ACT	16	21	owners of fortune telling slave girl	angry		Implicit			EntireVerse
 ACT	16	22	authorities, Philippi	giving orders		Indirect			
@@ -19923,7 +19923,7 @@ ACT	16	36	jailer in Philippi	respectful		Dialogue			EndOfVerse
 ACT	16	37	Paul	upset		Dialogue			EndOfVerse
 ACT	16	38	officers of magistrates			Rare			
 ACT	16	38	narrator-ACT			Rare			
-ACT	16	38	Needs Review			Potential			Unspecified
+ACT	16	38	Needs Review			Potential			
 ACT	16	39	magistrates, chief			Indirect			
 ACT	17	3	Paul			Normal			Unspecified
 ACT	17	6	mob			Normal			EndOfVerse
@@ -19931,9 +19931,9 @@ ACT	17	7	mob			Implicit			EntireVerse
 ACT	17	10	brothers at Thessalonica			Indirect			
 ACT	17	11	Jews of Berea			Indirect			
 ACT	17	13	report concerning Paul			Rare			
-ACT	17	13	Needs Review			Potential			Unspecified
+ACT	17	13	Needs Review			Potential			
 ACT	17	14	Jews of Berea		the brothers (in Berea)	Rare			
-ACT	17	14	Needs Review			Potential			Unspecified
+ACT	17	14	Needs Review			Potential			
 ACT	17	15	Paul	commanding		Indirect			
 ACT	17	18	Epicurean and Stoic philosophers, other	superior		Normal			
 ACT	17	18	Epicurean and Stoic philosophers, some	superior		Normal			
@@ -19977,7 +19977,7 @@ ACT	19	26	Demetrius the silversmith			Implicit			EntireVerse
 ACT	19	27	Demetrius the silversmith			Implicit			EntireVerse
 ACT	19	28	craftsmen and workmen	furious		Normal			EndOfVerse
 ACT	19	30	brothers at Ephesus			Rare			
-ACT	19	30	Needs Review			Potential			Unspecified
+ACT	19	30	Needs Review			Potential			
 ACT	19	31	officials, Ephesus (friends of Paul)			Indirect			
 ACT	19	33	craftsmen and workmen	furious		Indirect			
 ACT	19	34	craftsmen and workmen	furious		Normal			EndOfVerse
@@ -19995,7 +19995,7 @@ ACT	20	10	Paul	calling out		Dialogue			EndOfVerse
 ACT	20	12	Paul's traveling companions, Luke and/Philip the evangelist/daughters of Philip the evangelist	begging	we and they of that place	Indirect			
 ACT	20	13	Paul			Rare			
 ACT	20	13	Paul's traveling companions, Luke and		we who went ahead	Rare			
-ACT	20	13	Needs Review			Potential			Unspecified
+ACT	20	13	Needs Review			Potential			
 ACT	20	16	Paul			Indirect			
 ACT	20	18	Paul			Normal			Unspecified
 ACT	20	19	Paul			Normal			Unspecified
@@ -20016,10 +20016,10 @@ ACT	20	33	Paul			Normal			Unspecified
 ACT	20	34	Paul			Normal			Unspecified
 ACT	20	35	Paul			Normal			Unspecified
 ACT	20	37	elders, Ephesian			Rare			
-ACT	20	37	Needs Review			Potential			Unspecified
+ACT	20	37	Needs Review			Potential			
 ACT	20	38	elders, Ephesian			Indirect			
 ACT	20	38	narrator-ACT			Quotation			Unspecified
-ACT	20	38	Needs Review			Potential			Unspecified
+ACT	20	38	Needs Review			Potential			
 ACT	21	4	disciples		Holy Spirit through disciples	Indirect			
 ACT	21	11	Agabus the prophet	proclaim		Dialogue			EndOfVerse
 ACT	21	13	Paul	sad		Dialogue			Unspecified
@@ -20032,7 +20032,7 @@ ACT	21	23	James/all the elders			Implicit	James		EntireVerse
 ACT	21	24	James/all the elders			Implicit	James		EntireVerse
 ACT	21	25	James/all the elders			Implicit	James		EntireVerse
 ACT	21	26	Paul			Rare			
-ACT	21	26	Needs Review			Potential			Unspecified
+ACT	21	26	Needs Review			Potential			
 ACT	21	28	Jews from Asia	shouting		Normal			EndOfVerse
 ACT	21	31	informer			Indirect			
 ACT	21	33	commander of Roman troops in Jerusalem			Indirect			
@@ -20096,11 +20096,11 @@ ACT	23	21	son of Paul's sister (young man)			Implicit			EntireVerse
 ACT	23	22	commander of Roman troops in Jerusalem	ordering		Dialogue			ContainedWithinVerse
 ACT	23	23	commander of Roman troops in Jerusalem	ordering		Dialogue			EndOfVerse
 ACT	23	24	commander of Roman troops in Jerusalem	ordering		Indirect			
-ACT	23	26	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			Unspecified
-ACT	23	27	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			Unspecified
-ACT	23	28	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			Unspecified
-ACT	23	29	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			Unspecified
-ACT	23	30	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			Unspecified
+ACT	23	26	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			
+ACT	23	27	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			
+ACT	23	28	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			
+ACT	23	29	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			
+ACT	23	30	commander of Roman troops in Jerusalem	letter	commander's letter	Potential			
 ACT	23	34	Paul			Indirect			
 ACT	23	34	Felix, governor of Judea			Indirect			
 ACT	23	35	Felix, governor of Judea	with authority		Normal			ContainedWithinVerse
@@ -20127,12 +20127,12 @@ ACT	24	21	Paul			Normal			Unspecified
 ACT	24	22	Felix, governor of Judea			Dialogue			Unspecified
 ACT	24	23	Felix, governor of Judea	ordering		Indirect			
 ACT	24	24	Felix, governor of Judea			Rare			
-ACT	24	24	Needs Review			Potential			Unspecified
+ACT	24	24	Needs Review			Potential			
 ACT	24	25	Felix, governor of Judea	afraid		Normal			EndOfVerse
 ACT	24	26	Felix, governor of Judea			Rare			
-ACT	24	26	Needs Review			Potential			Unspecified
+ACT	24	26	Needs Review			Potential			
 ACT	24	27	Felix, governor of Judea			Rare			
-ACT	24	27	Needs Review			Potential			Unspecified
+ACT	24	27	Needs Review			Potential			
 ACT	25	3	chief priests/Jewish leaders			Indirect			
 ACT	25	4	Festus, governor of Judea			Normal			Unspecified
 ACT	25	5	Festus, governor of Judea			Normal			Unspecified
@@ -20207,9 +20207,9 @@ ACT	27	25	Paul			Implicit			EntireVerse
 ACT	27	26	Paul			Normal			Unspecified
 ACT	27	27	sailors on ship to Italy (Rome)		sailors	Indirect			
 ACT	27	29	sailors on ship to Italy (Rome)		sailors	Rare			
-ACT	27	29	Needs Review			Potential			Unspecified
+ACT	27	29	Needs Review			Potential			
 ACT	27	30	sailors on ship to Italy (Rome)		sailors	Rare			
-ACT	27	30	Needs Review			Potential			Unspecified
+ACT	27	30	Needs Review			Potential			
 ACT	27	31	Paul	warning		Normal			EndOfVerse
 ACT	27	33	Paul	encouraging		Normal			EndOfVerse
 ACT	27	34	Paul	encouraging		Implicit			EntireVerse
@@ -20252,7 +20252,7 @@ ROM	2	22	you (hypothetical)			Hypothetical			Unspecified
 ROM	2	23	you (hypothetical)			Hypothetical			Unspecified
 ROM	2	24	scripture			Quotation	God		EndOfVerse
 ROM	3	1	Jews, the	speaking ironically		Hypothetical			Unspecified
-ROM	3	2	narrator-ROM			Potential			Unspecified
+ROM	3	2	narrator-ROM			Potential			
 ROM	3	3	Jews, the	speaking ironically		Hypothetical			Unspecified
 ROM	3	4	scripture			Quotation	David		EndOfVerse
 ROM	3	5	Jews, the	speaking ironically		Hypothetical			Unspecified
@@ -20291,11 +20291,11 @@ ROM	9	15	scripture			Quotation	God		Unspecified
 ROM	9	17	scripture			Quotation	God		EndOfVerse
 ROM	9	19	one of you			Hypothetical			Unspecified
 ROM	9	20	molded thing			Hypothetical			Unspecified
-ROM	9	20	scripture			Potential	Isaiah		Unspecified
+ROM	9	20	scripture			Potential	Isaiah		
 ROM	9	20	narrator-ROM			Rare			
 ROM	9	20	Needs Review			Rare			
 ROM	9	21	narrator-ROM			Rare			
-ROM	9	21	Needs Review			Potential			Unspecified
+ROM	9	21	Needs Review			Potential			
 ROM	9	25	scripture			Quotation	God		EndOfVerse
 ROM	9	26	scripture			Implicit	Hosea		EntireVerse
 ROM	9	27	scripture			Quotation	Isaiah		EndOfVerse
@@ -20371,8 +20371,8 @@ ROM	16	22	Tertius			Implicit
 1CO	6	16	scripture			Quotation			EndOfVerse
 1CO	6	18	scripture			Quotation			Unspecified
 1CO	7	1	narrator-1CO			Quotation			Unspecified
-1CO	7	8	narrator-1CO			Potential			Unspecified
-1CO	7	10	narrator-1CO			Potential			Unspecified
+1CO	7	8	narrator-1CO			Potential			
+1CO	7	10	narrator-1CO			Potential			
 1CO	8	1	narrator-1CO			Quotation			Unspecified
 1CO	8	4	narrator-1CO			Quotation			Unspecified
 1CO	8	5	narrator-1CO			Quotation			Unspecified
@@ -20386,8 +20386,8 @@ ROM	16	22	Tertius			Implicit
 # Including a "Needs Review" option to avoid automatically assigning the hypothetical quote
 # as scripture (since the parser ignores hypotheticals that are not pulled out as separate
 # blocks in the reference text)
-1CO	10	28	scripture			Potential	David		Unspecified
-1CO	10	28	Needs Review			Potential			Unspecified
+1CO	10	28	scripture			Potential	David		
+1CO	10	28	Needs Review			Potential			
 1CO	11	24	Jesus			Normal			EndOfVerse
 1CO	11	25	Jesus			Normal			EndOfVerse
 1CO	12	3	narrator-1CO			Quotation			Unspecified
@@ -20466,7 +20466,7 @@ GAL	3	13	scripture			Quotation	Moses		Unspecified
 GAL	3	16	narrator-GAL			Quotation			Unspecified
 GAL	3	16	scripture		scripture (God)	Quotation	God		Unspecified
 GAL	3	17	God		God (Yahweh)	Rare			
-GAL	3	17	Needs Review			Potential			Unspecified
+GAL	3	17	Needs Review			Potential			
 GAL	3	22	scripture			Indirect			
 GAL	4	6	narrator-GAL			Quotation			Unspecified
 GAL	4	6	Holy Spirit, the		the Spirit (of God's Son)	Quotation			Unspecified
@@ -20484,7 +20484,7 @@ GAL	5	9	saying about yeast			Quotation	narrator-GAL		Unspecified
 GAL	5	14	scripture			Quotation	God		Unspecified
 GAL	6	12	Judaizers			Indirect			
 EPH	1	7	God		God (Yahweh)	Rare			
-EPH	1	7	Needs Review			Potential			Unspecified
+EPH	1	7	Needs Review			Potential			
 EPH	2	11	narrator-EPH			Quotation			Unspecified
 EPH	4	8	scripture			Quotation	David		EndOfVerse
 EPH	4	9	narrator-EPH			Quotation			Unspecified
@@ -20494,16 +20494,16 @@ EPH	5	31	scripture			Quotation			Unspecified
 EPH	6	2	scripture			Quotation	God		Unspecified
 EPH	6	3	scripture			Implicit	God		EntireVerse
 PHP	2	11	everyone			Hypothetical			Unspecified
-PHP	4	2	narrator-PHP			Potential			Unspecified
-PHP	4	3	narrator-PHP			Potential			Unspecified
-PHP	4	4	narrator-PHP			Potential			Unspecified
+PHP	4	2	narrator-PHP			Potential			
+PHP	4	3	narrator-PHP			Potential			
+PHP	4	4	narrator-PHP			Potential			
 COL	2	18	narrator-COL			Quotation			Unspecified
 COL	2	21	rules of the world			Hypothetical			Unspecified
 COL	4	10	narrator-COL			Quotation			Unspecified
 COL	4	17	narrator-COL			Quotation			Unspecified
 1TH	4	12	unbelievers			Indirect			
 1TH	5	3	people			Hypothetical			Unspecified
-1TH	5	27	narrator-1TH			Potential			Unspecified
+1TH	5	27	narrator-1TH			Potential			
 2TH	2	4	man of lawlessness			Indirect			
 2TH	3	10	narrator-2TH			Quotation			Unspecified
 2TH	3	10	rule given by Paul			Quotation	narrator-2TH		Unspecified
@@ -20531,7 +20531,7 @@ COL	4	17	narrator-COL			Quotation			Unspecified
 # combine the two quotes into one "scripture" block. For languages with a single "and"
 # joining them, this will probably sound fine, but for languages that have a longer
 # clause introducing the second quote, this might not work.
-2TI	2	19	Needs Review			Potential			Unspecified
+2TI	2	19	Needs Review			Potential			
 TIT	1	12	Cretan prophet			Quotation			Unspecified
 TIT	1	12	narrator-TIT			Quotation			Unspecified
 TIT	2	12	narrator-TIT			Quotation			Unspecified
@@ -20558,8 +20558,8 @@ HEB	3	11	scripture			Implicit			EntireVerse
 HEB	3	13	narrator-HEB			Quotation			Unspecified
 HEB	3	15	scripture			Quotation			Unspecified
 HEB	3	15	narrator-HEB			Quotation			Unspecified
-HEB	3	18	scripture			Potential	God		Unspecified
-HEB	3	18	narrator-HEB			Potential			Unspecified
+HEB	3	18	scripture			Potential	God		
+HEB	3	18	narrator-HEB			Potential			
 HEB	4	3	scripture			Quotation	God		ContainedWithinVerse
 HEB	4	4	scripture			Quotation	God		Unspecified
 HEB	4	5	scripture			Quotation	God		EndOfVerse
@@ -20765,10 +20765,10 @@ REV	6	11	reply to the slain believers (in vision)			Indirect
 REV	6	16	kings, princes, generals, rich, powerful, slave and free	crying		Normal			EndOfVerse
 REV	6	17	kings, princes, generals, rich, powerful, slave and free	crying		Implicit			EntireVerse
 REV	7	3	angel standing in sun		angel from the rising sun with seal of living God	Normal			Unspecified
-REV	7	5	voice in heaven			Potential			Unspecified
-REV	7	6	voice in heaven			Potential			Unspecified
-REV	7	7	voice in heaven			Potential			Unspecified
-REV	7	8	voice in heaven			Potential			Unspecified
+REV	7	5	voice in heaven			Potential			
+REV	7	6	voice in heaven			Potential			
+REV	7	7	voice in heaven			Potential			
+REV	7	8	voice in heaven			Potential			
 REV	7	10	multitude from all nations, tribes, peoples, languages			Normal			EndOfVerse
 REV	7	12	angels, all the			Normal			EndOfVerse
 REV	7	13	elders, one of the			Normal			EndOfVerse
@@ -20800,11 +20800,11 @@ REV	12	11	voice in heaven, loud			Implicit			EntireVerse
 REV	12	12	voice in heaven, loud			Implicit			EntireVerse
 REV	13	3	whole earth			Indirect			
 REV	13	4	worshipers of the beast			Normal			EndOfVerse
-REV	13	9	voice in heaven			Potential			Unspecified
-REV	13	10	voice in heaven			Potential			Unspecified
-REV	13	10	saying about captivity and death by the sword			Potential	God		Unspecified
-REV	13	10	scripture		scripture (God)	Potential	God		Unspecified
-REV	13	10	God			Potential			Unspecified
+REV	13	9	voice in heaven			Potential			
+REV	13	10	voice in heaven			Potential			
+REV	13	10	saying about captivity and death by the sword			Potential	God		
+REV	13	10	scripture		scripture (God)	Potential	God		
+REV	13	10	God			Potential			
 REV	13	14	beast from out of the earth			Indirect			
 REV	14	7	angel flying directly overhead			Normal			EndOfVerse
 REV	14	8	angel flying directly overhead, second			Normal			EndOfVerse
@@ -20831,7 +20831,7 @@ REV	16	17	Needs Review			Normal
 REV	17	1	angel (one of the seven)			Normal			EndOfVerse
 REV	17	2	angel (one of the seven)			Implicit			EntireVerse
 REV	17	5	narrator-REV			Quotation			Unspecified
-REV	17	5	inscription on forehead of Babylon			Potential			Unspecified
+REV	17	5	inscription on forehead of Babylon			Potential			
 REV	17	7	angel (one of the seven)			Normal			EndOfVerse
 REV	17	8	angel (one of the seven)			Implicit			EntireVerse
 REV	17	9	angel (one of the seven)			Implicit			EntireVerse
@@ -20885,7 +20885,7 @@ REV	19	4	twenty-four elders/living creature, first/living creature, second/livin
 REV	19	5	voice from throne			Normal			Unspecified
 REV	19	6	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Normal			EndOfVerse
 REV	19	7	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Implicit			EntireVerse
-REV	19	8	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Potential			Unspecified
+REV	19	8	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Potential			
 REV	19	9	angel (one of the seven)			Normal			Unspecified
 REV	19	10	angel (one of the seven)			Normal			ContainedWithinVerse
 REV	19	11	narrator-REV			Quotation			Unspecified
@@ -20914,8 +20914,6 @@ REV	22	15	Jesus			Normal			Unspecified
 REV	22	16	Jesus			Implicit			EntireVerse
 REV	22	17	him who hears			Normal			
 REV	22	17	Holy Spirit, the/bride, the (referring to the Church)		Holy Spirit and the bride	Normal			
-REV	22	18	narrator-REV			Potential			Unspecified
-REV	22	19	narrator-REV			Potential			Unspecified
+REV	22	18	narrator-REV			Potential			
+REV	22	19	narrator-REV			Potential			
 REV	22	20	Jesus			Normal			ContainedWithinVerse
-
-


### PR DESCRIPTION
Also reverted a couple places where Potential lines were inadvertently changed to Implicit, and improved updater code so that Potential speech wouldn't get updated in the future.
Also added check in integrity tests to make sure quote position is not set for quote types where it makes no sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/845)
<!-- Reviewable:end -->
