### PR TITLE
PTX-22920: Reverted the changes from Normal, Dialogue, and Quotation to Implicit

### DIFF
--- a/ControlDataIntegrityTests/CharacterVerseDataTests.cs
+++ b/ControlDataIntegrityTests/CharacterVerseDataTests.cs
@@ -105,16 +105,8 @@ namespace ControlDataIntegrityTests
 				if (!IsNullOrEmpty(sPosition))
 				{
 					Assert.IsTrue(Enum.TryParse(sPosition, out QuotePosition position), "Invalid QuotePosition: " + sPosition);
-					if (position == QuotePosition.EntireVerse)
-					{
-						Assert.That(type, Is.EqualTo(QuoteType.Implicit)
-							.Or.EqualTo(QuoteType.ImplicitWithPotentialSelfQuote), "Line: " + line);
-					}
-					else
-					{
-						Assert.That(type, Is.Not.EqualTo(QuoteType.Implicit)
-							.And.Not.EqualTo(QuoteType.ImplicitWithPotentialSelfQuote), "Line: " + line);
-					}
+					if (type == QuoteType.Implicit || type == QuoteType.ImplicitWithPotentialSelfQuote)
+						Assert.That(position, Is.EqualTo(QuotePosition.EntireVerse), "Line: " + line);
 
 					Assert.False(type.IsOneOf(QuoteType.Potential, QuoteType.Rare, QuoteType.Alternate,
 						QuoteType.Indirect, QuoteType.Interruption), "Line: " + line);

--- a/ControlDataIntegrityTests/CharacterVerseDataTests.cs
+++ b/ControlDataIntegrityTests/CharacterVerseDataTests.cs
@@ -111,6 +111,14 @@ namespace ControlDataIntegrityTests
 					Assert.False(type.IsOneOf(QuoteType.Potential, QuoteType.Rare, QuoteType.Alternate,
 						QuoteType.Indirect, QuoteType.Interruption), "Line: " + line);
 				}
+				else
+				{
+					// For consistency and simplicity, we require that the quote position be set to
+					// EntireVerse for Implicit quotes (even though it could be unambiguously
+					// inferred from the quote type).
+					Assert.That(type, Is.Not.EqualTo(QuoteType.Implicit).And
+						.Not.EqualTo(QuoteType.ImplicitWithPotentialSelfQuote), "Line: " + line);
+				}
 
 				var extraSpacesMatch = extraSpacesRegex.Match(line);
 				Assert.IsFalse(extraSpacesMatch.Success, "Line with extra space(s): " + line);

--- a/DevTools/CharacterVerseUpdater.cs
+++ b/DevTools/CharacterVerseUpdater.cs
@@ -73,9 +73,24 @@ namespace DevTools
 				}
 
 				var cv = ControlCharacterVerseData.Singleton.ProcessLine(items, line.Number).Single();
+
+				// For re-processing purposes, we normally don't want to change anything
+				// that has already been set (in case some lines have been manually tweaked).
+				// Comment this block out to forcibly reprocess.
+				if (cv.ExpectedPosition != QuotePosition.Unspecified)
+				{
+					sb.Append(line.Contents).Append(Environment.NewLine);
+					continue;
+				}
+
+				if (cv.IsImplicit)
+				{
+					SetQuotePosition(cv, items, sb, line.Contents, QuotePosition.EntireVerse);
+					continue;
+				}
+
 				if (cv.QuoteType == QuoteType.Indirect || cv.QuoteType == QuoteType.Interruption ||
-				    cv.QuoteType == QuoteType.Implicit || cv.QuoteType == QuoteType.Rare ||
-				    cv.QuoteType == QuoteType.Potential ||
+				    cv.QuoteType == QuoteType.Rare || cv.QuoteType == QuoteType.Potential ||
 				    NarratorOverrides.GetCharacterOverrideDetailsForRefRange(new VerseRef(cv.BcvRef.BBCCCVVV, ScrVers.English),
 					    cv.Verse).Any() ||
 				    ControlCharacterVerseData.Singleton.GetCharacters(cv.Book, cv.Chapter, cv.Verse)

--- a/DevTools/CharacterVerseUpdater.cs
+++ b/DevTools/CharacterVerseUpdater.cs
@@ -123,13 +123,6 @@ namespace DevTools
 		private static void SetQuotePosition(GlyssenCharacters.CharacterVerse cv, string[] items, StringBuilder sb,
 			string line, QuotePosition position)
 		{
-			if (position == QuotePosition.EntireVerse &&
-			    items[CharacterVerseData.kiQuoteType] != QuoteType.Implicit.ToString() &&
-			    items[CharacterVerseData.kiQuoteType] != QuoteType.ImplicitWithPotentialSelfQuote.ToString() &&
-			    !ControlCharacterVerseData.GetOtherEntriesIncompatibleWithImplicitCv(cv).Any())
-			{
-				items[CharacterVerseData.kiQuoteType] = QuoteType.Implicit.ToString();
-			}
 			var sPos = position.ToString();
 			if (items.Length > CharacterVerseData.kiQuotePosition)
 			{

--- a/DevTools/Program.cs
+++ b/DevTools/Program.cs
@@ -26,7 +26,7 @@ namespace DevTools
 			Console.WriteLine("12) Obfuscate proprietary reference texts to make testing resources (output in GlyssenTests/Resources/temporary)");
 			Console.WriteLine("13) Generate reference text book title and chapter label summary");
 			Console.WriteLine("14) Create new English reference text (see comments in the Mode enum in ReferenceTextUtility). May append OT or NT.");
-			Console.WriteLine("15) Update Normal to Implicit based on Paratext resource texts. (Paratext dev use only. Requires unzipping Paratext resources.)");
+			Console.WriteLine("15) Set QuotePosition based on Paratext resource texts. (Paratext dev use only. Requires unzipping Paratext resources.)");
 			Console.WriteLine("16) Exit without doing anything.");
 
 			int command = -1;
@@ -43,7 +43,7 @@ namespace DevTools
 						ReferenceTextUtility.OnMessageRaised += (msg, error) => { Console.WriteLine(msg); };
 				}
 
-				if (command >= 1 && command <= 15)
+				if (command >= 1 && command <= 16)
 					break;
 				Console.WriteLine("Invalid option");
 

--- a/GlyssenCharacters/Resources/CharacterVerse.txt
+++ b/GlyssenCharacters/Resources/CharacterVerse.txt
@@ -7258,7 +7258,7 @@ EZR	8	28	narrator-EZR			Quotation
 EZR	8	29	narrator-EZR			Quotation			
 EZR	9	1	leaders			Normal			
 EZR	9	2	leaders			Normal			
-EZR	9	6-15	narrator-EZR			ImplicitWithPotentialSelfQuote			
+EZR	9	6-15	narrator-EZR			ImplicitWithPotentialSelfQuote			EntireVerse
 EZR	9	6	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate			
 EZR	9	7	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate			
 EZR	9	8	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate			
@@ -7283,7 +7283,7 @@ EZR	10	14	assembly, whole			Normal			EntireVerse
 # then let Glyssen apply the narrator override to the second block.
 NEH	1	2	Nehemiah			Indirect			
 NEH	1	3	Hanani, brother of Nehemiah/Judah, men of		Hanani/men of Judah	Normal	Hanani, brother of Nehemiah		
-NEH	1	5-11	narrator-NEH			ImplicitWithPotentialSelfQuote			
+NEH	1	5-11	narrator-NEH			ImplicitWithPotentialSelfQuote			EntireVerse
 NEH	1	5	Nehemiah	praying		Alternate			
 NEH	1	6	Nehemiah	praying		Alternate			
 NEH	1	7	Nehemiah	praying		Alternate			
@@ -11562,7 +11562,7 @@ JER	28	16	God		God (Yahweh)	Quotation			Unspecified
 # not put it in first-level quotes. Whether the quotes it contains are regarded as
 # "self quotes" depends on which character is chosen to speak it. The embedded quotes
 # are actually God, not Jeremish.
-JER	29	4-23	Jeremiah	letter	Jeremiah (Yahweh says)	ImplicitWithPotentialSelfQuote			
+JER	29	4-23	Jeremiah	letter	Jeremiah (Yahweh says)	ImplicitWithPotentialSelfQuote			EntireVerse
 JER	29	4-23	Elasah, son of Shaphan/Gemariah, son of Hilkiah	letter		Alternate			
 JER	29	4-23	God		God (Yahweh)	Alternate			
 JER	29	24	God		God (Yahweh)	Potential			
@@ -14544,7 +14544,7 @@ DAN	8	26	Daniel	vision		Alternate
 DAN	9	1	Daniel	vision		Potential			
 DAN	9	2	Daniel	vision		Potential			
 DAN	9	3	Daniel	vision		Potential			
-DAN	9	4-19	narrator-DAN			ImplicitWithPotentialSelfQuote			
+DAN	9	4-19	narrator-DAN			ImplicitWithPotentialSelfQuote			EntireVerse
 DAN	9	4-19	Daniel	prayer of repentance		Alternate			
 DAN	9	20	Daniel	vision		Potential			
 DAN	9	21	Daniel	vision		Potential			

--- a/GlyssenCharacters/Resources/CharacterVerse.txt
+++ b/GlyssenCharacters/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	167
+Control File Version	168
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage	Quote Position
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5
 GEN	1	3	God		God (Yahweh)	Normal			ContainedWithinVerse
@@ -22,14 +22,14 @@ GEN	1	28	God	blessing	God (Yahweh)	Normal			EndOfVerse
 GEN	1	29	God		God (Yahweh)	Normal			Unspecified
 GEN	1	30	God		God (Yahweh)	Normal			Unspecified
 GEN	2	16	God		God (Yahweh)	Normal			EndOfVerse
-GEN	2	17	God		God (Yahweh)	Implicit			EntireVerse
+GEN	2	17	God		God (Yahweh)	Normal			EntireVerse
 GEN	2	18	God		God (Yahweh)	Normal			EndOfVerse
 GEN	2	23	Adam			Normal			EndOfVerse
 GEN	3	1	serpent			Normal			EndOfVerse
 GEN	3	2	Eve			Normal			Unspecified
-GEN	3	3	Eve			Implicit			EntireVerse
+GEN	3	3	Eve			Normal			EntireVerse
 GEN	3	4	serpent			Normal			Unspecified
-GEN	3	5	serpent			Implicit			EntireVerse
+GEN	3	5	serpent			Normal			EntireVerse
 GEN	3	9	God	calling out	God (Yahweh)	Normal			EndOfVerse
 GEN	3	10	Adam			Normal			EndOfVerse
 GEN	3	11	God		God (Yahweh)	Normal			Unspecified
@@ -37,26 +37,26 @@ GEN	3	12	Adam			Normal			Unspecified
 GEN	3	13	Eve			Normal			
 GEN	3	13	God		God (Yahweh)	Normal			
 GEN	3	14	God		God (Yahweh)	Normal			EndOfVerse
-GEN	3	15	God		God (Yahweh)	Implicit			EntireVerse
+GEN	3	15	God		God (Yahweh)	Normal			EntireVerse
 GEN	3	16	God		God (Yahweh)	Normal			EndOfVerse
 GEN	3	17	God		God (Yahweh)	Normal			EndOfVerse
-GEN	3	18	God		God (Yahweh)	Implicit			EntireVerse
-GEN	3	19	God		God (Yahweh)	Implicit			EntireVerse
+GEN	3	18	God		God (Yahweh)	Normal			EntireVerse
+GEN	3	19	God		God (Yahweh)	Normal			EntireVerse
 GEN	3	22	God		God (Yahweh)	Normal			EndOfVerse
 GEN	4	1	Eve			Normal			EndOfVerse
 GEN	4	6	God		God (Yahweh)	Normal			EndOfVerse
-GEN	4	7	God		God (Yahweh)	Implicit			EntireVerse
+GEN	4	7	God		God (Yahweh)	Normal			EntireVerse
 GEN	4	8	Cain			Normal			Unspecified
 GEN	4	9	God		God (Yahweh)	Normal			
 GEN	4	9	Cain			Normal			
 GEN	4	10	God		God (Yahweh)	Normal			Unspecified
-GEN	4	11	God		God (Yahweh)	Implicit			EntireVerse
-GEN	4	12	God		God (Yahweh)	Implicit			EntireVerse
+GEN	4	11	God		God (Yahweh)	Normal			EntireVerse
+GEN	4	12	God		God (Yahweh)	Normal			EntireVerse
 GEN	4	13	Cain			Normal			Unspecified
-GEN	4	14	Cain			Implicit			EntireVerse
+GEN	4	14	Cain			Normal			EntireVerse
 GEN	4	15	God		God (Yahweh)	Normal			Unspecified
 GEN	4	23	Lamech (descendent of Cain)			Normal			EndOfVerse
-GEN	4	24	Lamech (descendent of Cain)			Implicit			EntireVerse
+GEN	4	24	Lamech (descendent of Cain)			Normal			EntireVerse
 GEN	4	25	Eve			Normal			EndOfVerse
 GEN	5	2	narrator-GEN			Quotation			ContainedWithinVerse
 #Languages which do not allow indirect speech may have God speak to assign the name to Man.								
@@ -66,20 +66,20 @@ GEN	6	3	God		God (Yahweh)	Normal			EndOfVerse
 GEN	6	6	God		God (Yahweh)	Indirect			
 GEN	6	7	God		God (Yahweh)	Normal			EndOfVerse
 GEN	6	13	God		God (Yahweh)	Normal			EndOfVerse
-GEN	6	14	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	15	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	16	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	17	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	18	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	19	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	20	God		God (Yahweh)	Implicit			EntireVerse
-GEN	6	21	God		God (Yahweh)	Implicit			EntireVerse
+GEN	6	14	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	15	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	16	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	17	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	18	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	19	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	20	God		God (Yahweh)	Normal			EntireVerse
+GEN	6	21	God		God (Yahweh)	Normal			EntireVerse
 GEN	7	1	God		God (Yahweh)	Normal			EndOfVerse
-GEN	7	2	God		God (Yahweh)	Implicit			EntireVerse
-GEN	7	3	God		God (Yahweh)	Implicit			EntireVerse
-GEN	7	4	God		God (Yahweh)	Implicit			EntireVerse
-GEN	8	16	God		God (Yahweh)	Implicit			EntireVerse
-GEN	8	17	God		God (Yahweh)	Implicit			EntireVerse
+GEN	7	2	God		God (Yahweh)	Normal			EntireVerse
+GEN	7	3	God		God (Yahweh)	Normal			EntireVerse
+GEN	7	4	God		God (Yahweh)	Normal			EntireVerse
+GEN	8	16	God		God (Yahweh)	Normal			EntireVerse
+GEN	8	17	God		God (Yahweh)	Normal			EntireVerse
 GEN	8	21	God	said in his heart	God (Yahweh)	Normal			Unspecified
 GEN	8	22	God		God (Yahweh)	Normal			Unspecified
 GEN	9	1	God		God (Yahweh)	Normal			EndOfVerse
@@ -108,7 +108,7 @@ GEN	10	9	narrator-GEN			Quotation			EndOfVerse
 GEN	11	3	men of Babel			Normal			Unspecified
 GEN	11	4	men of Babel			Normal			Unspecified
 GEN	11	6	God		God (Yahweh)	Normal			EndOfVerse
-GEN	11	7	God		God (Yahweh)	Implicit			EntireVerse
+GEN	11	7	God		God (Yahweh)	Normal			EntireVerse
 GEN	12	1	God		God (Yahweh)	Normal			EndOfVerse
 GEN	12	2	God		God (Yahweh)	Implicit			
 GEN	12	3	God		God (Yahweh)	Implicit			
@@ -117,9 +117,9 @@ GEN	12	11	Abraham (Abram)			Normal			EndOfVerse
 GEN	12	12	Abraham (Abram)			Implicit			
 GEN	12	13	Abraham (Abram)			Implicit			
 GEN	12	18	Pharaoh (1st)		Pharaoh	Normal			EndOfVerse
-GEN	12	19	Pharaoh (1st)		Pharaoh	Implicit			EntireVerse
+GEN	12	19	Pharaoh (1st)		Pharaoh	Normal			EntireVerse
 GEN	13	8	Abraham (Abram)			Normal			EndOfVerse
-GEN	13	9	Abraham (Abram)			Implicit			EntireVerse
+GEN	13	9	Abraham (Abram)			Normal			EntireVerse
 GEN	13	14	God		God (Yahweh)	Normal			EndOfVerse
 GEN	13	15	God		God (Yahweh)	Implicit			
 GEN	13	16	God		God (Yahweh)	Implicit			
@@ -194,7 +194,7 @@ GEN	18	9	angels at Sodom, two/God		three men (two angels, plus Yahweh)	Alternate
 GEN	18	10	God		God (Yahweh)	Normal			Unspecified
 GEN	18	12	Sarah (Sarai) (old)			Normal			EndOfVerse
 GEN	18	13	God		God (Yahweh)	Normal			EndOfVerse
-GEN	18	14	God		God (Yahweh)	Implicit			EntireVerse
+GEN	18	14	God		God (Yahweh)	Normal			EntireVerse
 GEN	18	15	God		God (Yahweh)	Normal			
 GEN	18	15	Sarah (Sarai) (old)			Normal			
 GEN	18	17	God		God (Yahweh)	Normal			EndOfVerse
@@ -203,8 +203,8 @@ GEN	18	19	God		God (Yahweh)	Implicit
 GEN	18	20	God		God (Yahweh)	Normal			EndOfVerse
 GEN	18	21	God		God (Yahweh)	Implicit			
 GEN	18	23	Abraham (Abram)			Normal			EndOfVerse
-GEN	18	24	Abraham (Abram)			Implicit			EntireVerse
-GEN	18	25	Abraham (Abram)			Implicit			EntireVerse
+GEN	18	24	Abraham (Abram)			Normal			EntireVerse
+GEN	18	25	Abraham (Abram)			Normal			EntireVerse
 GEN	18	26	God		God (Yahweh)	Normal			EndOfVerse
 GEN	18	27	Abraham (Abram)			Normal			EndOfVerse
 GEN	18	28	Abraham (Abram)			Normal			
@@ -242,7 +242,7 @@ GEN	20	3	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 GEN	20	4	Abimelech 1, king of the Philistines (in Gerar)		Abimelech, king of Gerar	Normal			EndOfVerse
 GEN	20	5	Abimelech 1, king of the Philistines (in Gerar)		Abimelech, king of Gerar	Normal			Unspecified
 GEN	20	6	God		God (Yahweh) (in vision)	Normal			Unspecified
-GEN	20	7	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	20	7	God		God (Yahweh) (in vision)	Normal			EntireVerse
 GEN	20	9	Abimelech 1, king of the Philistines (in Gerar)		Abimelech, king of Gerar	Normal			EndOfVerse
 GEN	20	10	Abimelech 1, king of the Philistines (in Gerar)		Abimelech, king of Gerar	Normal			Unspecified
 GEN	20	11	Abraham (Abram)			Normal			Unspecified
@@ -254,7 +254,7 @@ GEN	21	6	Sarah (Sarai) (old)			Normal			EndOfVerse
 GEN	21	7	Sarah (Sarai) (old)			Normal			Unspecified
 GEN	21	10	Sarah (Sarai) (old)			Normal			EndOfVerse
 GEN	21	12	God		God (Yahweh)	Normal			EndOfVerse
-GEN	21	13	God		God (Yahweh)	Implicit			EntireVerse
+GEN	21	13	God		God (Yahweh)	Normal			EntireVerse
 GEN	21	16	Hagar, Sarai's maid			Normal			Unspecified
 # Although the expression "angel of God" here uses Elohim rather than YHWH, the words spoken
 # suggest that this is in fact the voice of God, which can then be treated as a theophany (which
@@ -263,9 +263,9 @@ GEN	21	16	Hagar, Sarai's maid			Normal			Unspecified
 # angel who is understood to be speaking God's very words. In any case, this is a casting decision
 # and not an actual ambiguity in the text.
 GEN	21	17	Yahweh's angel		angel of God	Normal	Jesus		EndOfVerse
-GEN	21	18	Yahweh's angel		angel of God	Implicit	Jesus		EntireVerse
+GEN	21	18	Yahweh's angel		angel of God	Normal	Jesus		EntireVerse
 GEN	21	22	Abimelech 1, king of the Philistines (in Gerar)/Phicol		Abimelech and Phicol	Normal			EndOfVerse
-GEN	21	23	Abimelech 1, king of the Philistines (in Gerar)/Phicol		Abimelech and Phicol	Implicit			EntireVerse
+GEN	21	23	Abimelech 1, king of the Philistines (in Gerar)/Phicol		Abimelech and Phicol	Normal			EntireVerse
 GEN	21	24	Abraham (Abram)			Normal			Unspecified
 GEN	21	26	Abimelech 1, king of the Philistines (in Gerar)		Abimelech	Normal			Unspecified
 GEN	21	29	Abimelech 1, king of the Philistines (in Gerar)		Abimelech	Normal			EndOfVerse
@@ -285,28 +285,28 @@ GEN	22	14	narrator-GEN			Quotation			ContainedWithinVerse
 GEN	22	14	Abraham (Abram)			Indirect			
 GEN	22	14	Needs Review			Quotation			Unspecified
 GEN	22	16	Yahweh's angel	calling out from the sky		Normal	Jesus		Unspecified
-GEN	22	17	Yahweh's angel	calling out from the sky		Implicit	Jesus		EntireVerse
-GEN	22	18	Yahweh's angel	calling out from the sky		Implicit	Jesus		EntireVerse
+GEN	22	17	Yahweh's angel	calling out from the sky		Normal	Jesus		EntireVerse
+GEN	22	18	Yahweh's angel	calling out from the sky		Normal	Jesus		EntireVerse
 GEN	22	20	messenger to Abraham			Normal			Unspecified
 GEN	22	21	messenger to Abraham			Normal			Unspecified
 GEN	22	22	messenger to Abraham			Normal			Unspecified
-GEN	23	4	Abraham (Abram)			Implicit			EntireVerse
+GEN	23	4	Abraham (Abram)			Normal			EntireVerse
 GEN	23	6	Hittites			Normal			Unspecified
 GEN	23	8	Abraham (Abram)			Normal			EndOfVerse
-GEN	23	9	Abraham (Abram)			Implicit			EntireVerse
-GEN	23	11	Ephron the Hittite			Implicit			EntireVerse
+GEN	23	9	Abraham (Abram)			Normal			EntireVerse
+GEN	23	11	Ephron the Hittite			Normal			EntireVerse
 GEN	23	13	Abraham (Abram)			Normal			EndOfVerse
 GEN	23	15	Ephron the Hittite			Normal			Unspecified
 GEN	24	2	Abraham (Abram)			Normal			EndOfVerse
-GEN	24	3	Abraham (Abram)			Implicit			EntireVerse
-GEN	24	4	Abraham (Abram)			Implicit			EntireVerse
+GEN	24	3	Abraham (Abram)			Normal			EntireVerse
+GEN	24	4	Abraham (Abram)			Normal			EntireVerse
 GEN	24	5	Abraham's chief servant			Normal			Unspecified
 GEN	24	6	Abraham (Abram)			Normal			Unspecified
-GEN	24	7	Abraham (Abram)			Implicit			EntireVerse
-GEN	24	8	Abraham (Abram)			Implicit			EntireVerse
+GEN	24	7	Abraham (Abram)			Normal			EntireVerse
+GEN	24	8	Abraham (Abram)			Normal			EntireVerse
 GEN	24	12	Abraham's chief servant	praying		Normal			EndOfVerse
-GEN	24	13	Abraham's chief servant	praying		Implicit			EntireVerse
-GEN	24	14	Abraham's chief servant	praying		Implicit			EntireVerse
+GEN	24	13	Abraham's chief servant	praying		Normal			EntireVerse
+GEN	24	14	Abraham's chief servant	praying		Normal			EntireVerse
 GEN	24	17	Abraham's chief servant			Normal			EndOfVerse
 GEN	24	18	Rebekah			Normal			Unspecified
 GEN	24	19	Rebekah			Normal			Unspecified
@@ -320,24 +320,24 @@ GEN	24	30	Needs Review			Quotation			ContainedWithinVerse
 GEN	24	31	Laban			Normal			Unspecified
 GEN	24	33	Abraham's chief servant			Normal			
 GEN	24	33	Laban			Normal			
-GEN	24	34	Abraham's chief servant			Normal			Unspecified
-GEN	24	35	Abraham's chief servant			Normal			Unspecified
-GEN	24	36	Abraham's chief servant			Normal			Unspecified
-GEN	24	37	Abraham's chief servant			Normal			Unspecified
-GEN	24	38	Abraham's chief servant			Implicit			EntireVerse
-GEN	24	39	Abraham's chief servant			Normal			Unspecified
-GEN	24	40	Abraham's chief servant			Normal			Unspecified
-GEN	24	41	Abraham's chief servant			Implicit			EntireVerse
-GEN	24	42	Abraham's chief servant			Normal			Unspecified
-GEN	24	43	Abraham's chief servant			Implicit			EntireVerse
-GEN	24	44	Abraham's chief servant			Implicit			EntireVerse
-GEN	24	45	Abraham's chief servant			Normal			Unspecified
-GEN	24	46	Abraham's chief servant			Normal			Unspecified
-GEN	24	47	Abraham's chief servant			Normal			Unspecified
-GEN	24	48	Abraham's chief servant			Implicit			EntireVerse
-GEN	24	49	Abraham's chief servant			Implicit			EntireVerse
+GEN	24	34	Abraham's chief servant			Normal			EndOfVerse
+GEN	24	35	Abraham's chief servant			Implicit			
+GEN	24	36	Abraham's chief servant			Implicit			
+GEN	24	37	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	38	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	39	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	40	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	41	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	42	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	43	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	44	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	45	Abraham's chief servant			Implicit			
+GEN	24	46	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	47	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	48	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
+GEN	24	49	Abraham's chief servant			Implicit			
 GEN	24	50	Laban/Bethuel, Rebekah's father			Normal	Laban		EndOfVerse
-GEN	24	51	Laban/Bethuel, Rebekah's father			Implicit	Laban		EntireVerse
+GEN	24	51	Laban/Bethuel, Rebekah's father			Normal	Laban		EntireVerse
 GEN	24	54	Abraham's chief servant			Normal			EndOfVerse
 GEN	24	55	Laban/Rebekah's mother			Normal			Unspecified
 GEN	24	56	Abraham's chief servant			Normal			Unspecified
@@ -354,8 +354,8 @@ GEN	25	31	Jacob (Israel)			Normal			Unspecified
 GEN	25	32	Esau			Normal			Unspecified
 GEN	25	33	Jacob (Israel)			Normal			Unspecified
 GEN	26	2	God		God (Yahweh)	Normal			EndOfVerse
-GEN	26	3	God		God (Yahweh)	Implicit			EntireVerse
-GEN	26	4	God		God (Yahweh)	Implicit			EntireVerse
+GEN	26	3	God		God (Yahweh)	Normal			EntireVerse
+GEN	26	4	God		God (Yahweh)	Normal			EntireVerse
 GEN	26	5	God		God (Yahweh)	Normal			Unspecified
 GEN	26	7	men of Gerar			Indirect			
 GEN	26	7	Isaac	deceiving		Normal			
@@ -372,21 +372,21 @@ GEN	26	22	Isaac			Normal			Unspecified
 GEN	26	24	God		God (Yahweh)	Normal			EndOfVerse
 GEN	26	27	Isaac			Normal			EndOfVerse
 GEN	26	28	Abimelech 2, king of the Philistines (in Gerar)		Abimelech, king of the Philistines	Normal			Unspecified
-GEN	26	29	Abimelech 2, king of the Philistines (in Gerar)		Abimelech, king of the Philistines	Implicit			EntireVerse
+GEN	26	29	Abimelech 2, king of the Philistines (in Gerar)		Abimelech, king of the Philistines	Normal			EntireVerse
 GEN	26	32	servants of Isaac			Normal			EndOfVerse
 GEN	26	33	narrator-GEN			Quotation			ContainedWithinVerse
 GEN	27	1	Esau			Normal			
 GEN	27	1	Isaac (old)			Normal			
 GEN	27	2	Isaac (old)			Normal			Unspecified
-GEN	27	3	Isaac (old)			Implicit			EntireVerse
-GEN	27	4	Isaac (old)			Implicit			EntireVerse
+GEN	27	3	Isaac (old)			Normal			EntireVerse
+GEN	27	4	Isaac (old)			Normal			EntireVerse
 GEN	27	6	Rebekah			Normal			EndOfVerse
-GEN	27	7	Rebekah			Implicit			EntireVerse
-GEN	27	8	Rebekah			Implicit			EntireVerse
-GEN	27	9	Rebekah			Implicit			EntireVerse
-GEN	27	10	Rebekah			Implicit			EntireVerse
+GEN	27	7	Rebekah			Normal			EntireVerse
+GEN	27	8	Rebekah			Normal			EntireVerse
+GEN	27	9	Rebekah			Normal			EntireVerse
+GEN	27	10	Rebekah			Normal			EntireVerse
 GEN	27	11	Jacob (Israel)			Normal			Unspecified
-GEN	27	12	Jacob (Israel)			Implicit			EntireVerse
+GEN	27	12	Jacob (Israel)			Normal			EntireVerse
 GEN	27	13	Rebekah			Normal			Unspecified
 GEN	27	18	Isaac (old)			Normal			
 GEN	27	18	Jacob (Israel)			Normal			
@@ -400,8 +400,8 @@ GEN	27	24	Jacob (Israel)			Normal
 GEN	27	25	Isaac (old)			Normal			ContainedWithinVerse
 GEN	27	26	Isaac (old)			Normal			EndOfVerse
 GEN	27	27	Isaac (old)			Normal			EndOfVerse
-GEN	27	28	Isaac (old)			Implicit			EntireVerse
-GEN	27	29	Isaac (old)			Implicit			EntireVerse
+GEN	27	28	Isaac (old)			Normal			EntireVerse
+GEN	27	29	Isaac (old)			Normal			EntireVerse
 GEN	27	31	Esau			Normal			EndOfVerse
 GEN	27	32	Esau			Normal			
 GEN	27	32	Isaac (old)			Normal			
@@ -417,24 +417,24 @@ GEN	27	41	Esau			Normal			EndOfVerse
 GEN	27	42	Rebekah			Normal			
 GEN	27	42	person who informed Rebekah			Rare			
 GEN	27	42	Needs Review			Rare			
-GEN	27	43	Rebekah			Implicit			EntireVerse
-GEN	27	44	Rebekah			Implicit			EntireVerse
-GEN	27	45	Rebekah			Implicit			EntireVerse
+GEN	27	43	Rebekah			Normal			EntireVerse
+GEN	27	44	Rebekah			Normal			EntireVerse
+GEN	27	45	Rebekah			Normal			EntireVerse
 GEN	27	46	Rebekah			Normal			EndOfVerse
 GEN	28	1	Isaac (old)			Normal			EndOfVerse
-GEN	28	2	Isaac (old)			Implicit			EntireVerse
-GEN	28	3	Isaac (old)			Implicit			EntireVerse
-GEN	28	4	Isaac (old)			Implicit			EntireVerse
+GEN	28	2	Isaac (old)			Normal			EntireVerse
+GEN	28	3	Isaac (old)			Normal			EntireVerse
+GEN	28	4	Isaac (old)			Normal			EntireVerse
 GEN	28	6	Isaac (old)			Quotation			ContainedWithinVerse
 GEN	28	6	narrator-GEN			Quotation			ContainedWithinVerse
 GEN	28	13	God		God (Yahweh) (in vision)	Normal			EndOfVerse
-GEN	28	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
-GEN	28	15	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	28	14	God		God (Yahweh) (in vision)	Normal			EntireVerse
+GEN	28	15	God		God (Yahweh) (in vision)	Normal			EntireVerse
 GEN	28	16	Jacob (Israel)			Normal			EndOfVerse
 GEN	28	17	Jacob (Israel)			Normal			EndOfVerse
 GEN	28	20	Jacob (Israel)			Normal			EndOfVerse
-GEN	28	21	Jacob (Israel)			Implicit			EntireVerse
-GEN	28	22	Jacob (Israel)			Implicit			EntireVerse
+GEN	28	21	Jacob (Israel)			Normal			EntireVerse
+GEN	28	22	Jacob (Israel)			Normal			EntireVerse
 GEN	29	4	Jacob (Israel)			Dialogue			Unspecified
 GEN	29	4	shepherds at well			Dialogue			Unspecified
 GEN	29	5	Jacob (Israel)			Dialogue			Unspecified
@@ -452,7 +452,7 @@ GEN	29	20	Jacob (Israel)			Indirect
 GEN	29	21	Jacob (Israel)			Normal			EndOfVerse
 GEN	29	25	Jacob (Israel)			Normal			EndOfVerse
 GEN	29	26	Laban			Normal			EndOfVerse
-GEN	29	27	Laban			Implicit			EntireVerse
+GEN	29	27	Laban			Normal			EntireVerse
 GEN	29	32	Leah			Normal			EndOfVerse
 GEN	29	33	Leah			Normal			Unspecified
 GEN	29	34	Leah			Normal			Unspecified
@@ -473,15 +473,15 @@ GEN	30	20	Leah			Normal			Unspecified
 GEN	30	23	Rachel			Normal			Unspecified
 GEN	30	24	Rachel			Normal			Unspecified
 GEN	30	25	Jacob (Israel)			Normal			EndOfVerse
-GEN	30	26	Jacob (Israel)			Implicit			EntireVerse
+GEN	30	26	Jacob (Israel)			Normal			EntireVerse
 GEN	30	27	Laban			Normal			EndOfVerse
 GEN	30	28	Laban			Normal			Unspecified
 GEN	30	29	Jacob (Israel)			Normal			EndOfVerse
-GEN	30	30	Jacob (Israel)			Implicit			EntireVerse
+GEN	30	30	Jacob (Israel)			Normal			EntireVerse
 GEN	30	31	Laban			Normal			
 GEN	30	31	Jacob (Israel)			Normal			
-GEN	30	32	Jacob (Israel)			Implicit			EntireVerse
-GEN	30	33	Jacob (Israel)			Implicit			EntireVerse
+GEN	30	32	Jacob (Israel)			Normal			EntireVerse
+GEN	30	33	Jacob (Israel)			Normal			EntireVerse
 GEN	30	34	Laban			Normal			Unspecified
 GEN	31	1	Laban's sons			Normal			EndOfVerse
 GEN	31	3	God		God (Yahweh)	Normal			EndOfVerse
@@ -493,29 +493,29 @@ GEN	31	9	Jacob (Israel)			Normal			Unspecified
 GEN	31	10	Jacob (Israel)			Normal			Unspecified
 GEN	31	11	Jacob (Israel)			Normal			Unspecified
 GEN	31	12	Jacob (Israel)			Normal			Unspecified
-GEN	31	13	Jacob (Israel)			Implicit			EntireVerse
+GEN	31	13	Jacob (Israel)			Normal			EntireVerse
 GEN	31	14	Rachel/Leah			Normal	Rachel		EndOfVerse
-GEN	31	15	Rachel/Leah			Implicit	Rachel		EntireVerse
-GEN	31	16	Rachel/Leah			Implicit	Rachel		EntireVerse
+GEN	31	15	Rachel/Leah			Normal	Rachel		EntireVerse
+GEN	31	16	Rachel/Leah			Normal	Rachel		EntireVerse
 GEN	31	22	person who informed Laban			Indirect			
 GEN	31	24	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 GEN	31	26	Laban			Normal			EndOfVerse
-GEN	31	27	Laban			Implicit			EntireVerse
-GEN	31	28	Laban			Implicit			EntireVerse
-GEN	31	29	Laban			Implicit			EntireVerse
-GEN	31	30	Laban			Implicit			EntireVerse
+GEN	31	27	Laban			Normal			EntireVerse
+GEN	31	28	Laban			Normal			EntireVerse
+GEN	31	29	Laban			Normal			EntireVerse
+GEN	31	30	Laban			Normal			EntireVerse
 GEN	31	31	Jacob (Israel)			Normal			EndOfVerse
 GEN	31	32	Jacob (Israel)			Normal			StartOfVerse
 GEN	31	35	Rachel			Normal			ContainedWithinVerse
 GEN	31	36	Jacob (Israel)			Normal			EndOfVerse
-GEN	31	37	Jacob (Israel)			Implicit			EntireVerse
-GEN	31	38	Jacob (Israel)			Implicit			EntireVerse
-GEN	31	39	Jacob (Israel)			Implicit			EntireVerse
-GEN	31	40	Jacob (Israel)			Implicit			EntireVerse
-GEN	31	41	Jacob (Israel)			Implicit			EntireVerse
+GEN	31	37	Jacob (Israel)			Normal			EntireVerse
+GEN	31	38	Jacob (Israel)			Normal			EntireVerse
+GEN	31	39	Jacob (Israel)			Normal			EntireVerse
+GEN	31	40	Jacob (Israel)			Normal			EntireVerse
+GEN	31	41	Jacob (Israel)			Normal			EntireVerse
 GEN	31	42	Jacob (Israel)			Normal			Unspecified
 GEN	31	43	Laban			Normal			EndOfVerse
-GEN	31	44	Laban			Implicit			EntireVerse
+GEN	31	44	Laban			Normal			EntireVerse
 GEN	31	46	Jacob (Israel)			Normal			Unspecified
 GEN	31	47	Jacob (Israel)			Indirect			
 GEN	31	47	Laban			Indirect			
@@ -524,20 +524,20 @@ GEN	31	48	Laban			Normal			Unspecified
 GEN	31	49	Laban			Normal			Unspecified
 GEN	31	50	Laban			Normal			Unspecified
 GEN	31	51	Laban			Normal			Unspecified
-GEN	31	52	Laban			Implicit			EntireVerse
+GEN	31	52	Laban			Normal			EntireVerse
 GEN	31	53	Laban			Normal			StartOfVerse
 GEN	32	2	Jacob (Israel)			Normal			ContainedWithinVerse
 GEN	32	4	Jacob (Israel)			Normal			EndOfVerse
-GEN	32	5	Jacob (Israel)			Implicit			EntireVerse
+GEN	32	5	Jacob (Israel)			Normal			EntireVerse
 GEN	32	6	messengers sent by Jacob			Normal			EndOfVerse
 GEN	32	8	Jacob (Israel)	thought		Normal			EndOfVerse
 GEN	32	9	Jacob (Israel)	praying		Normal			EndOfVerse
-GEN	32	10	Jacob (Israel)	praying		Implicit			EntireVerse
-GEN	32	11	Jacob (Israel)	praying		Implicit			EntireVerse
-GEN	32	12	Jacob (Israel)	praying		Implicit			EntireVerse
+GEN	32	10	Jacob (Israel)	praying		Normal			EntireVerse
+GEN	32	11	Jacob (Israel)	praying		Normal			EntireVerse
+GEN	32	12	Jacob (Israel)	praying		Normal			EntireVerse
 GEN	32	16	Jacob (Israel)			Normal			EndOfVerse
 GEN	32	17	Jacob (Israel)			Normal			EndOfVerse
-GEN	32	18	Jacob (Israel)			Implicit			EntireVerse
+GEN	32	18	Jacob (Israel)			Normal			EntireVerse
 GEN	32	19	Jacob (Israel)			Normal			Unspecified
 GEN	32	20	Jacob (Israel)	thought		Normal			Unspecified
 GEN	32	26	angel who wrestled with Jacob		the man (angel)	Normal			
@@ -557,38 +557,38 @@ GEN	33	10	Jacob (Israel)			Normal			Unspecified
 GEN	33	11	Jacob (Israel)			Normal			StartOfVerse
 GEN	33	12	Esau			Normal			Unspecified
 GEN	33	13	Jacob (Israel)			Normal			EndOfVerse
-GEN	33	14	Jacob (Israel)			Implicit			EntireVerse
+GEN	33	14	Jacob (Israel)			Normal			EntireVerse
 GEN	33	15	Jacob (Israel)			Normal			
 GEN	33	15	Esau			Normal			
 GEN	34	4	Shechem, son of Hamor			Normal			EndOfVerse
 GEN	34	8	Hamor, Hivite ruler			Normal			EndOfVerse
-GEN	34	9	Hamor, Hivite ruler			Implicit			EntireVerse
-GEN	34	10	Hamor, Hivite ruler			Implicit			EntireVerse
+GEN	34	9	Hamor, Hivite ruler			Normal			EntireVerse
+GEN	34	10	Hamor, Hivite ruler			Normal			EntireVerse
 GEN	34	11	Shechem, son of Hamor			Normal			EndOfVerse
-GEN	34	12	Shechem, son of Hamor			Implicit			EntireVerse
+GEN	34	12	Shechem, son of Hamor			Normal			EntireVerse
 GEN	34	14	Simeon/Levi		Jacob's sons	Normal			Unspecified
-GEN	34	15	Simeon/Levi		Jacob's sons	Implicit			EntireVerse
-GEN	34	16	Simeon/Levi		Jacob's sons	Implicit			EntireVerse
-GEN	34	17	Simeon/Levi		Jacob's sons	Implicit			EntireVerse
-GEN	34	21	Hamor, Hivite ruler/Shechem, son of Hamor			Implicit			EntireVerse
-GEN	34	22	Hamor, Hivite ruler/Shechem, son of Hamor			Implicit			EntireVerse
+GEN	34	15	Simeon/Levi		Jacob's sons	Normal			EntireVerse
+GEN	34	16	Simeon/Levi		Jacob's sons	Normal			EntireVerse
+GEN	34	17	Simeon/Levi		Jacob's sons	Normal			EntireVerse
+GEN	34	21	Hamor, Hivite ruler/Shechem, son of Hamor			Normal			EntireVerse
+GEN	34	22	Hamor, Hivite ruler/Shechem, son of Hamor			Normal			EntireVerse
 # We used to default this verse to Shechem, son of Hamor mainly for dramatic reasons but also because it
 # seemed somewhat likely for it to be spoken by an impetuous young man. But since it will alsmot always
 # be part of the same quotation in the preceding verses and since FCBH does not do it this way in their DG,
 # I'm removing the explicit default character specifications.
-GEN	34	23	Hamor, Hivite ruler/Shechem, son of Hamor			Implicit			EntireVerse
+GEN	34	23	Hamor, Hivite ruler/Shechem, son of Hamor			Normal			EntireVerse
 GEN	34	30	Jacob (Israel)			Normal			EndOfVerse
 GEN	34	31	Simeon/Levi			Normal	Simeon		EndOfVerse
 GEN	35	1	God		God (Yahweh)	Normal			EndOfVerse
 GEN	35	2	Jacob (Israel)			Normal			EndOfVerse
-GEN	35	3	Jacob (Israel)			Implicit			EntireVerse
+GEN	35	3	Jacob (Israel)			Normal			EntireVerse
 GEN	35	10	God	blessing	God (Yahweh)	Normal			Unspecified
 GEN	35	11	God		God (Yahweh)	Normal			EndOfVerse
-GEN	35	12	God		God (Yahweh)	Implicit			EntireVerse
+GEN	35	12	God		God (Yahweh)	Normal			EntireVerse
 GEN	35	15	narrator-GEN			Quotation			ContainedWithinVerse
 GEN	35	17	midwife of Rachel			Normal			EndOfVerse
 GEN	37	6	Joseph			Normal			EndOfVerse
-GEN	37	7	Joseph			Implicit			EntireVerse
+GEN	37	7	Joseph			Normal			EntireVerse
 GEN	37	8	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Levi		ContainedWithinVerse
 GEN	37	9	Joseph			Normal			EndOfVerse
 GEN	37	10	Jacob (Israel)			Normal			Unspecified
@@ -600,7 +600,7 @@ GEN	37	16	Joseph			Normal			Unspecified
 GEN	37	17	man (at Shechem)			Normal			Unspecified
 GEN	37	18	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Potential	Levi		
 GEN	37	19	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Levi		EndOfVerse
-GEN	37	20	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Implicit	Levi		EntireVerse
+GEN	37	20	Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Levi		EntireVerse
 GEN	37	21	Reuben			Normal			Unspecified
 GEN	37	22	Reuben			Normal			Unspecified
 GEN	37	26	Judah			Normal			EndOfVerse
@@ -637,55 +637,55 @@ GEN	38	28	midwife of Tamar, daughter-in-law of Judah			Normal			EndOfVerse
 GEN	38	29	midwife of Tamar, daughter-in-law of Judah			Normal			ContainedWithinVerse
 GEN	39	7	Potiphar's wife			Normal			Unspecified
 GEN	39	8	Joseph			Normal			EndOfVerse
-GEN	39	9	Joseph			Implicit			EntireVerse
+GEN	39	9	Joseph			Normal			EntireVerse
 GEN	39	10	Potiphar's wife			Indirect			
 GEN	39	12	Potiphar's wife			Normal			ContainedWithinVerse
 GEN	39	14	Potiphar's wife			Normal			EndOfVerse
-GEN	39	15	Potiphar's wife			Implicit			EntireVerse
+GEN	39	15	Potiphar's wife			Normal			EntireVerse
 GEN	39	17	Potiphar's wife			Normal			EndOfVerse
-GEN	39	18	Potiphar's wife			Implicit			EntireVerse
+GEN	39	18	Potiphar's wife			Normal			EntireVerse
 GEN	39	19	Potiphar's wife			Normal			Unspecified
 GEN	40	7	Joseph			Normal			EndOfVerse
 GEN	40	8	chief cupbearer of Egypt/chief baker of Egypt			Normal	chief baker of Egypt		
 GEN	40	8	Joseph			Normal			
 GEN	40	9	chief cupbearer of Egypt			Normal			EndOfVerse
-GEN	40	10	chief cupbearer of Egypt			Implicit			EntireVerse
-GEN	40	11	chief cupbearer of Egypt			Implicit			EntireVerse
+GEN	40	10	chief cupbearer of Egypt			Normal			EntireVerse
+GEN	40	11	chief cupbearer of Egypt			Normal			EntireVerse
 GEN	40	12	Joseph			Normal			EndOfVerse
-GEN	40	13	Joseph			Implicit			EntireVerse
-GEN	40	14	Joseph			Implicit			EntireVerse
-GEN	40	15	Joseph			Implicit			EntireVerse
+GEN	40	13	Joseph			Normal			EntireVerse
+GEN	40	14	Joseph			Normal			EntireVerse
+GEN	40	15	Joseph			Normal			EntireVerse
 GEN	40	16	chief baker of Egypt			Normal			EndOfVerse
-GEN	40	17	chief baker of Egypt			Implicit			EntireVerse
+GEN	40	17	chief baker of Egypt			Normal			EntireVerse
 GEN	40	18	Joseph			Normal			EndOfVerse
-GEN	40	19	Joseph			Implicit			EntireVerse
+GEN	40	19	Joseph			Normal			EntireVerse
 GEN	41	8	Pharaoh (2nd)		Pharaoh	Indirect			
 GEN	41	9	chief cupbearer of Egypt			Normal			EndOfVerse
-GEN	41	10	chief cupbearer of Egypt			Implicit			EntireVerse
-GEN	41	11	chief cupbearer of Egypt			Implicit			EntireVerse
-GEN	41	12	chief cupbearer of Egypt			Implicit			EntireVerse
-GEN	41	13	chief cupbearer of Egypt			Implicit			EntireVerse
+GEN	41	10	chief cupbearer of Egypt			Normal			EntireVerse
+GEN	41	11	chief cupbearer of Egypt			Normal			EntireVerse
+GEN	41	12	chief cupbearer of Egypt			Normal			EntireVerse
+GEN	41	13	chief cupbearer of Egypt			Normal			EntireVerse
 GEN	41	15	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
 GEN	41	16	Joseph			Normal			Unspecified
 GEN	41	17	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
-GEN	41	18	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	19	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	20	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	21	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	22	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	23	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	41	24	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
+GEN	41	18	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	19	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	20	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	21	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	22	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	23	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	41	24	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
 GEN	41	25	Joseph			Normal			EndOfVerse
-GEN	41	26	Joseph			Implicit			EntireVerse
-GEN	41	27	Joseph			Implicit			EntireVerse
-GEN	41	28	Joseph			Implicit			EntireVerse
-GEN	41	29	Joseph			Implicit			EntireVerse
-GEN	41	30	Joseph			Implicit			EntireVerse
-GEN	41	31	Joseph			Implicit			EntireVerse
-GEN	41	32	Joseph			Implicit			EntireVerse
-GEN	41	33	Joseph			Implicit			EntireVerse
-GEN	41	34	Joseph			Implicit			EntireVerse
-GEN	41	35	Joseph			Implicit			EntireVerse
+GEN	41	26	Joseph			Normal			EntireVerse
+GEN	41	27	Joseph			Normal			EntireVerse
+GEN	41	28	Joseph			Normal			EntireVerse
+GEN	41	29	Joseph			Normal			EntireVerse
+GEN	41	30	Joseph			Normal			EntireVerse
+GEN	41	31	Joseph			Normal			EntireVerse
+GEN	41	32	Joseph			Normal			EntireVerse
+GEN	41	33	Joseph			Normal			EntireVerse
+GEN	41	34	Joseph			Normal			EntireVerse
+GEN	41	35	Joseph			Normal			EntireVerse
 GEN	41	36	Joseph			Normal			Unspecified
 GEN	41	38	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
 GEN	41	39	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
@@ -707,14 +707,14 @@ GEN	42	7	Joseph			Normal
 GEN	42	7	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		
 GEN	42	9	Joseph			Normal			EndOfVerse
 GEN	42	10	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		Unspecified
-GEN	42	11	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Implicit	Dan		EntireVerse
+GEN	42	11	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EntireVerse
 GEN	42	12	Joseph			Normal			Unspecified
 GEN	42	13	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EndOfVerse
 GEN	42	14	Joseph			Normal			EndOfVerse
-GEN	42	15	Joseph			Implicit			EntireVerse
-GEN	42	16	Joseph			Implicit			EntireVerse
+GEN	42	15	Joseph			Normal			EntireVerse
+GEN	42	16	Joseph			Normal			EntireVerse
 GEN	42	18	Joseph			Normal			EndOfVerse
-GEN	42	19	Joseph			Implicit			EntireVerse
+GEN	42	19	Joseph			Normal			EntireVerse
 GEN	42	20	Joseph			Normal			StartOfVerse
 #see Gen 37:2, 35:25 but either Dan or Judah OK								
 GEN	42	21	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EndOfVerse
@@ -728,9 +728,9 @@ GEN	42	28	Dan/Reuben/Levi/Judah/Issachar/Zebulun/Naphtali/Gad/Asher	surprised	br
 GEN	42	28	Levi/Reuben/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher	trembling	Joseph's brothers (not Simeon or Benjamin)	Normal	Levi		
 GEN	42	30	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		Unspecified
 GEN	42	31	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		Unspecified
-GEN	42	32	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Implicit	Dan		EntireVerse
+GEN	42	32	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		EntireVerse
 GEN	42	33	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		Unspecified
-GEN	42	34	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Implicit	Dan		EntireVerse
+GEN	42	34	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		EntireVerse
 GEN	42	36	Jacob (Israel)			Normal			EndOfVerse
 GEN	42	37	Reuben			Normal			EndOfVerse
 GEN	42	38	Jacob (Israel)			Normal			Unspecified
@@ -741,18 +741,18 @@ GEN	43	5	Judah			Normal			Unspecified
 GEN	43	6	Jacob (Israel)			Normal			Unspecified
 GEN	43	7	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Jacob's sons (not Simeon, Joseph, or Benjamin)	Normal	Dan		Unspecified
 GEN	43	8	Judah			Normal			EndOfVerse
-GEN	43	9	Judah			Implicit			EntireVerse
-GEN	43	10	Judah			Implicit			EntireVerse
+GEN	43	9	Judah			Normal			EntireVerse
+GEN	43	10	Judah			Normal			EntireVerse
 GEN	43	11	Jacob (Israel)			Normal			EndOfVerse
-GEN	43	12	Jacob (Israel)			Implicit			EntireVerse
-GEN	43	13	Jacob (Israel)			Implicit			EntireVerse
-GEN	43	14	Jacob (Israel)			Implicit			EntireVerse
+GEN	43	12	Jacob (Israel)			Normal			EntireVerse
+GEN	43	13	Jacob (Israel)			Normal			EntireVerse
+GEN	43	14	Jacob (Israel)			Normal			EntireVerse
 GEN	43	16	Joseph			Normal			EndOfVerse
 GEN	43	18	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher	thought	Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		EndOfVerse
 GEN	43	19	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Potential	Dan		
 GEN	43	20	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		Unspecified
-GEN	43	21	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Implicit	Dan		EntireVerse
-GEN	43	22	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Implicit	Dan		EntireVerse
+GEN	43	21	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		EntireVerse
+GEN	43	22	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers (not Simeon or Benjamin)	Normal	Dan		EntireVerse
 GEN	43	23	steward of Joseph's house			Normal			Unspecified
 GEN	43	25	steward of Joseph's house			Indirect			
 GEN	43	27	Joseph			Normal			EndOfVerse
@@ -762,59 +762,59 @@ GEN	43	31	Joseph			Normal			EndOfVerse
 GEN	44	1	Joseph			Normal			Unspecified
 GEN	44	2	Joseph			Normal			Unspecified
 GEN	44	4	Joseph			Normal			EndOfVerse
-GEN	44	5	Joseph			Implicit			EntireVerse
+GEN	44	5	Joseph			Normal			EntireVerse
 GEN	44	6	steward of Joseph's house			Indirect			
 #In theory, v. 7 and/or 9 could have been spoken by Benjamin (though very unlikely as the youngest) or by Simeon. But since 7-9 is
 #likely to be a single quotation and v. 8 could not have been spoken by Simeon or Benjamin, we'll omit them from the list of possibilities
 # for all three verses.
 GEN	44	7	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EndOfVerse
-GEN	44	8	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Implicit	Dan		EntireVerse
-GEN	44	9	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Implicit	Dan		EntireVerse
+GEN	44	8	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EntireVerse
+GEN	44	9	Reuben/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher		Joseph's brothers	Normal	Dan		EntireVerse
 GEN	44	10	steward of Joseph's house			Normal			Unspecified
 GEN	44	15	Joseph			Normal			EndOfVerse
 GEN	44	16	Judah			Normal			Unspecified
 GEN	44	17	Joseph			Normal			Unspecified
-GEN	44	18	Judah			Normal			Unspecified
-GEN	44	19	Judah			Normal			Unspecified
-GEN	44	20	Judah			Normal			Unspecified
-GEN	44	21	Judah			Normal			Unspecified
-GEN	44	22	Judah			Normal			Unspecified
-GEN	44	23	Judah			Normal			Unspecified
-GEN	44	24	Judah			Normal			Unspecified
-GEN	44	25	Judah			Normal			Unspecified
-GEN	44	26	Judah			Normal			Unspecified
-GEN	44	27	Judah			Normal			Unspecified
-GEN	44	28	Judah			Normal			Unspecified
-GEN	44	29	Judah			Normal			Unspecified
-GEN	44	30	Judah			Implicit			EntireVerse
-GEN	44	31	Judah			Implicit			EntireVerse
-GEN	44	32	Judah			Implicit			EntireVerse
-GEN	44	33	Judah			Implicit			EntireVerse
-GEN	44	34	Judah			Implicit			EntireVerse
-GEN	45	1	Joseph			Normal			Unspecified
-GEN	45	3	Joseph			Normal			Unspecified
-GEN	45	4	Joseph			Normal			Unspecified
-GEN	45	5	Joseph			Normal			Unspecified
-GEN	45	6	Joseph			Normal			Unspecified
-GEN	45	7	Joseph			Normal			Unspecified
-GEN	45	8	Joseph			Normal			Unspecified
-GEN	45	9	Joseph			Normal			Unspecified
-GEN	45	10	Joseph			Implicit			EntireVerse
-GEN	45	11	Joseph			Implicit			EntireVerse
-GEN	45	12	Joseph			Implicit			EntireVerse
-GEN	45	13	Joseph			Implicit			EntireVerse
+GEN	44	18	Judah			Normal			EndOfVerse
+GEN	44	19	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	20	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	21	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	22	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	23	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	24	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	25	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	26	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	27	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	28	Judah			Implicit			
+GEN	44	29	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	30	Judah			Implicit			
+GEN	44	31	Judah			Implicit			
+GEN	44	32	Judah			ImplicitWithPotentialSelfQuote			
+GEN	44	33	Judah			Implicit			
+GEN	44	34	Judah			Implicit			
+GEN	45	1	Joseph			Implicit			
+GEN	45	3	Joseph			Implicit			
+GEN	45	4	Joseph			Implicit			
+GEN	45	5	Joseph			Implicit			
+GEN	45	6	Joseph			Implicit			
+GEN	45	7	Joseph			Implicit			
+GEN	45	8	Joseph			Implicit			
+GEN	45	9	Joseph			ImplicitWithPotentialSelfQuote			
+GEN	45	10	Joseph			ImplicitWithPotentialSelfQuote			
+GEN	45	11	Joseph			ImplicitWithPotentialSelfQuote			
+GEN	45	12	Joseph			Implicit			
+GEN	45	13	Joseph			ImplicitWithPotentialSelfQuote			
 GEN	45	16	news to Pharoah's palace			Indirect			
 GEN	45	17	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
-GEN	45	18	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	45	19	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
-GEN	45	20	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
+GEN	45	18	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	45	19	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
+GEN	45	20	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
 GEN	45	24	Joseph			Normal			EndOfVerse
 GEN	45	26	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Jacob's sons	Normal	Dan		Unspecified
 GEN	45	28	Jacob (Israel)			Normal			EndOfVerse
 GEN	46	2	God		God (in vision)	Normal			
 GEN	46	2	Jacob (Israel)			Normal			
 GEN	46	3	God		God (in vision)	Normal			Unspecified
-GEN	46	4	God		God (in vision)	Implicit			EntireVerse
+GEN	46	4	God		God (in vision)	Normal			EntireVerse
 GEN	46	30	Jacob (Israel)			Normal			EndOfVerse
 GEN	46	31	Joseph			Normal			Unspecified
 GEN	46	32	Joseph			Normal			Unspecified
@@ -825,7 +825,7 @@ GEN	47	3	Pharaoh (2nd)			Normal
 GEN	47	3	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Joseph's brothers (five representatives)	Normal	Dan		
 GEN	47	4	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Joseph's brothers (five representatives)	Normal	Dan		Unspecified
 GEN	47	5	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
-GEN	47	6	Pharaoh (2nd)		Pharaoh	Implicit			EntireVerse
+GEN	47	6	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
 GEN	47	7	Joseph			Indirect			
 GEN	47	8	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
 GEN	47	9	Jacob (Israel)			Normal			Unspecified
@@ -833,9 +833,9 @@ GEN	47	10	Joseph			Indirect
 GEN	47	15	Egyptians, all the			Normal			EndOfVerse
 GEN	47	16	Joseph			Normal			Unspecified
 GEN	47	18	Egyptians, all the			Normal			EndOfVerse
-GEN	47	19	Egyptians, all the			Implicit			EntireVerse
+GEN	47	19	Egyptians, all the			Normal			EntireVerse
 GEN	47	23	Joseph			Normal			EndOfVerse
-GEN	47	24	Joseph			Implicit			EntireVerse
+GEN	47	24	Joseph			Normal			EntireVerse
 GEN	47	25	Egyptians, all the			Normal			Unspecified
 GEN	47	29	Jacob (Israel)			Normal			EndOfVerse
 GEN	47	30	Jacob (Israel)			Normal			
@@ -846,7 +846,7 @@ GEN	48	2	news giver to Jacob			Normal			Unspecified
 GEN	48	3	Jacob (Israel)			Normal			Unspecified
 GEN	48	4	Jacob (Israel)			Normal			Unspecified
 GEN	48	5	Jacob (Israel)			Normal			Unspecified
-GEN	48	6	Jacob (Israel)			Implicit			EntireVerse
+GEN	48	6	Jacob (Israel)			Normal			EntireVerse
 GEN	48	7	Jacob (Israel)			Normal			
 GEN	48	7	narrator-GEN			Interruption			
 GEN	48	8	Jacob (Israel)			Normal			Unspecified
@@ -854,12 +854,12 @@ GEN	48	9	Joseph			Normal
 GEN	48	9	Jacob (Israel)			Normal			
 GEN	48	11	Jacob (Israel)			Normal			EndOfVerse
 GEN	48	15	Jacob (Israel)			Normal			EndOfVerse
-GEN	48	16	Jacob (Israel)			Implicit			EntireVerse
+GEN	48	16	Jacob (Israel)			Normal			EntireVerse
 GEN	48	18	Joseph			Normal			EndOfVerse
 GEN	48	19	Jacob (Israel)			Normal			EndOfVerse
 GEN	48	20	Jacob (Israel)			Normal			ContainedWithinVerse
 GEN	48	21	Jacob (Israel)			Normal			EndOfVerse
-GEN	48	22	Jacob (Israel)			Implicit			EntireVerse
+GEN	48	22	Jacob (Israel)			Normal			EntireVerse
 GEN	49	1	Jacob (Israel)			Normal			Unspecified
 GEN	49	2	Jacob (Israel)			Normal			Unspecified
 GEN	49	3	Jacob (Israel)			Normal			Unspecified
@@ -890,10 +890,10 @@ GEN	49	27	Jacob (Israel)			Normal			Unspecified
 GEN	49	29	Jacob (Israel)			Normal			EndOfVerse
 GEN	49	30	Jacob (Israel)			Normal			Unspecified
 GEN	49	31	Jacob (Israel)			Normal			Unspecified
-GEN	49	32	Jacob (Israel)			Implicit			EntireVerse
+GEN	49	32	Jacob (Israel)			Normal			EntireVerse
 GEN	50	2	Joseph			Indirect			
 GEN	50	4	Joseph			Normal			EndOfVerse
-GEN	50	5	Joseph			Implicit			EntireVerse
+GEN	50	5	Joseph			Normal			EntireVerse
 GEN	50	6	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
 GEN	50	11	Canaanites			Normal			Unspecified
 GEN	50	15	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Joseph's brothers	Normal	Levi		EndOfVerse
@@ -901,12 +901,12 @@ GEN	50	16	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benja
 GEN	50	17	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Joseph's brothers	Normal	Levi		Unspecified
 GEN	50	18	Reuben/Simeon/Levi/Judah/Issachar/Zebulun/Dan/Naphtali/Gad/Asher/Benjamin		Joseph's brothers	Normal	Levi		EndOfVerse
 GEN	50	19	Joseph			Normal			Unspecified
-GEN	50	20	Joseph			Implicit			EntireVerse
+GEN	50	20	Joseph			Normal			EntireVerse
 GEN	50	21	Joseph			Normal			StartOfVerse
 GEN	50	24	Joseph			Normal			EndOfVerse
 GEN	50	25	Joseph			Normal			Unspecified
 EXO	1	9	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
-EXO	1	10	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
+EXO	1	10	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
 EXO	1	16	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
 EXO	1	18	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	1	19	Shiphrah (midwife)/Puah (midwife)		midwives (Shiphrah and Puah)	Normal	Shiphrah (midwife)		EndOfVerse
@@ -930,9 +930,9 @@ EXO	3	4	Moses			Normal
 EXO	3	5	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	6	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	7	God		God (angel of the LORD within burning bush)	Normal			EndOfVerse
-EXO	3	8	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	3	9	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	3	10	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
+EXO	3	8	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	3	9	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	3	10	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
 EXO	3	11	Moses			Normal			EndOfVerse
 EXO	3	12	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	13	Moses			Normal			EndOfVerse
@@ -941,10 +941,10 @@ EXO	3	15	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	16	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	17	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	3	18	God		God (angel of the LORD within burning bush)	Normal			Unspecified
-EXO	3	19	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	3	20	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	3	21	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	3	22	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
+EXO	3	19	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	3	20	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	3	21	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	3	22	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
 EXO	4	1	Moses			Normal			EndOfVerse
 EXO	4	2	God		God (angel of the LORD within burning bush)	Normal			
 EXO	4	2	Moses			Normal			
@@ -957,11 +957,11 @@ EXO	4	8	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	4	9	God		God (angel of the LORD within burning bush)	Normal			Unspecified
 EXO	4	10	Moses			Normal			Unspecified
 EXO	4	11	God		God (angel of the LORD within burning bush)	Normal			Unspecified
-EXO	4	12	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
+EXO	4	12	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
 EXO	4	13	Moses			Normal			Unspecified
 EXO	4	14	God		God (angel of the LORD within burning bush)	Normal			EndOfVerse
-EXO	4	15	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
-EXO	4	16	God		God (angel of the LORD within burning bush)	Implicit			EntireVerse
+EXO	4	15	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
+EXO	4	16	God		God (angel of the LORD within burning bush)	Normal			EntireVerse
 EXO	4	17	God		God (angel of the LORD within burning bush)	Normal			StartOfVerse
 EXO	4	18	Moses			Normal			
 EXO	4	18	Jethro (Reuel), Moses' father-in-law			Normal			
@@ -978,96 +978,96 @@ EXO	5	2	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
 EXO	5	3	Moses/Aaron			Normal	Aaron		Unspecified
 EXO	5	4	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
 EXO	5	5	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
-EXO	5	7	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
-EXO	5	8	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
-EXO	5	9	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
+EXO	5	7	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
+EXO	5	8	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
+EXO	5	9	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
 EXO	5	10	slave drivers, Egyptian			Normal			EndOfVerse
-EXO	5	11	slave drivers, Egyptian			Implicit			EntireVerse
+EXO	5	11	slave drivers, Egyptian			Normal			EntireVerse
 EXO	5	13	slave drivers, Egyptian			Normal			EndOfVerse
 EXO	5	14	slave drivers, Egyptian			Normal			EndOfVerse
 EXO	5	15	Israelite foremen			Normal			EndOfVerse
-EXO	5	16	Israelite foremen			Implicit			EntireVerse
+EXO	5	16	Israelite foremen			Normal			EntireVerse
 EXO	5	17	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
-EXO	5	18	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
+EXO	5	18	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
 EXO	5	19	Pharaoh (3rd)		Pharaoh	Quotation			Unspecified
 EXO	5	19	narrator-EXO			Quotation			Unspecified
 EXO	5	21	Israelite foremen			Normal			Unspecified
 EXO	5	22	Moses			Normal			EndOfVerse
-EXO	5	23	Moses			Implicit			EntireVerse
+EXO	5	23	Moses			Normal			EntireVerse
 EXO	6	1	God		God (Yahweh)	Normal			Unspecified
 EXO	6	2	God		God (Yahweh)	Normal			Unspecified
 EXO	6	3	God		God (Yahweh)	Normal			Unspecified
 EXO	6	4	God		God (Yahweh)	Normal			Unspecified
 EXO	6	5	God		God (Yahweh)	Normal			Unspecified
 EXO	6	6	God		God (Yahweh)	Normal			Unspecified
-EXO	6	7	God		God (Yahweh)	Implicit			EntireVerse
-EXO	6	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	6	7	God		God (Yahweh)	Normal			EntireVerse
+EXO	6	8	God		God (Yahweh)	Normal			EntireVerse
 EXO	6	11	God		God (Yahweh)	Normal			Unspecified
 EXO	6	12	Moses			Normal			EndOfVerse
 EXO	6	26	God		God (Yahweh)	Normal			Unspecified
 EXO	6	29	God		God (Yahweh)	Normal			EndOfVerse
 EXO	6	30	Moses			Normal			EndOfVerse
 EXO	7	1	God		God (Yahweh)	Normal			Unspecified
-EXO	7	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	7	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	7	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	7	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	7	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	7	4	God		God (Yahweh)	Normal			EntireVerse
 EXO	7	5	God		God (Yahweh)	Normal			Unspecified
 EXO	7	9	God		God (Yahweh)	Normal			Unspecified
 EXO	7	14	God		God (Yahweh)	Normal			Unspecified
 EXO	7	15	God		God (Yahweh)	Normal			Unspecified
 EXO	7	16	God		God (Yahweh)	Normal			Unspecified
-EXO	7	17	God		God (Yahweh)	Implicit			EntireVerse
-EXO	7	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	7	17	God		God (Yahweh)	Normal			EntireVerse
+EXO	7	18	God		God (Yahweh)	Normal			EntireVerse
 EXO	7	19	God		God (Yahweh)	Normal			Unspecified
 EXO	8	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	8	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	8	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	8	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	8	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	8	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	8	4	God		God (Yahweh)	Normal			EntireVerse
 EXO	8	5	God		God (Yahweh)	Normal			Unspecified
 EXO	8	8	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	8	9	Moses			Normal			Unspecified
 EXO	8	10	Pharaoh (3rd)		Pharaoh	Normal			
 EXO	8	10	Moses			Normal			
-EXO	8	11	Moses			Implicit			EntireVerse
+EXO	8	11	Moses			Normal			EntireVerse
 EXO	8	16	God		God (Yahweh)	Normal			EndOfVerse
 EXO	8	19	magicians			Normal			Unspecified
 EXO	8	20	God		God (Yahweh)	Normal			EndOfVerse
-EXO	8	21	God		God (Yahweh)	Implicit			EntireVerse
-EXO	8	22	God		God (Yahweh)	Implicit			EntireVerse
-EXO	8	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	8	21	God		God (Yahweh)	Normal			EntireVerse
+EXO	8	22	God		God (Yahweh)	Normal			EntireVerse
+EXO	8	23	God		God (Yahweh)	Normal			EntireVerse
 EXO	8	25	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	8	26	Moses			Normal			Unspecified
-EXO	8	27	Moses			Implicit			EntireVerse
+EXO	8	27	Moses			Normal			EntireVerse
 EXO	8	28	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	8	29	Moses			Normal			Unspecified
 EXO	9	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	9	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	9	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	4	God		God (Yahweh)	Normal			EntireVerse
 EXO	9	5	God		God (Yahweh)	Normal			Unspecified
 EXO	9	8	God		God (Yahweh)	Normal			EndOfVerse
-EXO	9	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	9	9	God		God (Yahweh)	Normal			EntireVerse
 EXO	9	13	God		God (Yahweh)	Normal			EndOfVerse
-EXO	9	14	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	15	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	16	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	17	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	18	God		God (Yahweh)	Implicit			EntireVerse
-EXO	9	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	9	14	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	15	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	16	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	17	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	18	God		God (Yahweh)	Normal			EntireVerse
+EXO	9	19	God		God (Yahweh)	Normal			EntireVerse
 EXO	9	22	God		God (Yahweh)	Normal			EndOfVerse
 EXO	9	27	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
-EXO	9	28	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
+EXO	9	28	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
 EXO	9	29	Moses			Normal			Unspecified
-EXO	9	30	Moses			Implicit			EntireVerse
+EXO	9	30	Moses			Normal			EntireVerse
 # Almost all translators agree that vv. 31-32 are commentary by the narrator, but at least one project
 # continues the quote and has Moses speak these words to Pharaoh.
 EXO	9	31	Moses			Potential			
 EXO	9	32	Moses			Potential			
 EXO	10	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	10	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	10	2	God		God (Yahweh)	Normal			EntireVerse
 EXO	10	3	Moses/Aaron			Normal	Aaron		EndOfVerse
-EXO	10	4	Moses/Aaron			Implicit	Aaron		EntireVerse
-EXO	10	5	Moses/Aaron			Implicit	Aaron		EntireVerse
+EXO	10	4	Moses/Aaron			Normal	Aaron		EntireVerse
+EXO	10	5	Moses/Aaron			Normal	Aaron		EntireVerse
 EXO	10	6	Moses/Aaron			Normal	Aaron		StartOfVerse
 EXO	10	7	Pharaoh's officials			Normal			EndOfVerse
 EXO	10	8	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
@@ -1076,40 +1076,40 @@ EXO	10	10	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
 EXO	10	11	Pharaoh (3rd)		Pharaoh	Normal			StartOfVerse
 EXO	10	12	God		God (Yahweh)	Normal			EndOfVerse
 EXO	10	16	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
-EXO	10	17	Pharaoh (3rd)		Pharaoh	Implicit			EntireVerse
+EXO	10	17	Pharaoh (3rd)		Pharaoh	Normal			EntireVerse
 EXO	10	21	God		God (Yahweh)	Normal			EndOfVerse
 EXO	10	24	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	10	25	Moses			Normal			Unspecified
-EXO	10	26	Moses			Implicit			EntireVerse
+EXO	10	26	Moses			Normal			EntireVerse
 EXO	10	28	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	10	29	Moses			Normal			Unspecified
 EXO	11	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	11	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	11	2	God		God (Yahweh)	Normal			EntireVerse
 EXO	11	4	Moses			Normal			EndOfVerse
-EXO	11	5	Moses			Implicit			EntireVerse
-EXO	11	6	Moses			Implicit			EntireVerse
-EXO	11	7	Moses			Implicit			EntireVerse
+EXO	11	5	Moses			Normal			EntireVerse
+EXO	11	6	Moses			Normal			EntireVerse
+EXO	11	7	Moses			Normal			EntireVerse
 EXO	11	8	Moses			Normal			StartOfVerse
 EXO	11	9	God		God (Yahweh)	Normal			Unspecified
-EXO	12	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	4	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	5	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	6	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	7	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	8	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	9	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	10	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	11	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	12	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	13	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	14	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	15	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	16	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	17	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	18	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	19	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	12	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	4	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	5	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	6	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	7	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	8	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	9	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	10	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	11	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	12	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	13	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	14	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	15	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	16	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	17	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	18	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	19	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	20	God		God (Yahweh)	Normal			EntireVerse
 EXO	12	21	Moses			Normal			Unspecified
 EXO	12	22	Moses			Normal			Unspecified
 EXO	12	23	Moses			Normal			Unspecified
@@ -1121,12 +1121,12 @@ EXO	12	31	Pharaoh (3rd)		Pharaoh	Normal			EndOfVerse
 EXO	12	32	Pharaoh (3rd)		Pharaoh	Normal			Unspecified
 EXO	12	33	Egyptians	terrified		Normal			EndOfVerse
 EXO	12	43	God		God (Yahweh)	Normal			Unspecified
-EXO	12	44	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	45	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	46	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	47	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	48	God		God (Yahweh)	Implicit			EntireVerse
-EXO	12	49	God		God (Yahweh)	Implicit			EntireVerse
+EXO	12	44	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	45	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	46	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	47	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	48	God		God (Yahweh)	Normal			EntireVerse
+EXO	12	49	God		God (Yahweh)	Normal			EntireVerse
 EXO	13	2	God		God (Yahweh)	Normal			Unspecified
 EXO	13	3	Moses			Normal			Unspecified
 EXO	13	4	Moses			Normal			Unspecified
@@ -1140,25 +1140,25 @@ EXO	13	11	Moses			Normal			Unspecified
 EXO	13	12	Moses			Normal			Unspecified
 EXO	13	13	Moses			Normal			Unspecified
 EXO	13	14	Moses			Normal			Unspecified
-EXO	13	15	Moses			Implicit			EntireVerse
+EXO	13	15	Moses			Normal			EntireVerse
 EXO	13	16	Moses			Normal			StartOfVerse
 EXO	13	17	God		God (Yahweh)	Normal			EndOfVerse
 EXO	13	19	Joseph			Quotation			Unspecified
 EXO	13	19	narrator-EXO			Quotation			Unspecified
-EXO	14	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	14	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	14	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	14	3	God		God (Yahweh)	Normal			EntireVerse
 EXO	14	4	God		God (Yahweh)	Normal			StartOfVerse
 EXO	14	5	Pharaoh (3rd)/Pharaoh's officials		Pharaoh/Pharaoh's officials	Normal			
 EXO	14	5	person who informed Pharaoh			Rare			
 EXO	14	5	Needs Review			Rare			
 EXO	14	11	Israelites	terrified		Normal			EndOfVerse
-EXO	14	12	Israelites	terrified		Implicit			EntireVerse
+EXO	14	12	Israelites	terrified		Normal			EntireVerse
 EXO	14	13	Moses			Normal			Unspecified
-EXO	14	14	Moses			Implicit			EntireVerse
+EXO	14	14	Moses			Normal			EntireVerse
 EXO	14	15	God		God (Yahweh)	Normal			EndOfVerse
-EXO	14	16	God		God (Yahweh)	Implicit			EntireVerse
-EXO	14	17	God		God (Yahweh)	Implicit			EntireVerse
-EXO	14	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	14	16	God		God (Yahweh)	Normal			EntireVerse
+EXO	14	17	God		God (Yahweh)	Normal			EntireVerse
+EXO	14	18	God		God (Yahweh)	Normal			EntireVerse
 EXO	14	25	Egyptians	afraid		Normal			EndOfVerse
 EXO	14	26	God		God (Yahweh)	Normal			EndOfVerse
 EXO	15	1	Moses/Israelites	singing		Normal	Moses		Unspecified
@@ -1184,24 +1184,24 @@ EXO	15	24	Israelites	grumbling		Normal			EndOfVerse
 EXO	15	26	God		God (Yahweh)	Normal			EndOfVerse
 EXO	16	3	Israelites	grumbling		Normal			Unspecified
 EXO	16	4	God		God (Yahweh)	Normal			EndOfVerse
-EXO	16	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	16	5	God		God (Yahweh)	Normal			EntireVerse
 EXO	16	6	Moses/Aaron			Normal	Aaron		EndOfVerse
-EXO	16	7	Moses/Aaron			Implicit	Aaron		EntireVerse
+EXO	16	7	Moses/Aaron			Normal	Aaron		EntireVerse
 EXO	16	8	Moses			Normal			EndOfVerse
 EXO	16	9	Moses			Normal			EndOfVerse
 EXO	16	10	Aaron			Rare			
 EXO	16	10	Needs Review			Potential			
-EXO	16	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	16	12	God		God (Yahweh)	Normal			EntireVerse
 EXO	16	15	Israelites	questioning		Normal			
 EXO	16	15	Moses			Normal			
-EXO	16	16	Moses			Implicit			EntireVerse
+EXO	16	16	Moses			Normal			EntireVerse
 EXO	16	19	Moses			Normal			Unspecified
 EXO	16	22	elders of Israel		rulers of the congregation	Potential			
 EXO	16	23	Moses			Normal			Unspecified
 EXO	16	25	Moses			Normal			Unspecified
-EXO	16	26	Moses			Implicit			EntireVerse
+EXO	16	26	Moses			Normal			EntireVerse
 EXO	16	28	God		God (Yahweh)	Normal			EndOfVerse
-EXO	16	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	16	29	God		God (Yahweh)	Normal			EntireVerse
 EXO	16	31	narrator-EXO			Quotation			Unspecified
 EXO	16	32	Moses			Normal			Unspecified
 EXO	16	33	Moses			Normal			EndOfVerse
@@ -1221,56 +1221,56 @@ EXO	18	4	Moses			Normal			Unspecified
 EXO	18	6	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
 EXO	18	8	Moses			Potential			
 EXO	18	10	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
-EXO	18	11	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
+EXO	18	11	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
 EXO	18	14	Jethro (Reuel), Moses' father-in-law			Normal			EndOfVerse
 EXO	18	15	Moses			Normal			Unspecified
-EXO	18	16	Moses			Implicit			EntireVerse
+EXO	18	16	Moses			Normal			EntireVerse
 EXO	18	17	Jethro (Reuel), Moses' father-in-law			Normal			Unspecified
-EXO	18	18	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
-EXO	18	19	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
-EXO	18	20	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
-EXO	18	21	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
-EXO	18	22	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
-EXO	18	23	Jethro (Reuel), Moses' father-in-law			Implicit			EntireVerse
+EXO	18	18	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
+EXO	18	19	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
+EXO	18	20	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
+EXO	18	21	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
+EXO	18	22	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
+EXO	18	23	Jethro (Reuel), Moses' father-in-law			Normal			EntireVerse
 EXO	19	3	God		God (Yahweh)	Normal			Unspecified
-EXO	19	4	God		God (Yahweh)	Implicit			EntireVerse
-EXO	19	5	God		God (Yahweh)	Implicit			EntireVerse
-EXO	19	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	19	4	God		God (Yahweh)	Normal			EntireVerse
+EXO	19	5	God		God (Yahweh)	Normal			EntireVerse
+EXO	19	6	God		God (Yahweh)	Normal			EntireVerse
 EXO	19	8	Israelites			Normal			ContainedWithinVerse
 EXO	19	9	God		God (Yahweh)	Normal			ContainedWithinVerse
 EXO	19	10	God		God (Yahweh)	Normal			EndOfVerse
-EXO	19	11	God		God (Yahweh)	Implicit			EntireVerse
-EXO	19	12	God		God (Yahweh)	Implicit			EntireVerse
-EXO	19	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	19	11	God		God (Yahweh)	Normal			EntireVerse
+EXO	19	12	God		God (Yahweh)	Normal			EntireVerse
+EXO	19	13	God		God (Yahweh)	Normal			EntireVerse
 EXO	19	15	Moses			Normal			Unspecified
 EXO	19	21	God		God (Yahweh)	Normal			EndOfVerse
-EXO	19	22	God		God (Yahweh)	Implicit			EntireVerse
+EXO	19	22	God		God (Yahweh)	Normal			EntireVerse
 EXO	19	23	Moses			Normal			EndOfVerse
 EXO	19	24	God		God (Yahweh)	Normal			EndOfVerse
 EXO	19	25	Moses			Indirect			
-EXO	20	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	4	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	5	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	6	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	7	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	8	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	9	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	10	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	11	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	12	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	13	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	14	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	15	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	20	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	4	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	5	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	6	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	7	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	8	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	9	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	10	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	11	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	12	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	13	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	14	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	15	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	16	God		God (Yahweh)	Normal			EntireVerse
 EXO	20	17	God		God (Yahweh)	Normal			Unspecified
 EXO	20	19	Israelites	fearful		Normal			EndOfVerse
 EXO	20	20	Moses			Normal			Unspecified
 EXO	20	22	God		God (Yahweh)	Normal			EndOfVerse
-EXO	20	23	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	24	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	25	God		God (Yahweh)	Implicit			EntireVerse
-EXO	20	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	20	23	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	24	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	25	God		God (Yahweh)	Normal			EntireVerse
+EXO	20	26	God		God (Yahweh)	Normal			EntireVerse
 EXO	21	1	God		God (Yahweh)	Normal			Unspecified
 EXO	21	2	God		God (Yahweh)	Normal			Unspecified
 EXO	21	3	God		God (Yahweh)	Normal			Unspecified
@@ -1372,7 +1372,7 @@ EXO	23	31	God		God (Yahweh)	Normal			Unspecified
 EXO	23	32	God		God (Yahweh)	Normal			Unspecified
 EXO	23	33	God		God (Yahweh)	Normal			Unspecified
 EXO	24	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	24	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	24	2	God		God (Yahweh)	Normal			EntireVerse
 EXO	24	3	Israelites			Normal			EndOfVerse
 EXO	24	7	Israelites			Normal			EndOfVerse
 EXO	24	8	Moses			Normal			EndOfVerse
@@ -1625,108 +1625,108 @@ EXO	32	8	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EXO	32	9	God		God (Yahweh)	Normal			Unspecified
 EXO	32	10	God		God (Yahweh)	Implicit			
 EXO	32	11	Moses			Normal			EndOfVerse
-EXO	32	12	Moses			Implicit			EntireVerse
-EXO	32	13	Moses			Implicit			EntireVerse
+EXO	32	12	Moses			Normal			EntireVerse
+EXO	32	13	Moses			Normal			EntireVerse
 EXO	32	17	Joshua			Normal			EndOfVerse
 EXO	32	18	Moses			Normal			EndOfVerse
 EXO	32	21	Moses			Normal			EndOfVerse
 EXO	32	22	Aaron			Normal			Unspecified
 EXO	32	23	Aaron			Normal			Unspecified
-EXO	32	24	Aaron			Implicit			EntireVerse
+EXO	32	24	Aaron			Normal			EntireVerse
 EXO	32	26	Moses			Normal			ContainedWithinVerse
 EXO	32	27	Moses			Normal			EndOfVerse
 EXO	32	29	Moses			Normal			EndOfVerse
 EXO	32	30	Moses			Normal			EndOfVerse
 EXO	32	31	Moses			Normal			EndOfVerse
-EXO	32	32	Moses			Implicit			EntireVerse
+EXO	32	32	Moses			Normal			EntireVerse
 EXO	32	33	God		God (Yahweh)	Normal			EndOfVerse
-EXO	32	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	32	34	God		God (Yahweh)	Normal			EntireVerse
 EXO	33	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	33	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	33	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	33	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	33	3	God		God (Yahweh)	Normal			EntireVerse
 EXO	33	5	God		God (Yahweh)	Normal			Unspecified
 EXO	33	7	narrator-EXO			Quotation			Unspecified
 EXO	33	7	Moses			Indirect			
 EXO	33	12	Moses			Normal			EndOfVerse
-EXO	33	13	Moses			Implicit			EntireVerse
+EXO	33	13	Moses			Normal			EntireVerse
 EXO	33	14	God		God (Yahweh)	Normal			Unspecified
 EXO	33	15	Moses			Normal			Unspecified
-EXO	33	16	Moses			Implicit			EntireVerse
+EXO	33	16	Moses			Normal			EntireVerse
 EXO	33	17	God		God (Yahweh)	Normal			Unspecified
 EXO	33	18	Moses			Normal			Unspecified
 EXO	33	19	God		God (Yahweh)	Normal			EndOfVerse
 EXO	33	20	God		God (Yahweh)	Normal			Unspecified
 EXO	33	21	God		God (Yahweh)	Normal			Unspecified
-EXO	33	22	God		God (Yahweh)	Implicit			EntireVerse
-EXO	33	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	33	22	God		God (Yahweh)	Normal			EntireVerse
+EXO	33	23	God		God (Yahweh)	Normal			EntireVerse
 EXO	34	1	God		God (Yahweh)	Normal			EndOfVerse
-EXO	34	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	34	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	3	God		God (Yahweh)	Normal			EntireVerse
 EXO	34	4	Moses			Indirect			
 EXO	34	6	God		God (Yahweh)	Normal			EndOfVerse
-EXO	34	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	34	7	God		God (Yahweh)	Normal			EntireVerse
 EXO	34	9	Moses			Normal			Unspecified
 EXO	34	10	God		God (Yahweh)	Normal			Unspecified
-EXO	34	11	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	12	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	13	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	14	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	15	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	16	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	17	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	18	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	19	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	20	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	21	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	22	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	23	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	24	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	25	God		God (Yahweh)	Implicit			EntireVerse
-EXO	34	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	34	11	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	12	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	13	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	14	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	15	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	16	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	17	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	18	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	19	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	20	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	21	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	22	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	23	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	24	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	25	God		God (Yahweh)	Normal			EntireVerse
+EXO	34	26	God		God (Yahweh)	Normal			EntireVerse
 EXO	34	27	God		God (Yahweh)	Normal			Unspecified
 EXO	35	1	Moses			Normal			Unspecified
-EXO	35	2	Moses			Implicit			EntireVerse
+EXO	35	2	Moses			Normal			EntireVerse
 EXO	35	3	Moses			Normal			StartOfVerse
 EXO	35	4	Moses			Normal			Unspecified
-EXO	35	5	Moses			Implicit			EntireVerse
-EXO	35	6	Moses			Implicit			EntireVerse
-EXO	35	7	Moses			Implicit			EntireVerse
-EXO	35	8	Moses			Implicit			EntireVerse
-EXO	35	9	Moses			Implicit			EntireVerse
-EXO	35	10	Moses			Implicit			EntireVerse
-EXO	35	11	Moses			Implicit			EntireVerse
-EXO	35	12	Moses			Implicit			EntireVerse
-EXO	35	13	Moses			Implicit			EntireVerse
-EXO	35	14	Moses			Implicit			EntireVerse
-EXO	35	15	Moses			Implicit			EntireVerse
-EXO	35	16	Moses			Implicit			EntireVerse
-EXO	35	17	Moses			Implicit			EntireVerse
-EXO	35	18	Moses			Implicit			EntireVerse
+EXO	35	5	Moses			Normal			EntireVerse
+EXO	35	6	Moses			Normal			EntireVerse
+EXO	35	7	Moses			Normal			EntireVerse
+EXO	35	8	Moses			Normal			EntireVerse
+EXO	35	9	Moses			Normal			EntireVerse
+EXO	35	10	Moses			Normal			EntireVerse
+EXO	35	11	Moses			Normal			EntireVerse
+EXO	35	12	Moses			Normal			EntireVerse
+EXO	35	13	Moses			Normal			EntireVerse
+EXO	35	14	Moses			Normal			EntireVerse
+EXO	35	15	Moses			Normal			EntireVerse
+EXO	35	16	Moses			Normal			EntireVerse
+EXO	35	17	Moses			Normal			EntireVerse
+EXO	35	18	Moses			Normal			EntireVerse
 EXO	35	19	Moses			Normal			Unspecified
 EXO	35	30	Moses			Normal			EndOfVerse
-EXO	35	31	Moses			Implicit			EntireVerse
-EXO	35	32	Moses			Implicit			EntireVerse
-EXO	35	33	Moses			Implicit			EntireVerse
-EXO	35	34	Moses			Implicit			EntireVerse
-EXO	35	35	Moses			Implicit			EntireVerse
-EXO	36	1	Moses			Implicit			EntireVerse
+EXO	35	31	Moses			Normal			EntireVerse
+EXO	35	32	Moses			Normal			EntireVerse
+EXO	35	33	Moses			Normal			EntireVerse
+EXO	35	34	Moses			Normal			EntireVerse
+EXO	35	35	Moses			Normal			EntireVerse
+EXO	36	1	Moses			Normal			EntireVerse
 EXO	36	5	craftsman			Normal			EndOfVerse
 EXO	36	6	Moses			Normal			Unspecified
 EXO	39	30	narrator-EXO			Quotation			Unspecified
-EXO	40	2	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	3	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	4	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	5	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	6	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	7	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	8	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	9	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	10	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	11	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	12	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	13	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	14	God		God (Yahweh)	Implicit			EntireVerse
-EXO	40	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	40	2	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	3	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	4	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	5	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	6	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	7	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	8	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	9	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	10	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	11	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	12	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	13	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	14	God		God (Yahweh)	Normal			EntireVerse
+EXO	40	15	God		God (Yahweh)	Normal			EntireVerse
 # In a few of the following chapters, FCBH has God speak all the way through the end. However,
 # some other translations have God's speech end earlier, with the final verse(s) in each section
 # being a summary (spoken by the narrator). So rather than forcing these questionable places to
@@ -1902,24 +1902,24 @@ LEV	8	33	Moses			Implicit
 LEV	8	34	Moses			Implicit			
 LEV	8	35	Moses			Implicit			
 LEV	9	2	Moses			Normal			Unspecified
-LEV	9	3	Moses			Implicit			EntireVerse
-LEV	9	4	Moses			Implicit			EntireVerse
+LEV	9	3	Moses			Normal			EntireVerse
+LEV	9	4	Moses			Normal			EntireVerse
 LEV	9	6	Moses			Normal			EndOfVerse
 LEV	9	7	Moses			Normal			Unspecified
 LEV	10	3	Moses			Normal			ContainedWithinVerse
 LEV	10	4	Moses			Normal			EndOfVerse
 LEV	10	6	Moses			Normal			EndOfVerse
 LEV	10	7	Moses			Normal			StartOfVerse
-LEV	10	9	God		God (Yahweh)	Implicit			EntireVerse
-LEV	10	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	10	9	God		God (Yahweh)	Normal			EntireVerse
+LEV	10	10	God		God (Yahweh)	Normal			EntireVerse
 LEV	10	11	God		God (Yahweh)	Normal			Unspecified
 LEV	10	12	Moses			Normal			EndOfVerse
-LEV	10	13	Moses			Implicit			EntireVerse
-LEV	10	14	Moses			Implicit			EntireVerse
+LEV	10	13	Moses			Normal			EntireVerse
+LEV	10	14	Moses			Normal			EntireVerse
 LEV	10	15	Moses			Normal			Unspecified
 LEV	10	16	Moses			Indirect			
-LEV	10	17	Moses			Implicit			EntireVerse
-LEV	10	18	Moses			Implicit			EntireVerse
+LEV	10	17	Moses			Normal			EntireVerse
+LEV	10	18	Moses			Normal			EntireVerse
 LEV	10	19	Aaron			Normal			EndOfVerse
 LEV	11	2	God		God (Yahweh)	Implicit			
 LEV	11	3	God		God (Yahweh)	Implicit			
@@ -2656,7 +2656,7 @@ NUM	6	26	God		God (Yahweh)	Implicit
 NUM	6	27	God		God (Yahweh)	Implicit			
 NUM	7	5	God		God (Yahweh)	Implicit			
 NUM	7	11	God		God (Yahweh)	Normal			Unspecified
-NUM	8	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	8	2	God		God (Yahweh)	Normal			EntireVerse
 NUM	8	6	God		God (Yahweh)	Normal			Unspecified
 NUM	8	7	God		God (Yahweh)	Normal			Unspecified
 NUM	8	8	God		God (Yahweh)	Normal			Unspecified
@@ -2671,27 +2671,27 @@ NUM	8	16	God		God (Yahweh)	Normal			Unspecified
 NUM	8	17	God		God (Yahweh)	Normal			Unspecified
 NUM	8	18	God		God (Yahweh)	Normal			Unspecified
 NUM	8	19	God		God (Yahweh)	Normal			Unspecified
-NUM	8	24	God		God (Yahweh)	Implicit			EntireVerse
-NUM	8	25	God		God (Yahweh)	Implicit			EntireVerse
-NUM	8	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	8	24	God		God (Yahweh)	Normal			EntireVerse
+NUM	8	25	God		God (Yahweh)	Normal			EntireVerse
+NUM	8	26	God		God (Yahweh)	Normal			EntireVerse
 NUM	9	2	God		God (Yahweh)	Normal			Unspecified
-NUM	9	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	9	3	God		God (Yahweh)	Normal			EntireVerse
 NUM	9	4	Moses			Indirect			
 NUM	9	7	Israelites, some			Normal			Unspecified
 NUM	9	8	Moses			Normal			EndOfVerse
 NUM	9	10	God		God (Yahweh)	Normal			Unspecified
-NUM	9	11	God		God (Yahweh)	Implicit			EntireVerse
-NUM	9	12	God		God (Yahweh)	Implicit			EntireVerse
-NUM	9	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	9	11	God		God (Yahweh)	Normal			EntireVerse
+NUM	9	12	God		God (Yahweh)	Normal			EntireVerse
+NUM	9	13	God		God (Yahweh)	Normal			EntireVerse
 NUM	9	14	God		God (Yahweh)	Normal			StartOfVerse
-NUM	10	2	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	3	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	4	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	5	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	6	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	7	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	8	God		God (Yahweh)	Implicit			EntireVerse
-NUM	10	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	10	2	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	3	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	4	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	5	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	6	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	7	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	8	God		God (Yahweh)	Normal			EntireVerse
+NUM	10	9	God		God (Yahweh)	Normal			EntireVerse
 NUM	10	10	God		God (Yahweh)	Normal			StartOfVerse
 NUM	10	29	Moses			Normal			EndOfVerse
 NUM	10	30	Hobab, Moses brother-in-law			Normal			Unspecified
@@ -2700,20 +2700,20 @@ NUM	10	32	Moses			Normal			Unspecified
 NUM	10	35	Moses			Normal			EndOfVerse
 NUM	10	36	Moses			Normal			EndOfVerse
 NUM	11	4	Israelites	wailing		Normal			EndOfVerse
-NUM	11	5	Israelites	wailing		Implicit			EntireVerse
-NUM	11	6	Israelites	wailing		Implicit			EntireVerse
+NUM	11	5	Israelites	wailing		Normal			EntireVerse
+NUM	11	6	Israelites	wailing		Normal			EntireVerse
 NUM	11	11	Moses			Normal			EndOfVerse
-NUM	11	12	Moses			Implicit			EntireVerse
-NUM	11	13	Moses			Implicit			EntireVerse
-NUM	11	14	Moses			Implicit			EntireVerse
+NUM	11	12	Moses			Normal			EntireVerse
+NUM	11	13	Moses			Normal			EntireVerse
+NUM	11	14	Moses			Normal			EntireVerse
 NUM	11	15	Moses			Normal			StartOfVerse
 NUM	11	16	God		God (Yahweh)	Normal			EndOfVerse
-NUM	11	17	God		God (Yahweh)	Implicit			EntireVerse
-NUM	11	18	God		God (Yahweh)	Implicit			EntireVerse
-NUM	11	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	11	17	God		God (Yahweh)	Normal			EntireVerse
+NUM	11	18	God		God (Yahweh)	Normal			EntireVerse
+NUM	11	19	God		God (Yahweh)	Normal			EntireVerse
 NUM	11	20	God		God (Yahweh)	Normal			Unspecified
 NUM	11	21	Moses			Normal			EndOfVerse
-NUM	11	22	Moses			Implicit			EntireVerse
+NUM	11	22	Moses			Normal			EntireVerse
 NUM	11	23	God		God (Yahweh)	Normal			EndOfVerse
 NUM	11	27	young man	excited		Normal			Unspecified
 NUM	11	28	Joshua			Normal			EndOfVerse
@@ -2722,58 +2722,58 @@ NUM	12	1	Miriam/Aaron			Potential	Miriam
 NUM	12	2	Miriam/Aaron			Normal	Miriam		ContainedWithinVerse
 NUM	12	4	God		God (Yahweh)	Normal			Unspecified
 NUM	12	6	God		God (Yahweh)	Normal			EndOfVerse
-NUM	12	7	God		God (Yahweh)	Implicit			EntireVerse
-NUM	12	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	12	7	God		God (Yahweh)	Normal			EntireVerse
+NUM	12	8	God		God (Yahweh)	Normal			EntireVerse
 NUM	12	11	Aaron			Normal			EndOfVerse
 NUM	12	12	Aaron			Normal			Unspecified
 NUM	12	13	Moses			Normal			EndOfVerse
 NUM	12	14	God		God (Yahweh)	Normal			EndOfVerse
-NUM	13	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	13	2	God		God (Yahweh)	Normal			EntireVerse
 NUM	13	17	Moses			Normal			EndOfVerse
-NUM	13	18	Moses			Implicit			EntireVerse
-NUM	13	19	Moses			Implicit			EntireVerse
+NUM	13	18	Moses			Normal			EntireVerse
+NUM	13	19	Moses			Normal			EntireVerse
 NUM	13	20	Moses			Normal			Unspecified
 NUM	13	27	explorers, ten			Normal			EndOfVerse
-NUM	13	28	explorers, ten			Implicit			EntireVerse
-NUM	13	29	explorers, ten			Implicit			EntireVerse
+NUM	13	28	explorers, ten			Normal			EntireVerse
+NUM	13	29	explorers, ten			Normal			EntireVerse
 NUM	13	30	Caleb			Normal			EndOfVerse
 NUM	13	31	explorers, ten			Normal			EndOfVerse
 NUM	13	32	explorers, ten			Normal			EndOfVerse
-NUM	13	33	explorers, ten			Implicit			EntireVerse
+NUM	13	33	explorers, ten			Normal			EntireVerse
 NUM	14	2	Israelite community	grumbling		Normal			EndOfVerse
-NUM	14	3	Israelite community	grumbling		Implicit			EntireVerse
+NUM	14	3	Israelite community	grumbling		Normal			EntireVerse
 NUM	14	4	Israelite community	grumbling		Normal			EndOfVerse
 NUM	14	7	Joshua/Caleb			Normal	Caleb	NUM 14.7; DEU 1.25	EndOfVerse
-NUM	14	8	Joshua/Caleb			Implicit	Caleb		EntireVerse
-NUM	14	9	Joshua/Caleb			Implicit	Caleb		EntireVerse
+NUM	14	8	Joshua/Caleb			Normal	Caleb		EntireVerse
+NUM	14	9	Joshua/Caleb			Normal	Caleb		EntireVerse
 NUM	14	11	God		God (Yahweh)	Normal			EndOfVerse
 NUM	14	12	God		God (Yahweh)	Normal			Unspecified
 NUM	14	13	Moses			Normal			Unspecified
 NUM	14	14	Moses			Normal			Unspecified
 NUM	14	15	Moses			Normal			Unspecified
 NUM	14	16	Moses			Normal			Unspecified
-NUM	14	17	Moses			Implicit			EntireVerse
-NUM	14	18	Moses			Implicit			EntireVerse
+NUM	14	17	Moses			Normal			EntireVerse
+NUM	14	18	Moses			Normal			EntireVerse
 NUM	14	19	Moses			Normal			Unspecified
 NUM	14	20	God		God (Yahweh)	Normal			EndOfVerse
-NUM	14	21	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	22	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	23	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	14	21	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	22	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	23	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	24	God		God (Yahweh)	Normal			EntireVerse
 NUM	14	25	God		God (Yahweh)	Normal			Unspecified
 NUM	14	27	God		God (Yahweh)	Normal			Unspecified
 NUM	14	28	God		God (Yahweh)	Normal			Unspecified
-NUM	14	29	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	30	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	31	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	32	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	33	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	34	God		God (Yahweh)	Implicit			EntireVerse
-NUM	14	35	God		God (Yahweh)	Implicit			EntireVerse
+NUM	14	29	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	30	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	31	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	32	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	33	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	34	God		God (Yahweh)	Normal			EntireVerse
+NUM	14	35	God		God (Yahweh)	Normal			EntireVerse
 NUM	14	40	Israelite community	mourning		Normal			EndOfVerse
 NUM	14	41	Moses			Normal			EndOfVerse
-NUM	14	42	Moses			Implicit			EntireVerse
-NUM	14	43	Moses			Implicit			EntireVerse
+NUM	14	42	Moses			Normal			EntireVerse
+NUM	14	43	Moses			Normal			EntireVerse
 NUM	15	2	God		God (Yahweh)	Implicit			
 NUM	15	3	God		God (Yahweh)	Implicit			
 NUM	15	4	God		God (Yahweh)	Implicit			
@@ -2805,44 +2805,44 @@ NUM	15	30	God		God (Yahweh)	Implicit
 NUM	15	31	God		God (Yahweh)	Implicit			
 NUM	15	35	God		God (Yahweh)	Normal			EndOfVerse
 NUM	15	38	God		God (Yahweh)	Normal			Unspecified
-NUM	15	39	God		God (Yahweh)	Implicit			EntireVerse
-NUM	15	40	God		God (Yahweh)	Implicit			EntireVerse
-NUM	15	41	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	39	God		God (Yahweh)	Normal			EntireVerse
+NUM	15	40	God		God (Yahweh)	Normal			EntireVerse
+NUM	15	41	God		God (Yahweh)	Normal			EntireVerse
 NUM	16	3	Korah/Dathan/Abiram/On/250 Israelite leaders	arrogantly		Normal	Korah		EndOfVerse
 NUM	16	5	Moses			Normal			Unspecified
-NUM	16	6	Moses			Implicit			EntireVerse
-NUM	16	7	Moses			Implicit			EntireVerse
+NUM	16	6	Moses			Normal			EntireVerse
+NUM	16	7	Moses			Normal			EntireVerse
 NUM	16	8	Moses			Normal			Unspecified
-NUM	16	9	Moses			Implicit			EntireVerse
-NUM	16	10	Moses			Implicit			EntireVerse
-NUM	16	11	Moses			Implicit			EntireVerse
+NUM	16	9	Moses			Normal			EntireVerse
+NUM	16	10	Moses			Normal			EntireVerse
+NUM	16	11	Moses			Normal			EntireVerse
 NUM	16	12	Moses			Indirect			
 NUM	16	12	Dathan/Abiram			Normal	Dathan		
-NUM	16	13	Dathan/Abiram			Implicit	Dathan		EntireVerse
-NUM	16	14	Dathan/Abiram			Implicit	Dathan		EntireVerse
+NUM	16	13	Dathan/Abiram			Normal	Dathan		EntireVerse
+NUM	16	14	Dathan/Abiram			Normal	Dathan		EntireVerse
 NUM	16	15	Moses			Normal			EndOfVerse
 NUM	16	16	Moses			Normal			EndOfVerse
-NUM	16	17	Moses			Implicit			EntireVerse
-NUM	16	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	16	17	Moses			Normal			EntireVerse
+NUM	16	21	God		God (Yahweh)	Normal			EntireVerse
 NUM	16	22	Moses/Aaron			Normal	Moses		EndOfVerse
-NUM	16	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	16	24	God		God (Yahweh)	Normal			EntireVerse
 NUM	16	26	Moses			Normal			EndOfVerse
 NUM	16	28	Moses			Normal			EndOfVerse
-NUM	16	29	Moses			Implicit			EntireVerse
-NUM	16	30	Moses			Implicit			EntireVerse
+NUM	16	29	Moses			Normal			EntireVerse
+NUM	16	30	Moses			Normal			EntireVerse
 NUM	16	34	Israelites	frightened	Israelites, all	Normal			EndOfVerse
-NUM	16	37	God		God (Yahweh)	Implicit			EntireVerse
-NUM	16	38	God		God (Yahweh)	Implicit			EntireVerse
+NUM	16	37	God		God (Yahweh)	Normal			EntireVerse
+NUM	16	38	God		God (Yahweh)	Normal			EntireVerse
 NUM	16	41	Israelites	grumbling	Israelite community, whole	Normal			EndOfVerse
 NUM	16	45	God		God (Yahweh)	Normal			StartOfVerse
 NUM	16	46	Moses			Normal			EndOfVerse
-NUM	17	2	God		God (Yahweh)	Implicit			EntireVerse
-NUM	17	3	God		God (Yahweh)	Implicit			EntireVerse
-NUM	17	4	God		God (Yahweh)	Implicit			EntireVerse
-NUM	17	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	17	2	God		God (Yahweh)	Normal			EntireVerse
+NUM	17	3	God		God (Yahweh)	Normal			EntireVerse
+NUM	17	4	God		God (Yahweh)	Normal			EntireVerse
+NUM	17	5	God		God (Yahweh)	Normal			EntireVerse
 NUM	17	10	God		God (Yahweh)	Normal			EndOfVerse
 NUM	17	12	Israelites			Normal			EndOfVerse
-NUM	17	13	Israelites			Implicit			EntireVerse
+NUM	17	13	Israelites			Normal			EntireVerse
 NUM	18	1	God		God (Yahweh)	Normal			Unspecified
 NUM	18	2	God		God (Yahweh)	Normal			Unspecified
 NUM	18	3	God		God (Yahweh)	Normal			Unspecified
@@ -2896,21 +2896,21 @@ NUM	19	20	God		God (Yahweh)	Normal			Unspecified
 NUM	19	21	God		God (Yahweh)	Normal			Unspecified
 NUM	19	22	God		God (Yahweh)	Normal			Unspecified
 NUM	20	3	Israelites	quarreling	Israelite people, the	Normal			EndOfVerse
-NUM	20	4	Israelites	quarreling	Israelite people, the	Implicit			EntireVerse
-NUM	20	5	Israelites	quarreling	Israelite people, the	Implicit			EntireVerse
+NUM	20	4	Israelites	quarreling	Israelite people, the	Normal			EntireVerse
+NUM	20	5	Israelites	quarreling	Israelite people, the	Normal			EntireVerse
 NUM	20	8	God		God (Yahweh)	Normal			Unspecified
 NUM	20	10	Moses			Normal			EndOfVerse
 NUM	20	12	God		God (Yahweh)	Normal			EndOfVerse
 NUM	20	14	messengers Moses sent to king of Edom			Normal			EndOfVerse
-NUM	20	15	messengers Moses sent to king of Edom			Implicit			EntireVerse
-NUM	20	16	messengers Moses sent to king of Edom			Implicit			EntireVerse
-NUM	20	17	messengers Moses sent to king of Edom			Implicit			EntireVerse
+NUM	20	15	messengers Moses sent to king of Edom			Normal			EntireVerse
+NUM	20	16	messengers Moses sent to king of Edom			Normal			EntireVerse
+NUM	20	17	messengers Moses sent to king of Edom			Normal			EntireVerse
 NUM	20	18	Edom			Normal			EndOfVerse
 NUM	20	19	messengers Moses sent to king of Edom			Normal			EndOfVerse
 NUM	20	20	Edom			Normal			ContainedWithinVerse
-NUM	20	24	God		God (Yahweh)	Implicit			EntireVerse
-NUM	20	25	God		God (Yahweh)	Implicit			EntireVerse
-NUM	20	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	20	24	God		God (Yahweh)	Normal			EntireVerse
+NUM	20	25	God		God (Yahweh)	Normal			EntireVerse
+NUM	20	26	God		God (Yahweh)	Normal			EntireVerse
 NUM	21	2	Israelites		Israelite people, the	Normal			EndOfVerse
 NUM	21	5	Israelites		Israelite people, the	Normal			EndOfVerse
 NUM	21	7	Israelites		Israelite people, the	Normal			ContainedWithinVerse
@@ -2920,7 +2920,7 @@ NUM	21	15	Book of the Wars of Yahweh			Normal			Unspecified
 NUM	21	16	God		God (Yahweh)	Normal			EndOfVerse
 NUM	21	17	Israel	singing		Normal			Unspecified
 NUM	21	18	Israel	singing		Normal			Unspecified
-NUM	21	22	messengers Israel sent to Amorite king Sihon			Implicit			EntireVerse
+NUM	21	22	messengers Israel sent to Amorite king Sihon			Normal			EntireVerse
 NUM	21	27	poets			Normal			Unspecified
 NUM	21	28	poets			Normal			Unspecified
 NUM	21	29	poets			Normal			Unspecified
@@ -2928,25 +2928,25 @@ NUM	21	30	poets			Normal			Unspecified
 NUM	21	34	God		God (Yahweh)	Normal			EndOfVerse
 NUM	22	4	Moabites			Normal			ContainedWithinVerse
 NUM	22	5	Balak			Normal			EndOfVerse
-NUM	22	6	Balak			Implicit			EntireVerse
+NUM	22	6	Balak			Normal			EntireVerse
 NUM	22	8	Balaam			Normal			Unspecified
 NUM	22	9	God		God (Yahweh)	Normal			EndOfVerse
 NUM	22	10	Balaam			Normal			Unspecified
-NUM	22	11	Balaam			Implicit			EntireVerse
+NUM	22	11	Balaam			Normal			EntireVerse
 NUM	22	12	God		God (Yahweh)	Normal			EndOfVerse
 NUM	22	13	Balaam			Normal			EndOfVerse
 NUM	22	14	Moabite officials			Normal			Unspecified
 NUM	22	16	Moabite officials, more distinguished			Normal			Unspecified
 NUM	22	17	Moabite officials, more distinguished			Normal			Unspecified
 NUM	22	18	Balaam			Normal			EndOfVerse
-NUM	22	19	Balaam			Implicit			EntireVerse
+NUM	22	19	Balaam			Normal			EntireVerse
 NUM	22	20	God		God (Yahweh)	Normal			Unspecified
 NUM	22	28	donkey (female)			Normal			EndOfVerse
 NUM	22	29	Balaam			Normal			Unspecified
 NUM	22	30	donkey (female)			Normal			
 NUM	22	30	Balaam			Normal			
 NUM	22	32	Yahweh's angel			Normal	Jesus		EndOfVerse
-NUM	22	33	Yahweh's angel			Implicit	Jesus		EntireVerse
+NUM	22	33	Yahweh's angel			Normal	Jesus		EntireVerse
 NUM	22	34	Balaam			Normal			EndOfVerse
 NUM	22	35	Yahweh's angel			Normal	Jesus		Unspecified
 NUM	22	37	Balak			Normal			EndOfVerse
@@ -2956,9 +2956,9 @@ NUM	23	3	Balaam			Normal			ContainedWithinVerse
 NUM	23	4	Balaam			Normal			EndOfVerse
 NUM	23	5	God		God (Yahweh)	Normal			Unspecified
 NUM	23	7	Balaam			Normal			EndOfVerse
-NUM	23	8	Balaam			Implicit			EntireVerse
-NUM	23	9	Balaam			Implicit			EntireVerse
-NUM	23	10	Balaam			Implicit			EntireVerse
+NUM	23	8	Balaam			Normal			EntireVerse
+NUM	23	9	Balaam			Normal			EntireVerse
+NUM	23	10	Balaam			Normal			EntireVerse
 NUM	23	11	Balak			Normal			EndOfVerse
 NUM	23	12	Balaam			Normal			ContainedWithinVerse
 NUM	23	13	Balak			Normal			EndOfVerse
@@ -2966,69 +2966,69 @@ NUM	23	15	Balaam			Normal			Unspecified
 NUM	23	16	God		God (Yahweh)	Normal			Unspecified
 NUM	23	17	Balak			Normal			EndOfVerse
 NUM	23	18	Balaam			Normal			EndOfVerse
-NUM	23	19	Balaam			Implicit			EntireVerse
-NUM	23	20	Balaam			Implicit			EntireVerse
-NUM	23	21	Balaam			Implicit			EntireVerse
-NUM	23	22	Balaam			Implicit			EntireVerse
-NUM	23	23	Balaam			Implicit			EntireVerse
-NUM	23	24	Balaam			Implicit			EntireVerse
+NUM	23	19	Balaam			Normal			EntireVerse
+NUM	23	20	Balaam			Normal			EntireVerse
+NUM	23	21	Balaam			Normal			EntireVerse
+NUM	23	22	Balaam			Normal			EntireVerse
+NUM	23	23	Balaam			Normal			EntireVerse
+NUM	23	24	Balaam			Normal			EntireVerse
 NUM	23	25	Balak			Normal			EndOfVerse
 NUM	23	26	Balaam			Normal			Unspecified
 NUM	23	27	Balak			Normal			EndOfVerse
 NUM	23	29	Balaam			Normal			EndOfVerse
 NUM	24	3	Balaam		Balaam (Spirit of God upon him)	Normal			EndOfVerse
-NUM	24	4	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
-NUM	24	5	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
-NUM	24	6	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
-NUM	24	7	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
-NUM	24	8	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
-NUM	24	9	Balaam		Balaam (Spirit of God upon him)	Implicit			EntireVerse
+NUM	24	4	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
+NUM	24	5	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
+NUM	24	6	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
+NUM	24	7	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
+NUM	24	8	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
+NUM	24	9	Balaam		Balaam (Spirit of God upon him)	Normal			EntireVerse
 NUM	24	10	Balak			Normal			EndOfVerse
-NUM	24	11	Balak			Implicit			EntireVerse
+NUM	24	11	Balak			Normal			EntireVerse
 NUM	24	12	Balaam			Normal			EndOfVerse
-NUM	24	13	Balaam			Implicit			EntireVerse
+NUM	24	13	Balaam			Normal			EntireVerse
 NUM	24	14	Balaam			Normal			StartOfVerse
 NUM	24	15	Balaam			Normal			EndOfVerse
-NUM	24	16	Balaam			Implicit			EntireVerse
-NUM	24	17	Balaam			Implicit			EntireVerse
-NUM	24	18	Balaam			Implicit			EntireVerse
+NUM	24	16	Balaam			Normal			EntireVerse
+NUM	24	17	Balaam			Normal			EntireVerse
+NUM	24	18	Balaam			Normal			EntireVerse
 NUM	24	19	Balaam			Normal			Unspecified
 NUM	24	20	Balaam			Normal			Unspecified
 NUM	24	21	Balaam			Normal			Unspecified
-NUM	24	22	Balaam			Implicit			EntireVerse
+NUM	24	22	Balaam			Normal			EntireVerse
 NUM	24	23	Balaam			Normal			Unspecified
-NUM	24	24	Balaam			Implicit			EntireVerse
+NUM	24	24	Balaam			Normal			EntireVerse
 NUM	25	4	God		God (Yahweh)	Normal			EndOfVerse
 NUM	25	5	Moses			Normal			EndOfVerse
-NUM	25	11	God		God (Yahweh)	Implicit			EntireVerse
-NUM	25	12	God		God (Yahweh)	Implicit			EntireVerse
-NUM	25	13	God		God (Yahweh)	Implicit			EntireVerse
-NUM	25	17	God		God (Yahweh)	Implicit			EntireVerse
-NUM	25	18	God		God (Yahweh)	Implicit			EntireVerse
-NUM	26	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	25	11	God		God (Yahweh)	Normal			EntireVerse
+NUM	25	12	God		God (Yahweh)	Normal			EntireVerse
+NUM	25	13	God		God (Yahweh)	Normal			EntireVerse
+NUM	25	17	God		God (Yahweh)	Normal			EntireVerse
+NUM	25	18	God		God (Yahweh)	Normal			EntireVerse
+NUM	26	2	God		God (Yahweh)	Normal			EntireVerse
 NUM	26	4	Moses/Eleazar the priest, son of Aaron			Normal	Moses		Unspecified
-NUM	26	53	God		God (Yahweh)	Implicit			EntireVerse
-NUM	26	54	God		God (Yahweh)	Implicit			EntireVerse
-NUM	26	55	God		God (Yahweh)	Implicit			EntireVerse
+NUM	26	53	God		God (Yahweh)	Normal			EntireVerse
+NUM	26	54	God		God (Yahweh)	Normal			EntireVerse
+NUM	26	55	God		God (Yahweh)	Normal			EntireVerse
 NUM	26	56	God		God (Yahweh)	Normal			Unspecified
 NUM	26	65	narrator-NUM			Quotation			Unspecified
 NUM	26	65	God		God (Yahweh)	Quotation	narrator-NUM		Unspecified
-NUM	27	3	daughters of Zelophehad			Implicit			EntireVerse
-NUM	27	4	daughters of Zelophehad			Implicit			EntireVerse
-NUM	27	7	God		God (Yahweh)	Implicit			EntireVerse
-NUM	27	8	God		God (Yahweh)	Implicit			EntireVerse
-NUM	27	9	God		God (Yahweh)	Implicit			EntireVerse
-NUM	27	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	27	3	daughters of Zelophehad			Normal			EntireVerse
+NUM	27	4	daughters of Zelophehad			Normal			EntireVerse
+NUM	27	7	God		God (Yahweh)	Normal			EntireVerse
+NUM	27	8	God		God (Yahweh)	Normal			EntireVerse
+NUM	27	9	God		God (Yahweh)	Normal			EntireVerse
+NUM	27	10	God		God (Yahweh)	Normal			EntireVerse
 NUM	27	11	God		God (Yahweh)	Normal			StartOfVerse
 NUM	27	12	God		God (Yahweh)	Normal			EndOfVerse
-NUM	27	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	27	13	God		God (Yahweh)	Normal			EntireVerse
 NUM	27	14	God		God (Yahweh)	Normal			Unspecified
-NUM	27	16	Moses			Implicit			EntireVerse
-NUM	27	17	Moses			Implicit			EntireVerse
+NUM	27	16	Moses			Normal			EntireVerse
+NUM	27	17	Moses			Normal			EntireVerse
 NUM	27	18	God		God (Yahweh)	Normal			EndOfVerse
-NUM	27	19	God		God (Yahweh)	Implicit			EntireVerse
-NUM	27	20	God		God (Yahweh)	Implicit			EntireVerse
-NUM	27	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	27	19	God		God (Yahweh)	Normal			EntireVerse
+NUM	27	20	God		God (Yahweh)	Normal			EntireVerse
+NUM	27	21	God		God (Yahweh)	Normal			EntireVerse
 NUM	28	2	God		God (Yahweh)	Implicit			
 NUM	28	3	God		God (Yahweh)	Implicit			
 NUM	28	4	God		God (Yahweh)	Implicit			
@@ -3113,77 +3113,77 @@ NUM	30	12	Moses			Normal			Unspecified
 NUM	30	13	Moses			Normal			Unspecified
 NUM	30	14	Moses			Normal			Unspecified
 NUM	30	15	Moses			Normal			Unspecified
-NUM	31	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	31	2	God		God (Yahweh)	Normal			EntireVerse
 NUM	31	3	Moses			Normal			EndOfVerse
-NUM	31	4	Moses			Implicit			EntireVerse
+NUM	31	4	Moses			Normal			EntireVerse
 NUM	31	15	Moses			Normal			Unspecified
-NUM	31	16	Moses			Implicit			EntireVerse
-NUM	31	17	Moses			Implicit			EntireVerse
+NUM	31	16	Moses			Normal			EntireVerse
+NUM	31	17	Moses			Normal			EntireVerse
 NUM	31	18	Moses			Normal			Unspecified
 NUM	31	19	Moses			Normal			Unspecified
-NUM	31	20	Moses			Implicit			EntireVerse
+NUM	31	20	Moses			Normal			EntireVerse
 NUM	31	21	Eleazar the priest, son of Aaron			Normal			EndOfVerse
 NUM	31	22	Eleazar the priest, son of Aaron			Normal			Unspecified
 NUM	31	23	Eleazar the priest, son of Aaron			Normal			Unspecified
 NUM	31	24	Eleazar the priest, son of Aaron			Normal			Unspecified
-NUM	31	26	God		God (Yahweh)	Implicit			EntireVerse
-NUM	31	27	God		God (Yahweh)	Implicit			EntireVerse
-NUM	31	28	God		God (Yahweh)	Implicit			EntireVerse
-NUM	31	29	God		God (Yahweh)	Implicit			EntireVerse
-NUM	31	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	31	26	God		God (Yahweh)	Normal			EntireVerse
+NUM	31	27	God		God (Yahweh)	Normal			EntireVerse
+NUM	31	28	God		God (Yahweh)	Normal			EntireVerse
+NUM	31	29	God		God (Yahweh)	Normal			EntireVerse
+NUM	31	30	God		God (Yahweh)	Normal			EntireVerse
 NUM	31	49	Israelite army commanding officers			Normal			EndOfVerse
-NUM	31	50	Israelite army commanding officers			Implicit			EntireVerse
-NUM	32	3	Gadites/Reubenites			Implicit			EntireVerse
-NUM	32	4	Gadites/Reubenites			Implicit			EntireVerse
+NUM	31	50	Israelite army commanding officers			Normal			EntireVerse
+NUM	32	3	Gadites/Reubenites			Normal			EntireVerse
+NUM	32	4	Gadites/Reubenites			Normal			EntireVerse
 NUM	32	5	Gadites/Reubenites			Normal			Unspecified
 NUM	32	6	Moses			Normal			EndOfVerse
-NUM	32	7	Moses			Implicit			EntireVerse
-NUM	32	8	Moses			Implicit			EntireVerse
-NUM	32	9	Moses			Implicit			EntireVerse
-NUM	32	10	Moses			Implicit			EntireVerse
-NUM	32	11	Moses			Implicit			EntireVerse
-NUM	32	12	Moses			Implicit			EntireVerse
-NUM	32	13	Moses			Implicit			EntireVerse
-NUM	32	14	Moses			Implicit			EntireVerse
-NUM	32	15	Moses			Implicit			EntireVerse
+NUM	32	7	Moses			Normal			EntireVerse
+NUM	32	8	Moses			Normal			EntireVerse
+NUM	32	9	Moses			Normal			EntireVerse
+NUM	32	10	Moses			Normal			EntireVerse
+NUM	32	11	Moses			Normal			EntireVerse
+NUM	32	12	Moses			Normal			EntireVerse
+NUM	32	13	Moses			Normal			EntireVerse
+NUM	32	14	Moses			Normal			EntireVerse
+NUM	32	15	Moses			Normal			EntireVerse
 NUM	32	16	Gadites/Reubenites			Normal			EndOfVerse
-NUM	32	17	Gadites/Reubenites			Implicit			EntireVerse
-NUM	32	18	Gadites/Reubenites			Implicit			EntireVerse
-NUM	32	19	Gadites/Reubenites			Implicit			EntireVerse
+NUM	32	17	Gadites/Reubenites			Normal			EntireVerse
+NUM	32	18	Gadites/Reubenites			Normal			EntireVerse
+NUM	32	19	Gadites/Reubenites			Normal			EntireVerse
 NUM	32	20	Moses			Normal			EndOfVerse
-NUM	32	21	Moses			Implicit			EntireVerse
-NUM	32	22	Moses			Implicit			EntireVerse
-NUM	32	23	Moses			Implicit			EntireVerse
-NUM	32	24	Moses			Implicit			EntireVerse
+NUM	32	21	Moses			Normal			EntireVerse
+NUM	32	22	Moses			Normal			EntireVerse
+NUM	32	23	Moses			Normal			EntireVerse
+NUM	32	24	Moses			Normal			EntireVerse
 NUM	32	25	Gadites/Reubenites			Normal			EndOfVerse
-NUM	32	26	Gadites/Reubenites			Implicit			EntireVerse
-NUM	32	27	Gadites/Reubenites			Implicit			EntireVerse
+NUM	32	26	Gadites/Reubenites			Normal			EntireVerse
+NUM	32	27	Gadites/Reubenites			Normal			EntireVerse
 NUM	32	29	Moses			Normal			Unspecified
-NUM	32	30	Moses			Implicit			EntireVerse
+NUM	32	30	Moses			Normal			EntireVerse
 NUM	32	31	Gadites/Reubenites			Normal			EndOfVerse
-NUM	32	32	Gadites/Reubenites			Implicit			EntireVerse
+NUM	32	32	Gadites/Reubenites			Normal			EntireVerse
 NUM	33	51	God		God (Yahweh)	Normal			Unspecified
-NUM	33	52	God		God (Yahweh)	Implicit			EntireVerse
-NUM	33	53	God		God (Yahweh)	Implicit			EntireVerse
-NUM	33	54	God		God (Yahweh)	Implicit			EntireVerse
-NUM	33	55	God		God (Yahweh)	Implicit			EntireVerse
-NUM	33	56	God		God (Yahweh)	Implicit			EntireVerse
+NUM	33	52	God		God (Yahweh)	Normal			EntireVerse
+NUM	33	53	God		God (Yahweh)	Normal			EntireVerse
+NUM	33	54	God		God (Yahweh)	Normal			EntireVerse
+NUM	33	55	God		God (Yahweh)	Normal			EntireVerse
+NUM	33	56	God		God (Yahweh)	Normal			EntireVerse
 NUM	34	2	God		God (Yahweh)	Normal			Unspecified
-NUM	34	3	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	4	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	5	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	6	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	7	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	8	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	9	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	10	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	11	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	34	3	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	4	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	5	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	6	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	7	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	8	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	9	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	10	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	11	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	12	God		God (Yahweh)	Normal			EntireVerse
 NUM	34	13	Moses			Normal			EndOfVerse
-NUM	34	14	Moses			Implicit			EntireVerse
+NUM	34	14	Moses			Normal			EntireVerse
 NUM	34	15	Moses			Normal			StartOfVerse
-NUM	34	17	God		God (Yahweh)	Implicit			EntireVerse
-NUM	34	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	34	17	God		God (Yahweh)	Normal			EntireVerse
+NUM	34	18	God		God (Yahweh)	Normal			EntireVerse
 NUM	34	19	God		God (Yahweh)	Normal			Unspecified
 NUM	34	20	God		God (Yahweh)	Normal			Unspecified
 NUM	34	21	God		God (Yahweh)	Normal			Unspecified
@@ -3227,13 +3227,13 @@ NUM	35	32	God		God (Yahweh)	Normal			Unspecified
 NUM	35	33	God		God (Yahweh)	Normal			Unspecified
 NUM	35	34	God		God (Yahweh)	Normal			Unspecified
 NUM	36	2	family heads of Gilead			Normal			EndOfVerse
-NUM	36	3	family heads of Gilead			Implicit			EntireVerse
-NUM	36	4	family heads of Gilead			Implicit			EntireVerse
+NUM	36	3	family heads of Gilead			Normal			EntireVerse
+NUM	36	4	family heads of Gilead			Normal			EntireVerse
 NUM	36	5	Moses		Moses (at LORD's command)	Normal			EndOfVerse
-NUM	36	6	Moses		Moses (at LORD's command)	Implicit			EntireVerse
-NUM	36	7	Moses		Moses (at LORD's command)	Implicit			EntireVerse
-NUM	36	8	Moses		Moses (at LORD's command)	Implicit			EntireVerse
-NUM	36	9	Moses		Moses (at LORD's command)	Implicit			EntireVerse
+NUM	36	6	Moses		Moses (at LORD's command)	Normal			EntireVerse
+NUM	36	7	Moses		Moses (at LORD's command)	Normal			EntireVerse
+NUM	36	8	Moses		Moses (at LORD's command)	Normal			EntireVerse
+NUM	36	9	Moses		Moses (at LORD's command)	Normal			EntireVerse
 DEU	1	6	Moses			Implicit			
 DEU	1	6	God		God (Yahweh)	Quotation			Unspecified
 DEU	1	7	Moses			Implicit			
@@ -4030,7 +4030,7 @@ DEU	27	6	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	7	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	8	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	9	Moses/priests			Normal	Moses		EndOfVerse
-DEU	27	10	Moses/priests			Implicit	Moses		EntireVerse
+DEU	27	10	Moses/priests			Normal	Moses		EntireVerse
 DEU	27	11	Moses			Indirect			
 DEU	27	12	Moses			Implicit			
 DEU	27	13	Moses			Implicit			
@@ -4289,22 +4289,22 @@ JOS	1	7	God		God (Yahweh)	Implicit
 JOS	1	8	God		God (Yahweh)	Implicit			
 JOS	1	9	God		God (Yahweh)	Implicit			
 JOS	1	11	Joshua			Normal			Unspecified
-JOS	1	13	Joshua			Implicit			EntireVerse
-JOS	1	14	Joshua			Implicit			EntireVerse
-JOS	1	15	Joshua			Implicit			EntireVerse
+JOS	1	13	Joshua			Normal			EntireVerse
+JOS	1	14	Joshua			Normal			EntireVerse
+JOS	1	15	Joshua			Normal			EntireVerse
 JOS	1	16	Reubenites/Gadites/half-tribe of Manasseh			Normal			EndOfVerse
-JOS	1	17	Reubenites/Gadites/half-tribe of Manasseh			Implicit			EntireVerse
-JOS	1	18	Reubenites/Gadites/half-tribe of Manasseh			Implicit			EntireVerse
+JOS	1	17	Reubenites/Gadites/half-tribe of Manasseh			Normal			EntireVerse
+JOS	1	18	Reubenites/Gadites/half-tribe of Manasseh			Normal			EntireVerse
 JOS	2	1	Joshua			Normal			ContainedWithinVerse
 JOS	2	2	messenger to king of Jericho			Normal			Unspecified
 JOS	2	3	king of Jericho			Normal			Unspecified
 JOS	2	4	Rahab			Normal			Unspecified
 JOS	2	5	Rahab			Normal			Unspecified
 JOS	2	9	Rahab			Normal			Unspecified
-JOS	2	10	Rahab			Implicit			EntireVerse
-JOS	2	11	Rahab			Implicit			EntireVerse
-JOS	2	12	Rahab			Implicit			EntireVerse
-JOS	2	13	Rahab			Implicit			EntireVerse
+JOS	2	10	Rahab			Normal			EntireVerse
+JOS	2	11	Rahab			Normal			EntireVerse
+JOS	2	12	Rahab			Normal			EntireVerse
+JOS	2	13	Rahab			Normal			EntireVerse
 JOS	2	14	Israelite spies from Joshua, two men		men (spies)	Normal			Unspecified
 JOS	2	16	Rahab			Normal			Unspecified
 JOS	2	17	Israelite spies from Joshua, two men			Normal			Unspecified
@@ -4318,14 +4318,14 @@ JOS	3	4	Israelite officers			Normal			Unspecified
 JOS	3	5	Joshua			Normal			EndOfVerse
 JOS	3	6	Joshua			Normal			ContainedWithinVerse
 JOS	3	7	God		God (Yahweh)	Normal			EndOfVerse
-JOS	3	8	God		God (Yahweh)	Implicit			EntireVerse
+JOS	3	8	God		God (Yahweh)	Normal			EntireVerse
 JOS	3	9	Joshua			Normal			EndOfVerse
 JOS	3	10	Joshua			Normal			Unspecified
-JOS	3	11	Joshua			Implicit			EntireVerse
-JOS	3	12	Joshua			Implicit			EntireVerse
-JOS	3	13	Joshua			Implicit			EntireVerse
-JOS	4	2	God		God (Yahweh)	Implicit			EntireVerse
-JOS	4	3	God		God (Yahweh)	Implicit			EntireVerse
+JOS	3	11	Joshua			Normal			EntireVerse
+JOS	3	12	Joshua			Normal			EntireVerse
+JOS	3	13	Joshua			Normal			EntireVerse
+JOS	4	2	God		God (Yahweh)	Normal			EntireVerse
+JOS	4	3	God		God (Yahweh)	Normal			EntireVerse
 JOS	4	5	Joshua			Normal			Unspecified
 JOS	4	6	Joshua			Normal			Unspecified
 JOS	4	7	Joshua			Normal			Unspecified
@@ -4334,7 +4334,7 @@ JOS	4	17	Joshua			Normal			Unspecified
 JOS	4	21	Joshua			Normal			Unspecified
 JOS	4	22	Joshua			Normal			Unspecified
 JOS	4	23	Joshua			Normal			Unspecified
-JOS	4	24	Joshua			Implicit			EntireVerse
+JOS	4	24	Joshua			Normal			EntireVerse
 JOS	5	2	God		God (Yahweh)	Normal			EndOfVerse
 JOS	5	9	God		God (Yahweh)	Normal			ContainedWithinVerse
 JOS	5	13	Joshua			Normal			EndOfVerse
@@ -4350,27 +4350,27 @@ JOS	5	15	Jesus		commander of the LORD's army (Jesus)	Normal
 JOS	5	15	Needs Review			Normal			
 JOS	6	2	God		God (Yahweh)	Normal			EndOfVerse
 JOS	6	3	God		God (Yahweh)	Normal			Unspecified
-JOS	6	4	God		God (Yahweh)	Implicit			EntireVerse
-JOS	6	5	God		God (Yahweh)	Implicit			EntireVerse
+JOS	6	4	God		God (Yahweh)	Normal			EntireVerse
+JOS	6	5	God		God (Yahweh)	Normal			EntireVerse
 JOS	6	6	Joshua			Normal			EndOfVerse
 JOS	6	7	Joshua			Normal			Unspecified
 JOS	6	10	Joshua			Normal			Unspecified
 JOS	6	16	Joshua			Normal			EndOfVerse
-JOS	6	17	Joshua			Implicit			EntireVerse
-JOS	6	18	Joshua			Implicit			EntireVerse
-JOS	6	19	Joshua			Implicit			EntireVerse
+JOS	6	17	Joshua			Normal			EntireVerse
+JOS	6	18	Joshua			Normal			EntireVerse
+JOS	6	19	Joshua			Normal			EntireVerse
 JOS	6	22	Joshua			Normal			Unspecified
 JOS	6	26	Joshua			Normal			EndOfVerse
 JOS	7	2	Joshua			Normal			ContainedWithinVerse
 JOS	7	3	Israelite spies Joshua sent to Ai			Normal			EndOfVerse
 JOS	7	7	Joshua			Normal			EndOfVerse
-JOS	7	8	Joshua			Implicit			EntireVerse
+JOS	7	8	Joshua			Normal			EntireVerse
 JOS	7	9	Joshua			Normal			Unspecified
 JOS	7	10	God		God (Yahweh)	Normal			Unspecified
 JOS	7	11	God		God (Yahweh)	Normal			Unspecified
 JOS	7	12	God		God (Yahweh)	Normal			Unspecified
 JOS	7	13	God		God (Yahweh)	Normal			Unspecified
-JOS	7	14	God		God (Yahweh)	Implicit			EntireVerse
+JOS	7	14	God		God (Yahweh)	Normal			EntireVerse
 JOS	7	15	God		God (Yahweh)	Normal			Unspecified
 JOS	7	19	Joshua			Normal			Unspecified
 JOS	7	20	Achan			Normal			Unspecified
@@ -4390,24 +4390,24 @@ JOS	9	7	Israel, men of			Normal			Unspecified
 JOS	9	8	Gibeonites			Normal			
 JOS	9	8	Joshua			Normal			
 JOS	9	9	Gibeonites			Normal			Unspecified
-JOS	9	10	Gibeonites			Implicit			EntireVerse
-JOS	9	11	Gibeonites			Implicit			EntireVerse
-JOS	9	12	Gibeonites			Implicit			EntireVerse
-JOS	9	13	Gibeonites			Implicit			EntireVerse
+JOS	9	10	Gibeonites			Normal			EntireVerse
+JOS	9	11	Gibeonites			Normal			EntireVerse
+JOS	9	12	Gibeonites			Normal			EntireVerse
+JOS	9	13	Gibeonites			Normal			EntireVerse
 JOS	9	19	Israel, leaders of			Normal			EndOfVerse
 JOS	9	20	Israel, leaders of			Normal			Unspecified
 JOS	9	21	Israel, leaders of			Normal			Unspecified
 JOS	9	22	Joshua			Normal			Unspecified
-JOS	9	23	Joshua			Implicit			EntireVerse
+JOS	9	23	Joshua			Normal			EntireVerse
 JOS	9	24	Gibeonites			Normal			EndOfVerse
-JOS	9	25	Gibeonites			Implicit			EntireVerse
+JOS	9	25	Gibeonites			Normal			EntireVerse
 JOS	10	4	Adoni-Zedek, king of Jerusalem			Normal			Unspecified
 JOS	10	6	Gibeonites			Normal			EndOfVerse
 JOS	10	8	God		God (Yahweh)	Normal			Unspecified
 JOS	10	12	Joshua			Normal			Unspecified
 JOS	10	17	person who told Joshua where the kings were hiding			Indirect			
 JOS	10	18	Joshua			Normal			EndOfVerse
-JOS	10	19	Joshua			Implicit			EntireVerse
+JOS	10	19	Joshua			Normal			EntireVerse
 JOS	10	22	Joshua			Normal			Unspecified
 JOS	10	24	Joshua			Normal			ContainedWithinVerse
 JOS	10	25	Joshua			Normal			EndOfVerse
@@ -4424,9 +4424,9 @@ JOS	14	6	Caleb			Normal			Unspecified
 JOS	14	7	Caleb			Normal			Unspecified
 JOS	14	8	Caleb			Normal			Unspecified
 JOS	14	9	Caleb			Normal			Unspecified
-JOS	14	10	Caleb			Implicit			EntireVerse
-JOS	14	11	Caleb			Implicit			EntireVerse
-JOS	14	12	Caleb			Implicit			EntireVerse
+JOS	14	10	Caleb			Normal			EntireVerse
+JOS	14	11	Caleb			Normal			EntireVerse
+JOS	14	12	Caleb			Normal			EntireVerse
 JOS	15	16	Caleb			Normal			EndOfVerse
 JOS	15	18	Caleb			Normal			
 JOS	15	18	Achsah, Caleb's daughter			Rare			
@@ -4437,30 +4437,30 @@ JOS	17	14	Joseph, people of			Normal			EndOfVerse
 JOS	17	15	Joshua			Normal			EndOfVerse
 JOS	17	16	Joseph, people of			Normal			Unspecified
 JOS	17	17	Joshua			Normal			Unspecified
-JOS	17	18	Joshua			Implicit			EntireVerse
+JOS	17	18	Joshua			Normal			EntireVerse
 JOS	18	3	Joshua			Normal			EndOfVerse
 JOS	18	4	Joshua			Normal			Unspecified
 JOS	18	5	Joshua			Normal			Unspecified
 JOS	18	6	Joshua			Normal			Unspecified
 JOS	18	7	Joshua			Normal			Unspecified
 JOS	18	8	Joshua			Normal			EndOfVerse
-JOS	20	2	God		God (Yahweh)	Implicit			EntireVerse
-JOS	20	3	God		God (Yahweh)	Implicit			EntireVerse
-JOS	20	4	God		God (Yahweh)	Implicit			EntireVerse
-JOS	20	5	God		God (Yahweh)	Implicit			EntireVerse
-JOS	20	6	God		God (Yahweh)	Implicit			EntireVerse
+JOS	20	2	God		God (Yahweh)	Normal			EntireVerse
+JOS	20	3	God		God (Yahweh)	Normal			EntireVerse
+JOS	20	4	God		God (Yahweh)	Normal			EntireVerse
+JOS	20	5	God		God (Yahweh)	Normal			EntireVerse
+JOS	20	6	God		God (Yahweh)	Normal			EntireVerse
 JOS	21	2	Levites, family heads of			Normal			EndOfVerse
 JOS	22	2	Joshua			Normal			Unspecified
-JOS	22	3	Joshua			Implicit			EntireVerse
-JOS	22	4	Joshua			Implicit			EntireVerse
-JOS	22	5	Joshua			Implicit			EntireVerse
+JOS	22	3	Joshua			Normal			EntireVerse
+JOS	22	4	Joshua			Normal			EntireVerse
+JOS	22	5	Joshua			Normal			EntireVerse
 JOS	22	8	Joshua			Normal			Unspecified
 JOS	22	11	person who informed the sons of Israel			Normal			Unspecified
-JOS	22	16	Phineas the priest/chiefs of 10 tribes			Implicit	Phineas the priest		EntireVerse
-JOS	22	17	Phineas the priest/chiefs of 10 tribes			Implicit	Phineas the priest		EntireVerse
-JOS	22	18	Phineas the priest/chiefs of 10 tribes			Implicit	Phineas the priest		EntireVerse
-JOS	22	19	Phineas the priest/chiefs of 10 tribes			Implicit	Phineas the priest		EntireVerse
-JOS	22	20	Phineas the priest/chiefs of 10 tribes			Implicit	Phineas the priest		EntireVerse
+JOS	22	16	Phineas the priest/chiefs of 10 tribes			Normal	Phineas the priest		EntireVerse
+JOS	22	17	Phineas the priest/chiefs of 10 tribes			Normal	Phineas the priest		EntireVerse
+JOS	22	18	Phineas the priest/chiefs of 10 tribes			Normal	Phineas the priest		EntireVerse
+JOS	22	19	Phineas the priest/chiefs of 10 tribes			Normal	Phineas the priest		EntireVerse
+JOS	22	20	Phineas the priest/chiefs of 10 tribes			Normal	Phineas the priest		EntireVerse
 JOS	22	22	Reubenites/Gadites/half-tribe of Manasseh			Normal			Unspecified
 JOS	22	23	Reubenites/Gadites/half-tribe of Manasseh			Normal			Unspecified
 JOS	22	24	Reubenites/Gadites/half-tribe of Manasseh			Normal			Unspecified
@@ -4473,20 +4473,20 @@ JOS	22	31	Phineas the priest			Normal			EndOfVerse
 JOS	22	32	Phineas the priest/chiefs of 10 tribes		Phineas the priest/leaders	Indirect	Phineas the priest		
 JOS	22	34	narrator-JOS			Quotation			Unspecified
 JOS	23	2	Joshua (old)			Normal			EndOfVerse
-JOS	23	3	Joshua (old)			Implicit			EntireVerse
-JOS	23	4	Joshua (old)			Implicit			EntireVerse
-JOS	23	5	Joshua (old)			Implicit			EntireVerse
-JOS	23	6	Joshua (old)			Implicit			EntireVerse
-JOS	23	7	Joshua (old)			Implicit			EntireVerse
-JOS	23	8	Joshua (old)			Implicit			EntireVerse
-JOS	23	9	Joshua (old)			Implicit			EntireVerse
-JOS	23	10	Joshua (old)			Implicit			EntireVerse
-JOS	23	11	Joshua (old)			Implicit			EntireVerse
-JOS	23	12	Joshua (old)			Implicit			EntireVerse
-JOS	23	13	Joshua (old)			Implicit			EntireVerse
-JOS	23	14	Joshua (old)			Implicit			EntireVerse
-JOS	23	15	Joshua (old)			Implicit			EntireVerse
-JOS	23	16	Joshua (old)			Implicit			EntireVerse
+JOS	23	3	Joshua (old)			Normal			EntireVerse
+JOS	23	4	Joshua (old)			Normal			EntireVerse
+JOS	23	5	Joshua (old)			Normal			EntireVerse
+JOS	23	6	Joshua (old)			Normal			EntireVerse
+JOS	23	7	Joshua (old)			Normal			EntireVerse
+JOS	23	8	Joshua (old)			Normal			EntireVerse
+JOS	23	9	Joshua (old)			Normal			EntireVerse
+JOS	23	10	Joshua (old)			Normal			EntireVerse
+JOS	23	11	Joshua (old)			Normal			EntireVerse
+JOS	23	12	Joshua (old)			Normal			EntireVerse
+JOS	23	13	Joshua (old)			Normal			EntireVerse
+JOS	23	14	Joshua (old)			Normal			EntireVerse
+JOS	23	15	Joshua (old)			Normal			EntireVerse
+JOS	23	16	Joshua (old)			Normal			EntireVerse
 JOS	24	2	Joshua (old)			Normal			
 JOS	24	2	God		God (Yahweh)	Quotation			Unspecified
 JOS	24	3	Joshua (old)			Normal			
@@ -4514,10 +4514,10 @@ JOS	24	13	God		God (Yahweh)	Quotation			Unspecified
 JOS	24	14	Joshua (old)			Normal			Unspecified
 JOS	24	15	Joshua (old)			Normal			Unspecified
 JOS	24	16	Israelites		Israel, the people of	Normal			EndOfVerse
-JOS	24	17	Israelites		Israel, the people of	Implicit			EntireVerse
-JOS	24	18	Israelites		Israel, the people of	Implicit			EntireVerse
+JOS	24	17	Israelites		Israel, the people of	Normal			EntireVerse
+JOS	24	18	Israelites		Israel, the people of	Normal			EntireVerse
 JOS	24	19	Joshua (old)			Normal			EndOfVerse
-JOS	24	20	Joshua (old)			Implicit			EntireVerse
+JOS	24	20	Joshua (old)			Normal			EntireVerse
 JOS	24	21	Israelites		Israel, the people of	Normal			EndOfVerse
 JOS	24	22	Joshua (old)			Normal			
 JOS	24	22	Israelites		Israel, the people of	Normal			
@@ -4537,15 +4537,15 @@ JDG	2	1	Yahweh's angel			Normal	Jesus		EndOfVerse
 JDG	2	2	Yahweh's angel			Implicit	Jesus		
 JDG	2	3	Yahweh's angel			Implicit	Jesus		
 JDG	2	20	God		God (Yahweh)	Normal			EndOfVerse
-JDG	2	21	God		God (Yahweh)	Implicit			EntireVerse
-JDG	2	22	God		God (Yahweh)	Implicit			EntireVerse
+JDG	2	21	God		God (Yahweh)	Normal			EntireVerse
+JDG	2	22	God		God (Yahweh)	Normal			EntireVerse
 JDG	3	19	Eglon, king of Moab			Normal			
 JDG	3	19	Ehud, Israelite deliverer			Normal			
 JDG	3	20	Ehud, Israelite deliverer			Normal			Unspecified
 JDG	3	24	servants of Eglon, king of Moab			Normal			EndOfVerse
 JDG	3	28	Ehud, Israelite deliverer			Normal			Unspecified
 JDG	4	6	Deborah		Deborah, prophetess	Normal			EndOfVerse
-JDG	4	7	Deborah		Deborah, prophetess	Implicit			EntireVerse
+JDG	4	7	Deborah		Deborah, prophetess	Normal			EntireVerse
 JDG	4	8	Barak			Normal			Unspecified
 JDG	4	9	Deborah		Deborah, prophetess	Normal			Unspecified
 JDG	4	12	person who informed Sisera			Rare			
@@ -4614,7 +4614,7 @@ JDG	6	22	Gideon (Jerubbaal)			Normal			Unspecified
 JDG	6	23	God		God (Yahweh)	Normal			Unspecified
 JDG	6	24	narrator-JDG			Quotation			Unspecified
 JDG	6	25	God		God (Yahweh)	Normal			EndOfVerse
-JDG	6	26	God		God (Yahweh)	Implicit			EntireVerse
+JDG	6	26	God		God (Yahweh)	Normal			EntireVerse
 JDG	6	29	townsmen of Ophrah			Normal			
 JDG	6	29	person who informed townsmen of Ophrah			Normal			
 JDG	6	30	townsmen of Ophrah			Normal			EndOfVerse
@@ -4631,7 +4631,7 @@ JDG	7	4	God		God (Yahweh)	Normal			Unspecified
 JDG	7	5	God		God (Yahweh)	Normal			EndOfVerse
 JDG	7	7	God		God (Yahweh)	Normal			EndOfVerse
 JDG	7	9	God		God (Yahweh)	Normal			EndOfVerse
-JDG	7	10	God		God (Yahweh)	Implicit			EntireVerse
+JDG	7	10	God		God (Yahweh)	Normal			EntireVerse
 JDG	7	11	God		God (Yahweh)	Normal			StartOfVerse
 JDG	7	13	Midianite soldier who had a dream			Normal			Unspecified
 JDG	7	14	Midianite soldier who interprets dream			Normal			EndOfVerse
@@ -4668,18 +4668,18 @@ JDG	9	12	Jotham, son of Gideon (Jerubbaal)			Normal			Unspecified
 JDG	9	13	Jotham, son of Gideon (Jerubbaal)			Normal			Unspecified
 JDG	9	14	Jotham, son of Gideon (Jerubbaal)			Normal			Unspecified
 JDG	9	15	Jotham, son of Gideon (Jerubbaal)			Normal			Unspecified
-JDG	9	16	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
-JDG	9	17	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
-JDG	9	18	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
-JDG	9	19	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
-JDG	9	20	Jotham, son of Gideon (Jerubbaal)			Implicit			EntireVerse
+JDG	9	16	Jotham, son of Gideon (Jerubbaal)			Normal			EntireVerse
+JDG	9	17	Jotham, son of Gideon (Jerubbaal)			Normal			EntireVerse
+JDG	9	18	Jotham, son of Gideon (Jerubbaal)			Normal			EntireVerse
+JDG	9	19	Jotham, son of Gideon (Jerubbaal)			Normal			EntireVerse
+JDG	9	20	Jotham, son of Gideon (Jerubbaal)			Normal			EntireVerse
 JDG	9	25	messenger to Abimelech			Rare			
 JDG	9	25	Needs Review			Potential			
 JDG	9	28	Gaal, son of Ebed			Normal			Unspecified
 JDG	9	29	Gaal, son of Ebed			Normal			Unspecified
 JDG	9	31	Zebul, governor of Shechem			Normal			EndOfVerse
-JDG	9	32	Zebul, governor of Shechem			Implicit			EntireVerse
-JDG	9	33	Zebul, governor of Shechem			Implicit			EntireVerse
+JDG	9	32	Zebul, governor of Shechem			Normal			EntireVerse
+JDG	9	33	Zebul, governor of Shechem			Normal			EntireVerse
 JDG	9	36	Gaal, son of Ebed			Normal			
 JDG	9	36	Zebul, governor of Shechem			Normal			
 JDG	9	37	Gaal, son of Ebed			Normal			Unspecified
@@ -4692,8 +4692,8 @@ JDG	9	54	Abimelech, son of Gideon (Jerubbaal)			Normal			ContainedWithinVerse
 JDG	10	10	Israelites			Normal			EndOfVerse
 JDG	10	11	God		God (Yahweh)	Normal			EndOfVerse
 JDG	10	12	God		God (Yahweh)	Normal			Unspecified
-JDG	10	13	God		God (Yahweh)	Implicit			EntireVerse
-JDG	10	14	God		God (Yahweh)	Implicit			EntireVerse
+JDG	10	13	God		God (Yahweh)	Normal			EntireVerse
+JDG	10	14	God		God (Yahweh)	Normal			EntireVerse
 JDG	10	15	Israelites			Normal			Unspecified
 JDG	10	18	Gilead, leaders of			Normal			Unspecified
 JDG	11	2	Jephthah's half-brothers			Normal			Unspecified
@@ -4709,23 +4709,23 @@ JDG	11	16	messengers from Jephthah			Normal			Unspecified
 JDG	11	17	messengers from Jephthah			Normal			Unspecified
 JDG	11	18	messengers from Jephthah			Normal			Unspecified
 JDG	11	19	messengers from Jephthah			Normal			Unspecified
-JDG	11	20	messengers from Jephthah			Implicit			EntireVerse
-JDG	11	21	messengers from Jephthah			Implicit			EntireVerse
-JDG	11	22	messengers from Jephthah			Implicit			EntireVerse
+JDG	11	20	messengers from Jephthah			Normal			EntireVerse
+JDG	11	21	messengers from Jephthah			Normal			EntireVerse
+JDG	11	22	messengers from Jephthah			Normal			EntireVerse
 JDG	11	23	messengers from Jephthah			Normal			Unspecified
-JDG	11	24	messengers from Jephthah			Implicit			EntireVerse
-JDG	11	25	messengers from Jephthah			Implicit			EntireVerse
-JDG	11	26	messengers from Jephthah			Implicit			EntireVerse
-JDG	11	27	messengers from Jephthah			Implicit			EntireVerse
+JDG	11	24	messengers from Jephthah			Normal			EntireVerse
+JDG	11	25	messengers from Jephthah			Normal			EntireVerse
+JDG	11	26	messengers from Jephthah			Normal			EntireVerse
+JDG	11	27	messengers from Jephthah			Normal			EntireVerse
 JDG	11	30	Jephthah			Normal			EndOfVerse
-JDG	11	31	Jephthah			Implicit			EntireVerse
+JDG	11	31	Jephthah			Normal			EntireVerse
 JDG	11	35	Jephthah			Normal			Unspecified
 JDG	11	36	Jephthah's daughter			Normal			Unspecified
 JDG	11	37	Jephthah's daughter			Normal			Unspecified
 JDG	11	38	Jephthah			Normal			Unspecified
 JDG	12	1	Ephraimites		Ephraim, men of	Normal			EndOfVerse
 JDG	12	2	Jephthah			Normal			Unspecified
-JDG	12	3	Jephthah			Implicit			EntireVerse
+JDG	12	3	Jephthah			Normal			EntireVerse
 JDG	12	4	Jephthah			Indirect			
 JDG	12	4	Ephraimites			Quotation			Unspecified
 JDG	12	4	narrator-JDG			Quotation			Unspecified
@@ -4739,14 +4739,14 @@ JDG	13	3	Yahweh's angel			Normal	Jesus		EndOfVerse
 JDG	13	4	Yahweh's angel			Normal	Jesus		Unspecified
 JDG	13	5	Yahweh's angel			Normal	Jesus		Unspecified
 JDG	13	6	Manoah's wife, mother of Samson			Normal			EndOfVerse
-JDG	13	7	Manoah's wife, mother of Samson			Implicit			EntireVerse
+JDG	13	7	Manoah's wife, mother of Samson			Normal			EntireVerse
 JDG	13	8	Manoah, father of Samson			Normal			EndOfVerse
 JDG	13	10	Manoah's wife, mother of Samson			Normal			EndOfVerse
 JDG	13	11	Yahweh's angel			Normal	Jesus		
 JDG	13	11	Manoah, father of Samson			Normal			
 JDG	13	12	Manoah, father of Samson			Normal			EndOfVerse
 JDG	13	13	Yahweh's angel			Normal	Jesus		Unspecified
-JDG	13	14	Yahweh's angel			Implicit	Jesus		EntireVerse
+JDG	13	14	Yahweh's angel			Normal	Jesus		EntireVerse
 JDG	13	15	Manoah, father of Samson			Normal			Unspecified
 JDG	13	16	Yahweh's angel			Normal	Jesus		Unspecified
 JDG	13	17	Manoah, father of Samson			Normal			EndOfVerse
@@ -4836,21 +4836,21 @@ JDG	19	12	Levite husband of concubine			Normal			Unspecified
 JDG	19	13	Levite husband of concubine			Normal			Unspecified
 JDG	19	17	old man in Gibeah			Normal			Unspecified
 JDG	19	18	Levite husband of concubine			Normal			Unspecified
-JDG	19	19	Levite husband of concubine			Implicit			EntireVerse
+JDG	19	19	Levite husband of concubine			Normal			EntireVerse
 JDG	19	20	old man in Gibeah			Normal			Unspecified
 JDG	19	22	wicked men of Gibeah			Normal			EndOfVerse
 JDG	19	23	old man in Gibeah			Normal			EndOfVerse
-JDG	19	24	old man in Gibeah			Implicit			EntireVerse
+JDG	19	24	old man in Gibeah			Normal			EntireVerse
 JDG	19	28	Levite husband of concubine			Normal			Unspecified
 JDG	19	30	Israelites		everyone who saw it	Normal			EndOfVerse
 JDG	20	3	Israelites			Normal			EndOfVerse
 JDG	20	4	Levite husband of concubine			Normal			EndOfVerse
-JDG	20	5	Levite husband of concubine			Implicit			EntireVerse
-JDG	20	6	Levite husband of concubine			Implicit			EntireVerse
-JDG	20	7	Levite husband of concubine			Implicit			EntireVerse
+JDG	20	5	Levite husband of concubine			Normal			EntireVerse
+JDG	20	6	Levite husband of concubine			Normal			EntireVerse
+JDG	20	7	Levite husband of concubine			Normal			EntireVerse
 JDG	20	8	Israelites		Israelites, all	Normal			EndOfVerse
-JDG	20	9	Israelites		Israelites, all	Implicit			EntireVerse
-JDG	20	10	Israelites		Israelites, all	Implicit			EntireVerse
+JDG	20	9	Israelites		Israelites, all	Normal			EntireVerse
+JDG	20	10	Israelites		Israelites, all	Normal			EntireVerse
 JDG	20	12	Israelites	mourning	Israelites, all	Normal			EndOfVerse
 JDG	20	13	Israelites	mourning	Israelites, all	Normal			StartOfVerse
 JDG	20	18	God		God (Yahweh)	Normal			
@@ -4866,7 +4866,7 @@ JDG	21	1	Israel, men of			Normal			EndOfVerse
 JDG	21	3	Israelites	weeping	Israelites, all	Normal			Unspecified
 JDG	21	5	Israelites			Normal			Unspecified
 JDG	21	6	Israelites			Normal			Unspecified
-JDG	21	7	Israelites			Implicit			EntireVerse
+JDG	21	7	Israelites			Normal			EntireVerse
 JDG	21	8	Israelites			Normal			ContainedWithinVerse
 JDG	21	10	Israelite assembly			Normal			EndOfVerse
 JDG	21	11	Israelite assembly			Normal			Unspecified
@@ -4883,8 +4883,8 @@ RUT	1	9	Orpah/Ruth	weeping		Rare	Orpah
 RUT	1	9	Needs Review			Rare			
 RUT	1	10	Orpah/Ruth			Normal	Orpah		EndOfVerse
 RUT	1	11	Naomi			Normal			Unspecified
-RUT	1	12	Naomi			Implicit			EntireVerse
-RUT	1	13	Naomi			Implicit			EntireVerse
+RUT	1	12	Naomi			Normal			EntireVerse
+RUT	1	13	Naomi			Normal			EntireVerse
 RUT	1	15	Naomi			Normal			Unspecified
 RUT	1	16	Ruth			Normal			Unspecified
 RUT	1	17	Ruth			Normal			Unspecified
@@ -4897,32 +4897,32 @@ RUT	2	4	Boaz			Normal
 RUT	2	4	harvesters			Normal			
 RUT	2	5	Boaz			Normal			Unspecified
 RUT	2	6	foreman			Normal			Unspecified
-RUT	2	7	foreman			Implicit			EntireVerse
+RUT	2	7	foreman			Normal			EntireVerse
 RUT	2	8	Boaz			Normal			EndOfVerse
-RUT	2	9	Boaz			Implicit			EntireVerse
+RUT	2	9	Boaz			Normal			EntireVerse
 RUT	2	10	Ruth			Normal			EndOfVerse
 RUT	2	11	Boaz			Normal			Unspecified
-RUT	2	12	Boaz			Implicit			EntireVerse
+RUT	2	12	Boaz			Normal			EntireVerse
 RUT	2	13	Ruth			Normal			Unspecified
 RUT	2	14	Boaz			Normal			ContainedWithinVerse
 RUT	2	15	Boaz			Normal			EndOfVerse
-RUT	2	16	Boaz			Implicit			EntireVerse
+RUT	2	16	Boaz			Normal			EntireVerse
 RUT	2	19	Naomi			Normal			
 RUT	2	19	Ruth			Normal			
 RUT	2	20	Naomi			Normal			Unspecified
 RUT	2	21	Ruth			Normal			EndOfVerse
 RUT	2	22	Naomi			Normal			Unspecified
 RUT	3	1	Naomi			Normal			Unspecified
-RUT	3	2	Naomi			Implicit			EntireVerse
-RUT	3	3	Naomi			Implicit			EntireVerse
-RUT	3	4	Naomi			Implicit			EntireVerse
+RUT	3	2	Naomi			Normal			EntireVerse
+RUT	3	3	Naomi			Normal			EntireVerse
+RUT	3	4	Naomi			Normal			EntireVerse
 RUT	3	5	Ruth			Normal			Unspecified
 RUT	3	9	Boaz			Normal			
 RUT	3	9	Ruth			Normal			
 RUT	3	10	Boaz			Normal			Unspecified
-RUT	3	11	Boaz			Implicit			EntireVerse
-RUT	3	12	Boaz			Implicit			EntireVerse
-RUT	3	13	Boaz			Implicit			EntireVerse
+RUT	3	11	Boaz			Normal			EntireVerse
+RUT	3	12	Boaz			Normal			EntireVerse
+RUT	3	13	Boaz			Normal			EntireVerse
 RUT	3	14	Boaz			Normal			Unspecified
 RUT	3	15	Boaz			Normal			Unspecified
 RUT	3	16	Naomi			Normal			Unspecified
@@ -4937,11 +4937,11 @@ RUT	4	5	Boaz			Normal			Unspecified
 RUT	4	6	kinsman-redeemer			Normal			Unspecified
 RUT	4	8	kinsman-redeemer			Normal			Unspecified
 RUT	4	9	Boaz			Normal			EndOfVerse
-RUT	4	10	Boaz			Implicit			EntireVerse
+RUT	4	10	Boaz			Normal			EntireVerse
 RUT	4	11	elders			Normal			EndOfVerse
 RUT	4	12	elders			Normal			Unspecified
 RUT	4	14	women of Bethlehem			Normal			EndOfVerse
-RUT	4	15	women of Bethlehem			Implicit			EntireVerse
+RUT	4	15	women of Bethlehem			Normal			EntireVerse
 RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	1	8	Elkanah			Normal			EndOfVerse
 1SA	1	11	Hannah			Normal			Unspecified
@@ -4954,7 +4954,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	1	22	Hannah			Normal			Unspecified
 1SA	1	23	Elkanah			Normal			Unspecified
 1SA	1	26	Hannah			Normal			Unspecified
-1SA	1	27	Hannah			Implicit			EntireVerse
+1SA	1	27	Hannah			Normal			EntireVerse
 1SA	1	28	Hannah			Normal			StartOfVerse
 1SA	2	1	Hannah			Normal			Unspecified
 1SA	2	2	Hannah			Normal			Unspecified
@@ -4994,9 +4994,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	3	10	God		God (Yahweh)	Normal			
 1SA	3	10	Samuel (boy)			Normal			
 1SA	3	11	God		God (Yahweh)	Normal			Unspecified
-1SA	3	12	God		God (Yahweh)	Implicit			EntireVerse
-1SA	3	13	God		God (Yahweh)	Implicit			EntireVerse
-1SA	3	14	God		God (Yahweh)	Implicit			EntireVerse
+1SA	3	12	God		God (Yahweh)	Normal			EntireVerse
+1SA	3	13	God		God (Yahweh)	Normal			EntireVerse
+1SA	3	14	God		God (Yahweh)	Normal			EntireVerse
 1SA	3	16	Eli			Normal			
 1SA	3	16	Samuel (boy)			Normal			
 1SA	3	17	Eli			Normal			Unspecified
@@ -5004,8 +5004,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	4	3	elders of Israel			Normal			EndOfVerse
 1SA	4	6	Philistines			Normal			ContainedWithinVerse
 1SA	4	7	Philistines			Normal			Unspecified
-1SA	4	8	Philistines			Implicit			EntireVerse
-1SA	4	9	Philistines			Implicit			EntireVerse
+1SA	4	8	Philistines			Normal			EntireVerse
+1SA	4	9	Philistines			Normal			EntireVerse
 1SA	4	14	Eli			Normal			Unspecified
 1SA	4	16	Benjamite messenger to Eli			Normal			
 1SA	4	16	Eli			Normal			
@@ -5022,11 +5022,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	6	3	Philistine priests and fortune tellers			Normal			Unspecified
 1SA	6	4	Philistine priests and fortune tellers			Normal			
 1SA	6	4	Philistines			Normal			
-1SA	6	5	Philistine priests and fortune tellers			Implicit			EntireVerse
-1SA	6	6	Philistine priests and fortune tellers			Implicit			EntireVerse
-1SA	6	7	Philistine priests and fortune tellers			Implicit			EntireVerse
-1SA	6	8	Philistine priests and fortune tellers			Implicit			EntireVerse
-1SA	6	9	Philistine priests and fortune tellers			Implicit			EntireVerse
+1SA	6	5	Philistine priests and fortune tellers			Normal			EntireVerse
+1SA	6	6	Philistine priests and fortune tellers			Normal			EntireVerse
+1SA	6	7	Philistine priests and fortune tellers			Normal			EntireVerse
+1SA	6	8	Philistine priests and fortune tellers			Normal			EntireVerse
+1SA	6	9	Philistine priests and fortune tellers			Normal			EntireVerse
 1SA	6	20	Beth Shemesh, men of			Normal			EndOfVerse
 1SA	6	21	Beth Shemesh, messenger from			Normal	Beth Shemesh, men of		EndOfVerse
 1SA	7	3	Samuel			Normal			EndOfVerse
@@ -5037,15 +5037,15 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	8	5	elders of Israel			Normal			EndOfVerse
 1SA	8	6	elders of Israel			Normal			Unspecified
 1SA	8	7	God		God (Yahweh)	Normal			EndOfVerse
-1SA	8	8	God		God (Yahweh)	Implicit			EntireVerse
+1SA	8	8	God		God (Yahweh)	Normal			EntireVerse
 1SA	8	9	God		God (Yahweh)	Normal			Unspecified
 1SA	8	11	Samuel			Normal			Unspecified
-1SA	8	12	Samuel			Implicit			EntireVerse
-1SA	8	13	Samuel			Implicit			EntireVerse
-1SA	8	14	Samuel			Implicit			EntireVerse
-1SA	8	15	Samuel			Implicit			EntireVerse
-1SA	8	16	Samuel			Implicit			EntireVerse
-1SA	8	17	Samuel			Implicit			EntireVerse
+1SA	8	12	Samuel			Normal			EntireVerse
+1SA	8	13	Samuel			Normal			EntireVerse
+1SA	8	14	Samuel			Normal			EntireVerse
+1SA	8	15	Samuel			Normal			EntireVerse
+1SA	8	16	Samuel			Normal			EntireVerse
+1SA	8	17	Samuel			Normal			EntireVerse
 1SA	8	18	Samuel			Normal			Unspecified
 1SA	8	19	Israelites			Normal			Unspecified
 1SA	8	20	Israelites			Normal			Unspecified
@@ -5061,8 +5061,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	9	10	Saul			Normal			Unspecified
 1SA	9	11	Saul/servant of Saul (and of his father Kish)			Normal	servant of Saul (and of his father Kish)		EndOfVerse
 1SA	9	12	young women (maidens)			Normal			Unspecified
-1SA	9	13	young women (maidens)			Implicit			EntireVerse
-1SA	9	16	God		God (Yahweh)	Implicit			EntireVerse
+1SA	9	13	young women (maidens)			Normal			EntireVerse
+1SA	9	16	God		God (Yahweh)	Normal			EntireVerse
 1SA	9	17	God		God (Yahweh)	Normal			EndOfVerse
 1SA	9	18	Saul			Normal			EndOfVerse
 1SA	9	19	Samuel			Normal			Unspecified
@@ -5074,11 +5074,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	9	27	Samuel			Normal			Unspecified
 1SA	10	1	Samuel			Normal			Unspecified
 1SA	10	2	Samuel			Normal			Unspecified
-1SA	10	3	Samuel			Implicit			EntireVerse
-1SA	10	4	Samuel			Implicit			EntireVerse
-1SA	10	5	Samuel			Implicit			EntireVerse
-1SA	10	6	Samuel			Implicit			EntireVerse
-1SA	10	7	Samuel			Implicit			EntireVerse
+1SA	10	3	Samuel			Normal			EntireVerse
+1SA	10	4	Samuel			Normal			EntireVerse
+1SA	10	5	Samuel			Normal			EntireVerse
+1SA	10	6	Samuel			Normal			EntireVerse
+1SA	10	7	Samuel			Normal			EntireVerse
 1SA	10	8	Samuel			Normal			Unspecified
 1SA	10	11	people who had known Saul			Normal			EndOfVerse
 1SA	10	12	man of Gibeah			Normal			
@@ -5089,7 +5089,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	10	16	Saul			Normal			
 1SA	10	16	Samuel			Quotation			Unspecified
 1SA	10	18	Samuel			Normal			Unspecified
-1SA	10	19	Samuel			Implicit			EntireVerse
+1SA	10	19	Samuel			Normal			EntireVerse
 1SA	10	22	God		God (Yahweh)	Normal			
 1SA	10	22	Israelites			Normal			
 1SA	10	24	Israelites	shouting		Normal			
@@ -5108,8 +5108,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	11	13	Saul			Normal			Unspecified
 1SA	11	14	Samuel			Normal			Unspecified
 1SA	12	1	Samuel			Normal			EndOfVerse
-1SA	12	2	Samuel			Implicit			EntireVerse
-1SA	12	3	Samuel			Implicit			EntireVerse
+1SA	12	2	Samuel			Normal			EntireVerse
+1SA	12	3	Samuel			Normal			EntireVerse
 1SA	12	4	Israel, all			Normal			Unspecified
 1SA	12	5	Israel, all			Normal			
 1SA	12	5	Samuel			Normal			
@@ -5120,33 +5120,33 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	12	10	Samuel			Normal			Unspecified
 1SA	12	11	Samuel			Normal			Unspecified
 1SA	12	12	Samuel			Normal			Unspecified
-1SA	12	13	Samuel			Implicit			EntireVerse
-1SA	12	14	Samuel			Implicit			EntireVerse
-1SA	12	15	Samuel			Implicit			EntireVerse
-1SA	12	16	Samuel			Implicit			EntireVerse
-1SA	12	17	Samuel			Implicit			EntireVerse
+1SA	12	13	Samuel			Normal			EntireVerse
+1SA	12	14	Samuel			Normal			EntireVerse
+1SA	12	15	Samuel			Normal			EntireVerse
+1SA	12	16	Samuel			Normal			EntireVerse
+1SA	12	17	Samuel			Normal			EntireVerse
 1SA	12	19	Israel, all			Normal			EndOfVerse
 1SA	12	20	Samuel			Normal			Unspecified
-1SA	12	21	Samuel			Implicit			EntireVerse
-1SA	12	22	Samuel			Implicit			EntireVerse
-1SA	12	23	Samuel			Implicit			EntireVerse
-1SA	12	24	Samuel			Implicit			EntireVerse
-1SA	12	25	Samuel			Implicit			EntireVerse
+1SA	12	21	Samuel			Normal			EntireVerse
+1SA	12	22	Samuel			Normal			EntireVerse
+1SA	12	23	Samuel			Normal			EntireVerse
+1SA	12	24	Samuel			Normal			EntireVerse
+1SA	12	25	Samuel			Normal			EntireVerse
 1SA	13	3	Saul			Normal			EndOfVerse
 1SA	13	4	Saul's announcement			Potential			
 1SA	13	9	Saul			Normal			ContainedWithinVerse
 1SA	13	11	Samuel			Normal			
 1SA	13	11	Saul			Normal			
-1SA	13	12	Saul			Implicit			EntireVerse
+1SA	13	12	Saul			Normal			EntireVerse
 1SA	13	13	Samuel			Normal			Unspecified
-1SA	13	14	Samuel			Implicit			EntireVerse
+1SA	13	14	Samuel			Normal			EntireVerse
 1SA	13	19	Philistines			Normal			Unspecified
 1SA	14	1	Jonathan			Normal			Unspecified
 1SA	14	6	Jonathan			Normal			Unspecified
 1SA	14	7	Jonathan's armor bearer			Normal			Unspecified
 1SA	14	8	Jonathan			Normal			Unspecified
-1SA	14	9	Jonathan			Implicit			EntireVerse
-1SA	14	10	Jonathan			Implicit			EntireVerse
+1SA	14	9	Jonathan			Normal			EntireVerse
+1SA	14	10	Jonathan			Normal			EntireVerse
 1SA	14	11	Philistines			Normal			Unspecified
 1SA	14	12	Jonathan			Normal			
 1SA	14	12	Philistines			Normal			
@@ -5156,7 +5156,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	14	24	Saul			Normal			ContainedWithinVerse
 1SA	14	28	Israelite soldier in Saul's army			Normal			Unspecified
 1SA	14	29	Jonathan			Normal			Unspecified
-1SA	14	30	Jonathan			Implicit			EntireVerse
+1SA	14	30	Jonathan			Normal			EntireVerse
 1SA	14	33	messengers to Saul			Normal			
 1SA	14	33	Saul			Normal			
 1SA	14	34	Saul			Normal			Unspecified
@@ -5175,8 +5175,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	14	44	Saul			Normal			Unspecified
 1SA	14	45	Israelites (soldiers)			Normal			Unspecified
 1SA	15	1	Samuel			Normal			Unspecified
-1SA	15	2	Samuel			Implicit			EntireVerse
-1SA	15	3	Samuel			Implicit			EntireVerse
+1SA	15	2	Samuel			Normal			EntireVerse
+1SA	15	3	Samuel			Normal			EntireVerse
 1SA	15	6	Saul			Normal			Unspecified
 1SA	15	11	God		God (Yahweh)	Normal			StartOfVerse
 1SA	15	12	person who told Samuel where Saul was			Normal			EndOfVerse
@@ -5186,17 +5186,17 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	15	16	Samuel			Normal			
 1SA	15	16	Saul			Normal			
 1SA	15	17	Samuel			Normal			EndOfVerse
-1SA	15	18	Samuel			Implicit			EntireVerse
-1SA	15	19	Samuel			Implicit			EntireVerse
+1SA	15	18	Samuel			Normal			EntireVerse
+1SA	15	19	Samuel			Normal			EntireVerse
 1SA	15	20	Saul			Normal			Unspecified
-1SA	15	21	Saul			Implicit			EntireVerse
+1SA	15	21	Saul			Normal			EntireVerse
 1SA	15	22	Samuel			Normal			Unspecified
-1SA	15	23	Samuel			Implicit			EntireVerse
+1SA	15	23	Samuel			Normal			EntireVerse
 1SA	15	24	Saul			Normal			Unspecified
-1SA	15	25	Saul			Implicit			EntireVerse
+1SA	15	25	Saul			Normal			EntireVerse
 1SA	15	26	Samuel			Normal			Unspecified
 1SA	15	28	Samuel			Normal			EndOfVerse
-1SA	15	29	Samuel			Implicit			EntireVerse
+1SA	15	29	Samuel			Normal			EntireVerse
 1SA	15	30	Saul			Normal			Unspecified
 1SA	15	32	Agag, king of the Amalekites			Normal			
 1SA	15	32	Samuel			Normal			
@@ -5204,7 +5204,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	16	1	God		God (Yahweh)	Normal			EndOfVerse
 1SA	16	2	God		God (Yahweh)	Normal			
 1SA	16	2	Samuel			Normal			
-1SA	16	3	God		God (Yahweh)	Implicit			EntireVerse
+1SA	16	3	God		God (Yahweh)	Normal			EntireVerse
 1SA	16	4	Bethlehem, elders of	trembled		Normal			Unspecified
 1SA	16	5	Samuel			Normal			Unspecified
 1SA	16	6	Samuel	thought		Normal			Unspecified
@@ -5216,7 +5216,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	16	11	Samuel			Normal			
 1SA	16	12	God		God (Yahweh)	Normal			EndOfVerse
 1SA	16	15	Saul's servants			Normal			Unspecified
-1SA	16	16	Saul's servants			Implicit			EntireVerse
+1SA	16	16	Saul's servants			Normal			EntireVerse
 1SA	16	17	Saul			Normal			Unspecified
 1SA	16	18	Saul's servant (young)			Normal			Unspecified
 1SA	16	19	Saul's messengers to Jesse			Normal			
@@ -5226,10 +5226,10 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	16	22	Saul		Saul (via messenger)	Quotation			Unspecified
 1SA	16	22	Needs Review			Normal			
 1SA	17	8	Goliath, Philistine champion			Normal			EndOfVerse
-1SA	17	9	Goliath, Philistine champion			Implicit			EntireVerse
+1SA	17	9	Goliath, Philistine champion			Normal			EntireVerse
 1SA	17	10	Goliath, Philistine champion			Normal			Unspecified
 1SA	17	17	Jesse			Normal			EndOfVerse
-1SA	17	18	Jesse			Implicit			EntireVerse
+1SA	17	18	Jesse			Normal			EntireVerse
 1SA	17	19	Jesse			Potential			
 1SA	17	25	Israelites (soldiers)			Normal			EndOfVerse
 1SA	17	26	David			Normal			EndOfVerse
@@ -5239,16 +5239,16 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	17	32	David			Normal			Unspecified
 1SA	17	33	Saul			Normal			Unspecified
 1SA	17	34	David			Normal			EndOfVerse
-1SA	17	35	David			Implicit			EntireVerse
-1SA	17	36	David			Implicit			EntireVerse
+1SA	17	35	David			Normal			EntireVerse
+1SA	17	36	David			Normal			EntireVerse
 1SA	17	37	Saul			Normal			
 1SA	17	37	David			Normal			
 1SA	17	39	David			Normal			ContainedWithinVerse
 1SA	17	43	Goliath, Philistine champion			Normal			Unspecified
 1SA	17	44	Goliath, Philistine champion			Normal			EndOfVerse
 1SA	17	45	David			Normal			Unspecified
-1SA	17	46	David			Implicit			EntireVerse
-1SA	17	47	David			Implicit			EntireVerse
+1SA	17	46	David			Normal			EntireVerse
+1SA	17	47	David			Normal			EntireVerse
 1SA	17	55	Abner, commander of Saul's army			Normal			
 1SA	17	55	Saul			Normal			
 1SA	17	56	Saul			Normal			Unspecified
@@ -5285,28 +5285,28 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	20	4	Jonathan			Normal			Unspecified
 1SA	20	5	David			Normal			Unspecified
 1SA	20	6	David			Normal			Unspecified
-1SA	20	7	David			Implicit			EntireVerse
-1SA	20	8	David			Implicit			EntireVerse
+1SA	20	7	David			Normal			EntireVerse
+1SA	20	8	David			Normal			EntireVerse
 1SA	20	9	Jonathan			Normal			Unspecified
 1SA	20	10	David			Normal			Unspecified
 1SA	20	11	Jonathan			Normal			Unspecified
 1SA	20	12	Jonathan			Normal			EndOfVerse
-1SA	20	13	Jonathan			Implicit			EntireVerse
-1SA	20	14	Jonathan			Implicit			EntireVerse
-1SA	20	15	Jonathan			Implicit			EntireVerse
+1SA	20	13	Jonathan			Normal			EntireVerse
+1SA	20	14	Jonathan			Normal			EntireVerse
+1SA	20	15	Jonathan			Normal			EntireVerse
 1SA	20	16	Jonathan			Normal			Unspecified
 1SA	20	18	Jonathan			Normal			Unspecified
 1SA	20	19	Jonathan			Normal			Unspecified
 1SA	20	20	Jonathan			Normal			Unspecified
 1SA	20	21	Jonathan			Normal			Unspecified
 1SA	20	22	Jonathan			Normal			Unspecified
-1SA	20	23	Jonathan			Implicit			EntireVerse
+1SA	20	23	Jonathan			Normal			EntireVerse
 1SA	20	26	Saul			Normal			EndOfVerse
 1SA	20	27	Saul			Normal			EndOfVerse
 1SA	20	28	Jonathan			Normal			EndOfVerse
 1SA	20	29	Jonathan			Normal			Unspecified
 1SA	20	30	Saul			Normal			Unspecified
-1SA	20	31	Saul			Implicit			EntireVerse
+1SA	20	31	Saul			Normal			EntireVerse
 1SA	20	32	Jonathan			Normal			Unspecified
 1SA	20	36	Jonathan			Normal			ContainedWithinVerse
 1SA	20	37	Jonathan			Normal			EndOfVerse
@@ -5315,7 +5315,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	20	42	Jonathan			Normal			Unspecified
 1SA	21	1	Ahimelech the priest (son of Ahitub)			Normal			Unspecified
 1SA	21	2	David			Normal			Unspecified
-1SA	21	3	David			Implicit			EntireVerse
+1SA	21	3	David			Normal			EntireVerse
 1SA	21	4	Ahimelech the priest (son of Ahitub)			Normal			Unspecified
 1SA	21	5	David			Normal			Unspecified
 1SA	21	8	David			Normal			EndOfVerse
@@ -5323,24 +5323,24 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	21	9	David			Normal			
 1SA	21	11	servants of Achish, king of Gath			Normal			EndOfVerse
 1SA	21	14	Achish, king of Gath			Normal			Unspecified
-1SA	21	15	Achish, king of Gath			Implicit			EntireVerse
+1SA	21	15	Achish, king of Gath			Normal			EntireVerse
 1SA	22	3	David			Normal			Unspecified
 1SA	22	5	Gad the prophet, David's seer			Normal			ContainedWithinVerse
 1SA	22	7	Saul			Normal			EndOfVerse
-1SA	22	8	Saul			Implicit			EntireVerse
+1SA	22	8	Saul			Normal			EntireVerse
 1SA	22	9	Doeg the Edomite			Normal			EndOfVerse
-1SA	22	10	Doeg the Edomite			Implicit			EntireVerse
+1SA	22	10	Doeg the Edomite			Normal			EntireVerse
 1SA	22	11	Saul			Indirect			
 1SA	22	12	Ahimelech the priest (son of Ahitub)			Normal			
 1SA	22	12	Saul			Normal			
 1SA	22	13	Saul			Normal			Unspecified
 1SA	22	14	Ahimelech the priest (son of Ahitub)			Normal			Unspecified
-1SA	22	15	Ahimelech the priest (son of Ahitub)			Implicit			EntireVerse
+1SA	22	15	Ahimelech the priest (son of Ahitub)			Normal			EntireVerse
 1SA	22	16	Saul			Normal			Unspecified
 1SA	22	17	Saul			Normal			ContainedWithinVerse
 1SA	22	18	Saul			Normal			ContainedWithinVerse
 1SA	22	22	David			Normal			EndOfVerse
-1SA	22	23	David			Implicit			EntireVerse
+1SA	22	23	David			Normal			EntireVerse
 1SA	23	1	person who told David about Philistines			Normal			Unspecified
 1SA	23	2	David			Normal			
 1SA	23	2	God		God (Yahweh)	Normal			
@@ -5357,10 +5357,10 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	23	12	God		God (Yahweh)	Normal			
 1SA	23	17	Jonathan			Normal			Unspecified
 1SA	23	19	Ziphites			Normal			EndOfVerse
-1SA	23	20	Ziphites			Implicit			EntireVerse
+1SA	23	20	Ziphites			Normal			EntireVerse
 1SA	23	21	Saul			Normal			Unspecified
-1SA	23	22	Saul			Implicit			EntireVerse
-1SA	23	23	Saul			Implicit			EntireVerse
+1SA	23	22	Saul			Normal			EntireVerse
+1SA	23	23	Saul			Normal			EntireVerse
 1SA	23	27	messenger to Saul			Normal			EndOfVerse
 1SA	24	1	person who told Saul where David was			Normal			Unspecified
 1SA	24	4	David's men			Normal			ContainedWithinVerse
@@ -5371,39 +5371,39 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	24	11	David			Normal			Unspecified
 1SA	24	12	David			Normal			Unspecified
 1SA	24	13	David			Normal			Unspecified
-1SA	24	14	David			Implicit			EntireVerse
-1SA	24	15	David			Implicit			EntireVerse
+1SA	24	14	David			Normal			EntireVerse
+1SA	24	15	David			Normal			EntireVerse
 1SA	24	16	Saul			Normal			Unspecified
 1SA	24	17	Saul			Normal			Unspecified
-1SA	24	18	Saul			Implicit			EntireVerse
-1SA	24	19	Saul			Implicit			EntireVerse
-1SA	24	20	Saul			Implicit			EntireVerse
-1SA	24	21	Saul			Implicit			EntireVerse
+1SA	24	18	Saul			Normal			EntireVerse
+1SA	24	19	Saul			Normal			EntireVerse
+1SA	24	20	Saul			Normal			EntireVerse
+1SA	24	21	Saul			Normal			EntireVerse
 1SA	25	5	David			Normal			EndOfVerse
 1SA	25	6	David			Normal			Unspecified
-1SA	25	7	David			Implicit			EntireVerse
-1SA	25	8	David			Implicit			EntireVerse
+1SA	25	7	David			Normal			EntireVerse
+1SA	25	8	David			Normal			EntireVerse
 1SA	25	10	Nabal			Normal			EndOfVerse
-1SA	25	11	Nabal			Implicit			EntireVerse
+1SA	25	11	Nabal			Normal			EntireVerse
 1SA	25	13	David			Normal			Unspecified
 1SA	25	14	servant of Nabal			Normal			EndOfVerse
 1SA	25	15	servant of Nabal			Normal			Unspecified
 1SA	25	16	servant of Nabal			Normal			Unspecified
-1SA	25	17	servant of Nabal			Implicit			EntireVerse
+1SA	25	17	servant of Nabal			Normal			EntireVerse
 1SA	25	19	Abigail			Normal			ContainedWithinVerse
 1SA	25	21	David	thinking or talking to himself		Normal			EndOfVerse
-1SA	25	22	David	thinking or talking to himself		Implicit			EntireVerse
+1SA	25	22	David	thinking or talking to himself		Normal			EntireVerse
 1SA	25	24	Abigail			Normal			Unspecified
 1SA	25	25	Abigail			Normal			Unspecified
-1SA	25	26	Abigail			Implicit			EntireVerse
-1SA	25	27	Abigail			Implicit			EntireVerse
-1SA	25	28	Abigail			Implicit			EntireVerse
-1SA	25	29	Abigail			Implicit			EntireVerse
-1SA	25	30	Abigail			Implicit			EntireVerse
-1SA	25	31	Abigail			Implicit			EntireVerse
+1SA	25	26	Abigail			Normal			EntireVerse
+1SA	25	27	Abigail			Normal			EntireVerse
+1SA	25	28	Abigail			Normal			EntireVerse
+1SA	25	29	Abigail			Normal			EntireVerse
+1SA	25	30	Abigail			Normal			EntireVerse
+1SA	25	31	Abigail			Normal			EntireVerse
 1SA	25	32	David			Normal			EndOfVerse
-1SA	25	33	David			Implicit			EntireVerse
-1SA	25	34	David			Implicit			EntireVerse
+1SA	25	33	David			Normal			EntireVerse
+1SA	25	34	David			Normal			EntireVerse
 1SA	25	35	David			Normal			Unspecified
 1SA	25	39	David			Normal			Unspecified
 1SA	25	40	servants of David			Normal			Unspecified
@@ -5414,20 +5414,20 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	26	8	Abishai, Joab's brother			Normal			Unspecified
 1SA	26	9	David			Normal			Unspecified
 1SA	26	10	David			Normal			Unspecified
-1SA	26	11	David			Implicit			EntireVerse
+1SA	26	11	David			Normal			EntireVerse
 1SA	26	14	Abner, commander of Saul's army			Normal			
 1SA	26	14	David			Normal			
 1SA	26	15	David			Normal			Unspecified
-1SA	26	16	David			Implicit			EntireVerse
+1SA	26	16	David			Normal			EntireVerse
 1SA	26	17	David			Normal			
 1SA	26	17	Saul			Normal			
 1SA	26	18	David			Normal			Unspecified
-1SA	26	19	David			Implicit			EntireVerse
-1SA	26	20	David			Implicit			EntireVerse
+1SA	26	19	David			Normal			EntireVerse
+1SA	26	20	David			Normal			EntireVerse
 1SA	26	21	Saul			Normal			Unspecified
 1SA	26	22	David			Normal			Unspecified
-1SA	26	23	David			Implicit			EntireVerse
-1SA	26	24	David			Implicit			EntireVerse
+1SA	26	23	David			Normal			EntireVerse
+1SA	26	24	David			Normal			EntireVerse
 1SA	26	25	Saul			Normal			Unspecified
 1SA	27	1	David	thought		Normal			EndOfVerse
 1SA	27	5	David			Normal			EndOfVerse
@@ -5455,33 +5455,33 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1SA	28	15	Samuel (dead)			Normal			
 1SA	28	15	Saul			Normal			
 1SA	28	16	Samuel (dead)			Normal			EndOfVerse
-1SA	28	17	Samuel (dead)			Implicit			EntireVerse
-1SA	28	18	Samuel (dead)			Implicit			EntireVerse
-1SA	28	19	Samuel (dead)			Implicit			EntireVerse
+1SA	28	17	Samuel (dead)			Normal			EntireVerse
+1SA	28	18	Samuel (dead)			Normal			EntireVerse
+1SA	28	19	Samuel (dead)			Normal			EntireVerse
 1SA	28	21	woman medium			Normal			EndOfVerse
-1SA	28	22	woman medium			Implicit			EntireVerse
+1SA	28	22	woman medium			Normal			EntireVerse
 1SA	28	23	Saul			Normal			Unspecified
 1SA	29	3	Achish, king of Gath			Normal			
 1SA	29	3	Philistine commanders			Normal			
 1SA	29	4	Philistine commanders			Normal			EndOfVerse
-1SA	29	5	Philistine commanders			Implicit			EntireVerse
+1SA	29	5	Philistine commanders			Normal			EntireVerse
 1SA	29	6	Achish, king of Gath			Normal			EndOfVerse
-1SA	29	7	Achish, king of Gath			Implicit			EntireVerse
+1SA	29	7	Achish, king of Gath			Normal			EntireVerse
 1SA	29	8	David			Normal			Unspecified
 1SA	29	9	Achish, king of Gath			Normal			Unspecified
-1SA	29	10	Achish, king of Gath			Implicit			EntireVerse
+1SA	29	10	Achish, king of Gath			Normal			EntireVerse
 1SA	30	7	David			Normal			ContainedWithinVerse
 1SA	30	8	David			Normal			
 1SA	30	8	God		God (Yahweh)	Normal			
 1SA	30	13	David			Normal			
 1SA	30	13	Egyptian (slave of Amalekite)			Normal			
-1SA	30	14	Egyptian (slave of Amalekite)			Implicit			EntireVerse
+1SA	30	14	Egyptian (slave of Amalekite)			Normal			EntireVerse
 1SA	30	15	David			Normal			
 1SA	30	15	Egyptian (slave of Amalekite)			Normal			
 1SA	30	20	David's men			Normal			Unspecified
 1SA	30	22	evil men and troublemakers			Normal			EndOfVerse
 1SA	30	23	David			Normal			Unspecified
-1SA	30	24	David			Implicit			EntireVerse
+1SA	30	24	David			Normal			EntireVerse
 1SA	30	26	David			Normal			EndOfVerse
 1SA	31	4	Saul	critically wounded		Normal			ContainedWithinVerse
 2SA	1	3	David		David, king	Normal			
@@ -5493,7 +5493,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	1	7	Amalekite (young man from Saul's camp)			Normal			Unspecified
 2SA	1	8	Amalekite (young man from Saul's camp)			Normal			Unspecified
 2SA	1	9	Amalekite (young man from Saul's camp)			Normal			Unspecified
-2SA	1	10	Amalekite (young man from Saul's camp)			Implicit			EntireVerse
+2SA	1	10	Amalekite (young man from Saul's camp)			Normal			EntireVerse
 2SA	1	13	David			Normal			
 2SA	1	13	Amalekite (young man from Saul's camp)			Normal			
 2SA	1	14	David			Normal			Unspecified
@@ -5512,7 +5512,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	2	1	God		God (Yahweh)	Normal			
 2SA	2	4	Judah, men of			Normal			Unspecified
 2SA	2	5	David			Normal			EndOfVerse
-2SA	2	6	David			Implicit			EntireVerse
+2SA	2	6	David			Normal			EntireVerse
 2SA	2	7	David			Normal			StartOfVerse
 2SA	2	14	Abner, commander of Saul's army			Normal			
 2SA	2	14	Joab			Normal			
@@ -5524,32 +5524,32 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	2	27	Joab			Normal			EndOfVerse
 2SA	3	7	Ish-Bosheth, son of Saul			Normal			Unspecified
 2SA	3	8	Abner, commander of Saul's army			Normal			Unspecified
-2SA	3	9	Abner, commander of Saul's army			Implicit			EntireVerse
-2SA	3	10	Abner, commander of Saul's army			Implicit			EntireVerse
+2SA	3	9	Abner, commander of Saul's army			Normal			EntireVerse
+2SA	3	10	Abner, commander of Saul's army			Normal			EntireVerse
 2SA	3	12	Abner, commander of Saul's army			Normal			EndOfVerse
 2SA	3	13	David			Normal			Unspecified
 2SA	3	14	David			Normal			EndOfVerse
 2SA	3	16	Abner, commander of Saul's army			Normal			Unspecified
 2SA	3	17	Abner, commander of Saul's army			Normal			Unspecified
-2SA	3	18	Abner, commander of Saul's army			Implicit			EntireVerse
+2SA	3	18	Abner, commander of Saul's army			Normal			EntireVerse
 2SA	3	21	Abner, commander of Saul's army			Normal			ContainedWithinVerse
 2SA	3	23	messengers to Joab			Normal			Unspecified
 2SA	3	24	Joab			Normal			EndOfVerse
 2SA	3	25	Joab			Normal			Unspecified
 2SA	3	28	David		David, king	Normal			EndOfVerse
-2SA	3	29	David		David, king	Implicit			EntireVerse
+2SA	3	29	David		David, king	Normal			EntireVerse
 2SA	3	31	David		David, king	Normal			ContainedWithinVerse
 2SA	3	33	David		David, king	Normal			Unspecified
 2SA	3	34	David		David, king	Normal			Unspecified
 2SA	3	35	David		David, king	Normal			EndOfVerse
 2SA	3	38	David		David, king	Normal			EndOfVerse
-2SA	3	39	David		David, king	Implicit			EntireVerse
+2SA	3	39	David		David, king	Normal			EntireVerse
 2SA	4	8	Rechab/Baanah			Normal			EndOfVerse
 2SA	4	9	David		David, king	Normal			EndOfVerse
-2SA	4	10	David		David, king	Implicit			EntireVerse
-2SA	4	11	David		David, king	Implicit			EntireVerse
+2SA	4	10	David		David, king	Normal			EntireVerse
+2SA	4	11	David		David, king	Normal			EntireVerse
 2SA	5	1	Israel, all the tribes			Normal			EndOfVerse
-2SA	5	2	Israel, all the tribes			Implicit			EntireVerse
+2SA	5	2	Israel, all the tribes			Normal			EntireVerse
 2SA	5	6	Jebusites	taunting		Normal			
 2SA	5	6	Jebusites	thought		Normal			
 2SA	5	8	David		David, king	Normal			
@@ -5558,26 +5558,26 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	5	19	God		God (Yahweh)	Normal			
 2SA	5	20	David		David, king	Normal			Unspecified
 2SA	5	23	God		God (Yahweh)	Normal			Unspecified
-2SA	5	24	God		God (Yahweh)	Implicit			EntireVerse
+2SA	5	24	God		God (Yahweh)	Normal			EntireVerse
 2SA	6	9	David		David, king	Normal			EndOfVerse
 2SA	6	12	person who told David about Obed-Edom			Normal			Unspecified
 2SA	6	20	Michal, David's wife			Normal			Unspecified
 2SA	6	21	David		David, king	Normal			EndOfVerse
-2SA	6	22	David		David, king	Implicit			EntireVerse
+2SA	6	22	David		David, king	Normal			EntireVerse
 2SA	7	2	David		David, king	Normal			EndOfVerse
 2SA	7	3	Nathan		Nathan the prophet	Normal			Unspecified
 2SA	7	5	God		God (Yahweh)	Normal			Unspecified
-2SA	7	6	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	7	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	8	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	9	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	10	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	11	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	12	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	13	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	14	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	15	God		God (Yahweh)	Implicit			EntireVerse
-2SA	7	16	God		God (Yahweh)	Implicit			EntireVerse
+2SA	7	6	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	7	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	8	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	9	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	10	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	11	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	12	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	13	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	14	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	15	God		God (Yahweh)	Normal			EntireVerse
+2SA	7	16	God		God (Yahweh)	Normal			EntireVerse
 2SA	7	18	David		David, king	Normal			Unspecified
 2SA	7	19	David		David, king	Normal			Unspecified
 2SA	7	20	David		David, king	Normal			Unspecified
@@ -5587,9 +5587,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	7	24	David		David, king	Normal			Unspecified
 2SA	7	25	David		David, king	Normal			Unspecified
 2SA	7	26	David		David, king	Normal			Unspecified
-2SA	7	27	David		David, king	Implicit			EntireVerse
-2SA	7	28	David		David, king	Implicit			EntireVerse
-2SA	7	29	David		David, king	Implicit			EntireVerse
+2SA	7	27	David		David, king	Normal			EntireVerse
+2SA	7	28	David		David, king	Normal			EntireVerse
+2SA	7	29	David		David, king	Normal			EntireVerse
 2SA	8	10	Joram, son of Toi			Rare			
 2SA	8	10	Toi, king of Hamath			Rare			
 2SA	8	10	Needs Review			Potential			
@@ -5614,7 +5614,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	10	3	Ammonite nobles			Normal		2SA 10:3; 1CH 19:3	EndOfVerse
 2SA	10	5	David		David, king	Normal			EndOfVerse
 2SA	10	11	Joab			Normal			EndOfVerse
-2SA	10	12	Joab			Implicit			EntireVerse
+2SA	10	12	Joab			Normal			EntireVerse
 2SA	11	3	man answered David			Normal			
 2SA	11	3	David			Indirect			
 2SA	11	5	Bathsheba			Normal			Unspecified
@@ -5630,20 +5630,20 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	11	20	Joab			Normal			Unspecified
 2SA	11	21	Joab			Normal			Unspecified
 2SA	11	23	messenger from battle to David			Normal			Unspecified
-2SA	11	24	messenger from battle to David			Implicit			EntireVerse
+2SA	11	24	messenger from battle to David			Normal			EntireVerse
 2SA	11	25	David		David, king	Normal			EndOfVerse
 2SA	12	1	Nathan		Nathan the prophet	Normal			EndOfVerse
-2SA	12	2	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	3	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	4	Nathan		Nathan the prophet	Implicit			EntireVerse
+2SA	12	2	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	3	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	4	Nathan		Nathan the prophet	Normal			EntireVerse
 2SA	12	5	David		David, king	Normal			EndOfVerse
-2SA	12	6	David		David, king	Implicit			EntireVerse
+2SA	12	6	David		David, king	Normal			EntireVerse
 2SA	12	7	Nathan		Nathan the prophet	Normal			EndOfVerse
-2SA	12	8	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	9	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	10	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	11	Nathan		Nathan the prophet	Implicit			EntireVerse
-2SA	12	12	Nathan		Nathan the prophet	Implicit			EntireVerse
+2SA	12	8	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	9	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	10	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	11	Nathan		Nathan the prophet	Normal			EntireVerse
+2SA	12	12	Nathan		Nathan the prophet	Normal			EntireVerse
 2SA	12	13	David		David, king	Normal			
 2SA	12	13	Nathan		Nathan the prophet	Normal			
 2SA	12	14	Nathan		Nathan the prophet	Normal			Unspecified
@@ -5654,7 +5654,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	12	22	David		David, king	Normal			EndOfVerse
 2SA	12	23	David		David, king	Normal			Unspecified
 2SA	12	27	Joab			Normal			EndOfVerse
-2SA	12	28	Joab			Implicit			EntireVerse
+2SA	12	28	Joab			Normal			EntireVerse
 2SA	13	4	Amnon, son of David			Normal			
 2SA	13	4	Jonadab	shrewd		Normal			
 2SA	13	5	Jonadab	shrewd		Normal			EndOfVerse
@@ -5664,7 +5664,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	13	10	Amnon, son of David			Normal			ContainedWithinVerse
 2SA	13	11	Amnon, son of David			Normal			EndOfVerse
 2SA	13	12	Tamar, daughter of David			Normal			EndOfVerse
-2SA	13	13	Tamar, daughter of David			Implicit			EntireVerse
+2SA	13	13	Tamar, daughter of David			Normal			EntireVerse
 2SA	13	15	Amnon, son of David			Normal			EndOfVerse
 2SA	13	16	Tamar, daughter of David			Normal			Unspecified
 2SA	13	17	Amnon, son of David			Normal			EndOfVerse
@@ -5696,15 +5696,15 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	14	12	David		David, king	Dialogue			Unspecified
 2SA	14	12	woman from Tekoa			Dialogue			Unspecified
 2SA	14	13	woman from Tekoa			Dialogue			Unspecified
-2SA	14	14	woman from Tekoa			Implicit			EntireVerse
-2SA	14	15	woman from Tekoa			Implicit			EntireVerse
-2SA	14	16	woman from Tekoa			Implicit			EntireVerse
-2SA	14	17	woman from Tekoa			Implicit			EntireVerse
+2SA	14	14	woman from Tekoa			Dialogue			EntireVerse
+2SA	14	15	woman from Tekoa			Dialogue			EntireVerse
+2SA	14	16	woman from Tekoa			Dialogue			EntireVerse
+2SA	14	17	woman from Tekoa			Dialogue			EntireVerse
 2SA	14	18	David		David, king	Dialogue			Unspecified
 2SA	14	18	woman from Tekoa			Dialogue			Unspecified
 2SA	14	19	David		David, king	Dialogue			Unspecified
 2SA	14	19	woman from Tekoa			Dialogue			EndOfVerse
-2SA	14	20	woman from Tekoa			Implicit			EntireVerse
+2SA	14	20	woman from Tekoa			Dialogue			EntireVerse
 2SA	14	21	David		David, king	Dialogue			EndOfVerse
 2SA	14	22	Joab			Dialogue			EndOfVerse
 2SA	14	24	David		David, king	Indirect			
@@ -5718,7 +5718,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	15	3	Absalom, son of David			Normal			EndOfVerse
 2SA	15	4	Absalom, son of David			Normal			Unspecified
 2SA	15	7	Absalom, son of David			Normal			EndOfVerse
-2SA	15	8	Absalom, son of David			Implicit			EntireVerse
+2SA	15	8	Absalom, son of David			Normal			EntireVerse
 2SA	15	9	David		David, king	Normal			Unspecified
 2SA	15	10	Absalom, son of David			Normal			
 2SA	15	10	Absalom's secret messengers			Normal			
@@ -5726,19 +5726,19 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	15	14	David		David, king	Normal			EndOfVerse
 2SA	15	15	officials of David			Normal			Unspecified
 2SA	15	19	David		David, king	Normal			EndOfVerse
-2SA	15	20	David		David, king	Implicit			EntireVerse
+2SA	15	20	David		David, king	Normal			EntireVerse
 2SA	15	21	Ittai			Normal			EndOfVerse
 2SA	15	22	David		David, king	Normal			Unspecified
 2SA	15	25	David		David, king	Normal			EndOfVerse
-2SA	15	26	David		David, king	Implicit			EntireVerse
+2SA	15	26	David		David, king	Normal			EntireVerse
 2SA	15	27	David		David, king	Normal			Unspecified
-2SA	15	28	David		David, king	Implicit			EntireVerse
+2SA	15	28	David		David, king	Normal			EntireVerse
 2SA	15	31	David		David, king	Normal			
 2SA	15	31	informer		informer (to David)	Normal			
 2SA	15	33	David		David, king	Normal			Unspecified
 2SA	15	34	David		David, king	Normal			Unspecified
-2SA	15	35	David		David, king	Implicit			EntireVerse
-2SA	15	36	David		David, king	Implicit			EntireVerse
+2SA	15	35	David		David, king	Normal			EntireVerse
+2SA	15	36	David		David, king	Normal			EntireVerse
 2SA	16	2	David		David, king	Dialogue			Unspecified
 2SA	16	2	Ziba, servant of Saul's household			Dialogue			Unspecified
 2SA	16	3	David		David, king	Dialogue			Unspecified
@@ -5746,11 +5746,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	16	4	David		David, king	Dialogue			Unspecified
 2SA	16	4	Ziba, servant of Saul's household			Dialogue			Unspecified
 2SA	16	7	Shimei			Normal			EndOfVerse
-2SA	16	8	Shimei			Implicit			EntireVerse
+2SA	16	8	Shimei			Normal			EntireVerse
 2SA	16	9	Abishai, Joab's brother			Normal			EndOfVerse
 2SA	16	10	David		David, king	Normal			EndOfVerse
 2SA	16	11	David		David, king	Normal			EndOfVerse
-2SA	16	12	David		David, king	Implicit			EntireVerse
+2SA	16	12	David		David, king	Normal			EntireVerse
 2SA	16	16	Hushai, David's friend			Normal			EndOfVerse
 2SA	16	17	Absalom, son of David			Dialogue			EndOfVerse
 2SA	16	18	Hushai, David's friend			Dialogue			Unspecified
@@ -5758,17 +5758,17 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	16	20	Absalom, son of David			Dialogue			EndOfVerse
 2SA	16	21	Ahithophel			Dialogue			EndOfVerse
 2SA	17	1	Ahithophel			Normal			EndOfVerse
-2SA	17	2	Ahithophel			Implicit			EntireVerse
+2SA	17	2	Ahithophel			Normal			EntireVerse
 2SA	17	3	Ahithophel			Normal			Unspecified
 2SA	17	5	Absalom, son of David			Normal			EndOfVerse
 2SA	17	6	Absalom, son of David			Normal			EndOfVerse
 2SA	17	7	Hushai, David's friend			Normal			Unspecified
 2SA	17	8	Hushai, David's friend			Normal			Unspecified
-2SA	17	9	Hushai, David's friend			Implicit			EntireVerse
-2SA	17	10	Hushai, David's friend			Implicit			EntireVerse
-2SA	17	11	Hushai, David's friend			Implicit			EntireVerse
-2SA	17	12	Hushai, David's friend			Implicit			EntireVerse
-2SA	17	13	Hushai, David's friend			Implicit			EntireVerse
+2SA	17	9	Hushai, David's friend			Normal			EntireVerse
+2SA	17	10	Hushai, David's friend			Normal			EntireVerse
+2SA	17	11	Hushai, David's friend			Normal			EntireVerse
+2SA	17	12	Hushai, David's friend			Normal			EntireVerse
+2SA	17	13	Hushai, David's friend			Normal			EntireVerse
 2SA	17	14	Absalom, son of David/Israel, men of			Normal	Absalom, son of David		Unspecified
 2SA	17	15	Hushai, David's friend			Normal			Unspecified
 2SA	17	16	Hushai, David's friend			Normal			Unspecified
@@ -5783,7 +5783,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	18	10	men of David, one			Normal			EndOfVerse
 2SA	18	11	Joab			Normal			Unspecified
 2SA	18	12	men of David, one			Normal			EndOfVerse
-2SA	18	13	men of David, one			Implicit			EntireVerse
+2SA	18	13	men of David, one			Normal			EntireVerse
 2SA	18	14	Joab			Normal			Unspecified
 2SA	18	18	Absalom, son of David			Normal			ContainedWithinVerse
 2SA	18	19	Ahimaaz (messenger)			Normal			EndOfVerse
@@ -5810,31 +5810,31 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	19	2	informer		informer (to army)	Indirect			
 2SA	19	4	David	lamenting	David, king	Normal			EndOfVerse
 2SA	19	5	Joab			Normal			EndOfVerse
-2SA	19	6	Joab			Implicit			EntireVerse
-2SA	19	7	Joab			Implicit			EntireVerse
+2SA	19	6	Joab			Normal			EntireVerse
+2SA	19	7	Joab			Normal			EntireVerse
 2SA	19	8	informer		informer (to army)	Indirect			
 2SA	19	9	people, Israel, tribes of			Normal			EndOfVerse
 2SA	19	10	people, Israel, tribes of			Normal			Unspecified
 2SA	19	11	David		David, king	Normal			EndOfVerse
-2SA	19	12	David		David, king	Implicit			EntireVerse
+2SA	19	12	David		David, king	Normal			EntireVerse
 2SA	19	13	David		David, king	Normal			Unspecified
 2SA	19	14	Judah, men of			Normal			Unspecified
 2SA	19	19	Shimei			Normal			EndOfVerse
-2SA	19	20	Shimei			Implicit			EntireVerse
+2SA	19	20	Shimei			Normal			EntireVerse
 2SA	19	21	Abishai, Joab's brother			Normal			EndOfVerse
 2SA	19	22	David		David, king	Normal			EndOfVerse
 2SA	19	23	David		David, king	Normal			Unspecified
 2SA	19	25	David		David, king	Normal			EndOfVerse
 2SA	19	26	Mephibosheth, son of Jonathan			Normal			Unspecified
-2SA	19	27	Mephibosheth, son of Jonathan			Implicit			EntireVerse
-2SA	19	28	Mephibosheth, son of Jonathan			Implicit			EntireVerse
+2SA	19	27	Mephibosheth, son of Jonathan			Normal			EntireVerse
+2SA	19	28	Mephibosheth, son of Jonathan			Normal			EntireVerse
 2SA	19	29	David		David, king	Normal			EndOfVerse
 2SA	19	30	Mephibosheth, son of Jonathan			Normal			Unspecified
 2SA	19	33	David		David, king	Normal			EndOfVerse
 2SA	19	34	Barzillai (old)			Normal			Unspecified
-2SA	19	35	Barzillai (old)			Implicit			EntireVerse
-2SA	19	36	Barzillai (old)			Implicit			EntireVerse
-2SA	19	37	Barzillai (old)			Implicit			EntireVerse
+2SA	19	35	Barzillai (old)			Normal			EntireVerse
+2SA	19	36	Barzillai (old)			Normal			EntireVerse
+2SA	19	37	Barzillai (old)			Normal			EntireVerse
 2SA	19	38	David		David, king	Normal			Unspecified
 2SA	19	41	Israel		Israel, all the men of	Normal			EndOfVerse
 2SA	19	42	Judah, men of			Normal			EndOfVerse
@@ -5848,7 +5848,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	20	17	Joab			Dialogue			Unspecified
 2SA	20	17	woman, wise			Dialogue			Unspecified
 2SA	20	18	woman, wise			Dialogue			EndOfVerse
-2SA	20	19	woman, wise			Implicit			EntireVerse
+2SA	20	19	woman, wise			Dialogue			EntireVerse
 2SA	20	20	Joab			Dialogue			Unspecified
 2SA	20	21	Joab			Dialogue			StartOfVerse
 2SA	20	21	woman, wise			Dialogue			Unspecified
@@ -5947,17 +5947,17 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	1	11	Nathan		Nathan the prophet	Normal			Unspecified
 1KI	1	12	Nathan		Nathan the prophet	Normal			Unspecified
 1KI	1	13	Nathan		Nathan the prophet	Normal			Unspecified
-1KI	1	14	Nathan		Nathan the prophet	Implicit			EntireVerse
+1KI	1	14	Nathan		Nathan the prophet	Normal			EntireVerse
 1KI	1	16	David (old)	very old	David, king	Normal			Unspecified
 1KI	1	17	Bathsheba			Normal			Unspecified
-1KI	1	18	Bathsheba			Implicit			EntireVerse
-1KI	1	19	Bathsheba			Implicit			EntireVerse
-1KI	1	20	Bathsheba			Implicit			EntireVerse
-1KI	1	21	Bathsheba			Implicit			EntireVerse
+1KI	1	18	Bathsheba			Normal			EntireVerse
+1KI	1	19	Bathsheba			Normal			EntireVerse
+1KI	1	20	Bathsheba			Normal			EntireVerse
+1KI	1	21	Bathsheba			Normal			EntireVerse
 1KI	1	23	person who told David of Nathan's arrival			Normal			Unspecified
 1KI	1	24	Nathan		Nathan the prophet	Normal			Unspecified
 1KI	1	25	Nathan		Nathan the prophet	Normal			Unspecified
-1KI	1	26	Nathan		Nathan the prophet	Implicit			EntireVerse
+1KI	1	26	Nathan		Nathan the prophet	Normal			EntireVerse
 1KI	1	27	Nathan		Nathan the prophet	Normal			StartOfVerse
 1KI	1	28	David (old)	very old	David, king	Normal			ContainedWithinVerse
 1KI	1	29	David (old)	very old	David, king	Normal			EndOfVerse
@@ -5966,9 +5966,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	1	32	David (old)	very old	David, king	Normal			ContainedWithinVerse
 1KI	1	33	David (old)	very old	David, king	Normal			Unspecified
 1KI	1	34	David (old)	very old	David, king	Normal			Unspecified
-1KI	1	35	David (old)	very old	David, king	Implicit			EntireVerse
+1KI	1	35	David (old)	very old	David, king	Normal			EntireVerse
 1KI	1	36	Benaiah, son of Jehoiada			Normal			Unspecified
-1KI	1	37	Benaiah, son of Jehoiada			Implicit			EntireVerse
+1KI	1	37	Benaiah, son of Jehoiada			Normal			EntireVerse
 1KI	1	39	people, all the	shouting		Normal			EndOfVerse
 1KI	1	41	Joab			Normal			EndOfVerse
 1KI	1	42	Adonijah, son of David			Normal			Unspecified
@@ -5981,13 +5981,13 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	1	51	informer		informer (to Solomon)	Normal			EndOfVerse
 1KI	1	52	Solomon, king			Normal			EndOfVerse
 1KI	1	53	Solomon, king			Normal			Unspecified
-1KI	2	2	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	3	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	4	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	5	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	6	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	7	David (old)	very old	David, king	Implicit			EntireVerse
-1KI	2	8	David (old)	very old	David, king	Implicit			EntireVerse
+1KI	2	2	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	3	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	4	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	5	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	6	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	7	David (old)	very old	David, king	Normal			EntireVerse
+1KI	2	8	David (old)	very old	David, king	Normal			EntireVerse
 1KI	2	9	David (old)	very old	David, king	Normal			Unspecified
 1KI	2	13	Adonijah, son of David			Normal			
 1KI	2	13	Bathsheba			Normal			
@@ -6003,7 +6003,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	2	21	Bathsheba			Normal			Unspecified
 1KI	2	22	Solomon, king			Normal			Unspecified
 1KI	2	23	Solomon, king			Normal			Unspecified
-1KI	2	24	Solomon, king			Implicit			EntireVerse
+1KI	2	24	Solomon, king			Normal			EntireVerse
 1KI	2	26	Solomon, king			Normal			Unspecified
 1KI	2	29	person who informed Solomon			Normal			
 1KI	2	29	Solomon, king			Normal			
@@ -6011,29 +6011,29 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	2	30	Joab			Normal			
 1KI	2	31	Solomon, king			Normal			Unspecified
 1KI	2	32	Solomon, king			Normal			Unspecified
-1KI	2	33	Solomon, king			Implicit			EntireVerse
+1KI	2	33	Solomon, king			Normal			EntireVerse
 1KI	2	36	Solomon, king			Normal			EndOfVerse
-1KI	2	37	Solomon, king			Implicit			EntireVerse
+1KI	2	37	Solomon, king			Normal			EntireVerse
 1KI	2	38	Shimei			Normal			Unspecified
 1KI	2	39	person who told Shimei where his servants were			Normal			Unspecified
 1KI	2	42	Solomon, king			Normal			EndOfVerse
-1KI	2	43	Solomon, king			Implicit			EntireVerse
+1KI	2	43	Solomon, king			Normal			EntireVerse
 1KI	2	44	Solomon, king			Normal			Unspecified
-1KI	2	45	Solomon, king			Implicit			EntireVerse
+1KI	2	45	Solomon, king			Normal			EntireVerse
 1KI	3	5	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 1KI	3	6	Solomon, king			Normal			EndOfVerse
-1KI	3	7	Solomon, king			Implicit			EntireVerse
-1KI	3	8	Solomon, king			Implicit			EntireVerse
-1KI	3	9	Solomon, king			Implicit			EntireVerse
+1KI	3	7	Solomon, king			Normal			EntireVerse
+1KI	3	8	Solomon, king			Normal			EntireVerse
+1KI	3	9	Solomon, king			Normal			EntireVerse
 1KI	3	11	God		God (Yahweh) (in vision)	Normal			EndOfVerse
-1KI	3	12	God		God (Yahweh) (in vision)	Implicit			EntireVerse
-1KI	3	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
-1KI	3	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+1KI	3	12	God		God (Yahweh) (in vision)	Normal			EntireVerse
+1KI	3	13	God		God (Yahweh) (in vision)	Normal			EntireVerse
+1KI	3	14	God		God (Yahweh) (in vision)	Normal			EntireVerse
 1KI	3	17	prostitute, one			Normal			EndOfVerse
-1KI	3	18	prostitute, one			Implicit			EntireVerse
-1KI	3	19	prostitute, one			Implicit			EntireVerse
-1KI	3	20	prostitute, one			Implicit			EntireVerse
-1KI	3	21	prostitute, one			Implicit			EntireVerse
+1KI	3	18	prostitute, one			Normal			EntireVerse
+1KI	3	19	prostitute, one			Normal			EntireVerse
+1KI	3	20	prostitute, one			Normal			EntireVerse
+1KI	3	21	prostitute, one			Normal			EntireVerse
 1KI	3	22	prostitute, one			Normal			
 1KI	3	22	prostitute, other			Normal			
 1KI	3	23	Solomon, king			Normal			EndOfVerse
@@ -6042,23 +6042,23 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	3	26	prostitute, one		prostitute, one (mother of living baby)	Normal			
 1KI	3	26	prostitute, other		prostitute, other (mother of dead baby)	Normal			
 1KI	3	27	Solomon, king			Normal			Unspecified
-1KI	5	3	Solomon, king	sent message		Implicit			EntireVerse
-1KI	5	4	Solomon, king	sent message		Implicit			EntireVerse
-1KI	5	5	Solomon, king	sent message		Implicit			EntireVerse
-1KI	5	6	Solomon, king	sent message		Implicit			EntireVerse
+1KI	5	3	Solomon, king	sent message		Normal			EntireVerse
+1KI	5	4	Solomon, king	sent message		Normal			EntireVerse
+1KI	5	5	Solomon, king	sent message		Normal			EntireVerse
+1KI	5	6	Solomon, king	sent message		Normal			EntireVerse
 1KI	5	7	Hiram, king of Tyre			Normal			EndOfVerse
 1KI	5	8	Hiram, king of Tyre	sent word		Normal			EndOfVerse
-1KI	5	9	Hiram, king of Tyre	sent word		Implicit			EntireVerse
-1KI	6	12	God		God (Yahweh)	Implicit			EntireVerse
-1KI	6	13	God		God (Yahweh)	Implicit			EntireVerse
+1KI	5	9	Hiram, king of Tyre	sent word		Normal			EntireVerse
+1KI	6	12	God		God (Yahweh)	Normal			EntireVerse
+1KI	6	13	God		God (Yahweh)	Normal			EntireVerse
 1KI	8	12	Solomon, king			Normal			EndOfVerse
 1KI	8	13	Solomon, king			Normal			Unspecified
 1KI	8	15	Solomon, king	blessing		Normal			Unspecified
 1KI	8	16	Solomon, king	blessing		Normal			Unspecified
 1KI	8	17	Solomon, king	blessing		Normal			Unspecified
 1KI	8	18	Solomon, king	blessing		Normal			Unspecified
-1KI	8	19	Solomon, king	blessing		Implicit			EntireVerse
-1KI	8	20	Solomon, king	blessing		Implicit			EntireVerse
+1KI	8	19	Solomon, king	blessing		Normal			EntireVerse
+1KI	8	20	Solomon, king	blessing		Normal			EntireVerse
 1KI	8	21	Solomon, king	blessing		Normal			StartOfVerse
 1KI	8	23	Solomon, king	praying		Normal			Unspecified
 1KI	8	24	Solomon, king	praying		Normal			Unspecified
@@ -6091,11 +6091,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	8	51	Solomon, king	praying		Normal			Unspecified
 1KI	8	52	Solomon, king	praying		Normal			Unspecified
 1KI	8	53	Solomon, king	praying		Normal			Unspecified
-1KI	8	56	Solomon, king	blessing		Implicit			EntireVerse
-1KI	8	57	Solomon, king	blessing		Implicit			EntireVerse
-1KI	8	58	Solomon, king	blessing		Implicit			EntireVerse
-1KI	8	59	Solomon, king	blessing		Implicit			EntireVerse
-1KI	8	60	Solomon, king	blessing		Implicit			EntireVerse
+1KI	8	56	Solomon, king	blessing		Normal			EntireVerse
+1KI	8	57	Solomon, king	blessing		Normal			EntireVerse
+1KI	8	58	Solomon, king	blessing		Normal			EntireVerse
+1KI	8	59	Solomon, king	blessing		Normal			EntireVerse
+1KI	8	60	Solomon, king	blessing		Normal			EntireVerse
 1KI	8	61	Solomon, king	blessing		Normal			StartOfVerse
 1KI	9	3	God		God (Yahweh) (in vision)	Normal			Unspecified
 1KI	9	4	God		God (Yahweh) (in vision)	Normal			Unspecified
@@ -6106,32 +6106,32 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	9	9	God		God (Yahweh) (in vision)	Normal			Unspecified
 1KI	9	13	Hiram, king of Tyre			Normal			Unspecified
 1KI	10	6	queen of Sheba			Normal			EndOfVerse
-1KI	10	7	queen of Sheba			Implicit			EntireVerse
-1KI	10	8	queen of Sheba			Implicit			EntireVerse
-1KI	10	9	queen of Sheba			Implicit			EntireVerse
+1KI	10	7	queen of Sheba			Normal			EntireVerse
+1KI	10	8	queen of Sheba			Normal			EntireVerse
+1KI	10	9	queen of Sheba			Normal			EntireVerse
 1KI	11	2	God		God (Yahweh)	Normal			Unspecified
 1KI	11	11	God		God (Yahweh)	Normal			EndOfVerse
-1KI	11	12	God		God (Yahweh)	Implicit			EntireVerse
+1KI	11	12	God		God (Yahweh)	Normal			EntireVerse
 1KI	11	13	God		God (Yahweh)	Normal			Unspecified
 1KI	11	21	Hadad the Edomite			Normal			EndOfVerse
 1KI	11	22	Hadad the Edomite			Normal			
 1KI	11	22	Pharaoh (6th)		Pharaoh	Normal			
 1KI	11	31	Ahijah the prophet			Normal			EndOfVerse
-1KI	11	32	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	33	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	34	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	35	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	36	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	37	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	38	Ahijah the prophet			Implicit			EntireVerse
-1KI	11	39	Ahijah the prophet			Implicit			EntireVerse
-1KI	12	4	Jeroboam/Israel, all			Implicit			EntireVerse
+1KI	11	32	Ahijah the prophet			Normal			EntireVerse
+1KI	11	33	Ahijah the prophet			Normal			EntireVerse
+1KI	11	34	Ahijah the prophet			Normal			EntireVerse
+1KI	11	35	Ahijah the prophet			Normal			EntireVerse
+1KI	11	36	Ahijah the prophet			Normal			EntireVerse
+1KI	11	37	Ahijah the prophet			Normal			EntireVerse
+1KI	11	38	Ahijah the prophet			Normal			EntireVerse
+1KI	11	39	Ahijah the prophet			Normal			EntireVerse
+1KI	12	4	Jeroboam/Israel, all			Normal			EntireVerse
 1KI	12	5	Rehoboam, king			Normal			Unspecified
 1KI	12	6	Rehoboam, king			Normal			Unspecified
 1KI	12	7	elders in Shechem		elders	Normal		1KI 12.7;2CH 10.7	Unspecified
 1KI	12	9	Rehoboam, king			Normal			Unspecified
 1KI	12	10	young men (advisors of Rehoboam)			Normal		1KI 12.10;2CH 10.10	EndOfVerse
-1KI	12	11	young men (advisors of Rehoboam)			Implicit		1KI 12.11;2CH 10.11	EntireVerse
+1KI	12	11	young men (advisors of Rehoboam)			Normal		1KI 12.11;2CH 10.11	EntireVerse
 1KI	12	12	narrator-1KI			Quotation			Unspecified
 1KI	12	12	Rehoboam, king			Quotation			Unspecified
 1KI	12	14	Rehoboam, king			Normal			EndOfVerse
@@ -6149,52 +6149,52 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	13	6	Jeroboam		Jeroboam, king of Israel	Normal			Unspecified
 1KI	13	7	Jeroboam		Jeroboam, king of Israel	Normal			Unspecified
 1KI	13	8	man of God from Judah			Normal			Unspecified
-1KI	13	9	man of God from Judah			Implicit			EntireVerse
+1KI	13	9	man of God from Judah			Normal			EntireVerse
 1KI	13	12	old prophet in Bethel			Normal			Unspecified
 1KI	13	13	old prophet in Bethel			Normal			Unspecified
 1KI	13	14	man of God from Judah			Normal			
 1KI	13	14	old prophet in Bethel			Normal			
 1KI	13	15	old prophet in Bethel	deceitful		Normal			Unspecified
 1KI	13	16	man of God from Judah			Normal			Unspecified
-1KI	13	17	man of God from Judah			Implicit			EntireVerse
+1KI	13	17	man of God from Judah			Normal			EntireVerse
 1KI	13	18	old prophet in Bethel	deceitful		Normal			ContainedWithinVerse
 1KI	13	21	old prophet in Bethel			Normal			EndOfVerse
-1KI	13	22	old prophet in Bethel			Implicit			EntireVerse
+1KI	13	22	old prophet in Bethel			Normal			EntireVerse
 1KI	13	26	old prophet in Bethel			Normal			EndOfVerse
 1KI	13	27	old prophet in Bethel			Normal			Unspecified
 1KI	13	30	sons of prophet in Bethel			Normal			
 1KI	13	30	old prophet in Bethel			Normal			
 1KI	13	30	Needs Review			Normal			
 1KI	13	31	old prophet in Bethel			Normal			EndOfVerse
-1KI	13	32	old prophet in Bethel			Implicit			EntireVerse
+1KI	13	32	old prophet in Bethel			Normal			EntireVerse
 1KI	14	2	Jeroboam		Jeroboam, king of Israel	Normal			Unspecified
 1KI	14	3	Jeroboam		Jeroboam, king of Israel	Normal			Unspecified
 1KI	14	5	God		God (Yahweh)	Normal			Unspecified
 1KI	14	6	Ahijah the prophet			Normal			Unspecified
 1KI	14	7	Ahijah the prophet			Normal			Unspecified
-1KI	14	8	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	9	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	10	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	11	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	12	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	13	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	14	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	15	Ahijah the prophet			Implicit			EntireVerse
-1KI	14	16	Ahijah the prophet			Implicit			EntireVerse
-1KI	15	19	Asa, king of Judah			Implicit			EntireVerse
-1KI	16	2	God		God (Yahweh)	Implicit			EntireVerse
-1KI	16	3	God		God (Yahweh)	Implicit			EntireVerse
-1KI	16	4	God		God (Yahweh)	Implicit			EntireVerse
+1KI	14	8	Ahijah the prophet			Normal			EntireVerse
+1KI	14	9	Ahijah the prophet			Normal			EntireVerse
+1KI	14	10	Ahijah the prophet			Normal			EntireVerse
+1KI	14	11	Ahijah the prophet			Normal			EntireVerse
+1KI	14	12	Ahijah the prophet			Normal			EntireVerse
+1KI	14	13	Ahijah the prophet			Normal			EntireVerse
+1KI	14	14	Ahijah the prophet			Normal			EntireVerse
+1KI	14	15	Ahijah the prophet			Normal			EntireVerse
+1KI	14	16	Ahijah the prophet			Normal			EntireVerse
+1KI	15	19	Asa, king of Judah			Normal			EntireVerse
+1KI	16	2	God		God (Yahweh)	Normal			EntireVerse
+1KI	16	3	God		God (Yahweh)	Normal			EntireVerse
+1KI	16	4	God		God (Yahweh)	Normal			EntireVerse
 1KI	16	16	messenger telling about Zimri's conspiracy			Indirect			
 1KI	17	1	Elijah			Normal			EndOfVerse
-1KI	17	3	God		God (Yahweh)	Implicit			EntireVerse
-1KI	17	4	God		God (Yahweh)	Implicit			EntireVerse
-1KI	17	9	God		God (Yahweh)	Implicit			EntireVerse
+1KI	17	3	God		God (Yahweh)	Normal			EntireVerse
+1KI	17	4	God		God (Yahweh)	Normal			EntireVerse
+1KI	17	9	God		God (Yahweh)	Normal			EntireVerse
 1KI	17	10	Elijah			Normal			Unspecified
 1KI	17	11	Elijah			Normal			EndOfVerse
 1KI	17	12	widow at Zarephath			Normal			Unspecified
 1KI	17	13	Elijah			Normal			Unspecified
-1KI	17	14	Elijah			Implicit			EntireVerse
+1KI	17	14	Elijah			Normal			EntireVerse
 1KI	17	18	widow at Zarephath			Normal			EndOfVerse
 1KI	17	19	Elijah			Normal			Unspecified
 1KI	17	20	Elijah			Normal			EndOfVerse
@@ -6209,11 +6209,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	18	7	Obadiah, manager of Ahab's palace			Dialogue			EndOfVerse
 1KI	18	8	Elijah			Dialogue			Unspecified
 1KI	18	9	Obadiah, manager of Ahab's palace			Normal			Unspecified
-1KI	18	10	Obadiah, manager of Ahab's palace			Implicit			EntireVerse
-1KI	18	11	Obadiah, manager of Ahab's palace			Implicit			EntireVerse
-1KI	18	12	Obadiah, manager of Ahab's palace			Implicit			EntireVerse
-1KI	18	13	Obadiah, manager of Ahab's palace			Implicit			EntireVerse
-1KI	18	14	Obadiah, manager of Ahab's palace			Implicit			EntireVerse
+1KI	18	10	Obadiah, manager of Ahab's palace			Normal			EntireVerse
+1KI	18	11	Obadiah, manager of Ahab's palace			Normal			EntireVerse
+1KI	18	12	Obadiah, manager of Ahab's palace			Normal			EntireVerse
+1KI	18	13	Obadiah, manager of Ahab's palace			Normal			EntireVerse
+1KI	18	14	Obadiah, manager of Ahab's palace			Normal			EntireVerse
 1KI	18	15	Elijah			Dialogue			Unspecified
 1KI	18	17	Ahab, king of Israel			Dialogue			EndOfVerse
 1KI	18	18	Elijah			Dialogue			Unspecified
@@ -6221,7 +6221,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	18	20	Ahab, king of Israel			Indirect			
 1KI	18	21	Elijah			Normal			ContainedWithinVerse
 1KI	18	22	Elijah			Normal			Unspecified
-1KI	18	23	Elijah			Implicit			EntireVerse
+1KI	18	23	Elijah			Normal			EntireVerse
 1KI	18	24	Elijah			Normal			
 1KI	18	24	people, all the			Normal			
 1KI	18	25	Elijah			Normal			EndOfVerse
@@ -6233,7 +6233,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	18	33	Elijah			Normal			Unspecified
 1KI	18	34	Elijah			Normal			Unspecified
 1KI	18	36	Elijah			Normal			EndOfVerse
-1KI	18	37	Elijah			Implicit			EntireVerse
+1KI	18	37	Elijah			Normal			EntireVerse
 1KI	18	39	people, all the			Normal			EndOfVerse
 1KI	18	40	Elijah			Normal			ContainedWithinVerse
 1KI	18	41	Elijah			Normal			EndOfVerse
@@ -6251,16 +6251,16 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	19	13	God		gentle whisper (God)	Normal			EndOfVerse
 1KI	19	14	Elijah			Normal			EndOfVerse
 1KI	19	15	God		God (Yahweh)	Normal			EndOfVerse
-1KI	19	16	God		God (Yahweh)	Implicit			EntireVerse
-1KI	19	17	God		God (Yahweh)	Implicit			EntireVerse
+1KI	19	16	God		God (Yahweh)	Normal			EntireVerse
+1KI	19	17	God		God (Yahweh)	Normal			EntireVerse
 1KI	19	18	God		God (Yahweh)	Normal			StartOfVerse
 1KI	19	20	Elijah			Dialogue			Unspecified
 1KI	19	20	Elisha			Dialogue			Unspecified
 1KI	20	2	messengers of Ben-Hadad, king of Aram			Normal			Unspecified
-1KI	20	3	messengers of Ben-Hadad, king of Aram			Implicit			EntireVerse
+1KI	20	3	messengers of Ben-Hadad, king of Aram			Normal			EntireVerse
 1KI	20	4	Ahab, king of Israel			Normal			Unspecified
 1KI	20	5	messengers of Ben-Hadad, king of Aram			Normal			EndOfVerse
-1KI	20	6	messengers of Ben-Hadad, king of Aram			Implicit			EntireVerse
+1KI	20	6	messengers of Ben-Hadad, king of Aram			Normal			EntireVerse
 1KI	20	7	Ahab, king of Israel			Normal			EndOfVerse
 1KI	20	8	elders/Israelites			Normal			Unspecified
 1KI	20	9	Ahab, king of Israel			Normal			ContainedWithinVerse
@@ -6278,7 +6278,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	20	18	Ben-Hadad, king of Aram			Normal			Unspecified
 1KI	20	22	prophet			Normal			Unspecified
 1KI	20	23	officials of Ben-Hadad, king of Aram			Normal			Unspecified
-1KI	20	24	officials of Ben-Hadad, king of Aram			Implicit			EntireVerse
+1KI	20	24	officials of Ben-Hadad, king of Aram			Normal			EntireVerse
 1KI	20	25	officials of Ben-Hadad, king of Aram			Normal			StartOfVerse
 1KI	20	28	man of God (prophet to the king of Israel)			Normal			EndOfVerse
 1KI	20	31	officials of Ben-Hadad, king of Aram			Normal			EndOfVerse
@@ -6309,13 +6309,13 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	21	13	scoundrels			Normal			Unspecified
 1KI	21	14	messengers to Jezebel			Normal			EndOfVerse
 1KI	21	15	Jezebel			Normal			EndOfVerse
-1KI	21	18	God		God (Yahweh)	Implicit			EntireVerse
+1KI	21	18	God		God (Yahweh)	Normal			EntireVerse
 1KI	21	19	God		God (Yahweh)	Normal			Unspecified
 1KI	21	20	Ahab, king of Israel			Dialogue			Unspecified
 1KI	21	20	Elijah			Dialogue			EndOfVerse
-1KI	21	21	Elijah			Implicit			EntireVerse
-1KI	21	22	Elijah			Implicit			EntireVerse
-1KI	21	23	Elijah			Implicit			EntireVerse
+1KI	21	21	Elijah			Normal			EntireVerse
+1KI	21	22	Elijah			Normal			EntireVerse
+1KI	21	23	Elijah			Normal			EntireVerse
 1KI	21	24	Elijah			Normal			Unspecified
 1KI	21	29	God		God (Yahweh)	Normal			Unspecified
 1KI	22	3	Ahab, king of Israel			Normal			EndOfVerse
@@ -6341,11 +6341,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1KI	22	20	Micaiah, son of Imlah			Normal			Unspecified
 1KI	22	21	Micaiah, son of Imlah			Normal			Unspecified
 1KI	22	22	Micaiah, son of Imlah			Normal			Unspecified
-1KI	22	23	Micaiah, son of Imlah			Implicit			EntireVerse
+1KI	22	23	Micaiah, son of Imlah			Normal			EntireVerse
 1KI	22	24	Zedekiah, son of Kenaanah, false prophet			Normal		1KI 22.24;2CH 18.23	Unspecified
 1KI	22	25	Micaiah, son of Imlah			Normal			EndOfVerse
 1KI	22	26	Ahab, king of Israel			Normal			EndOfVerse
-1KI	22	27	Ahab, king of Israel			Implicit			EntireVerse
+1KI	22	27	Ahab, king of Israel			Normal			EntireVerse
 1KI	22	28	Micaiah, son of Imlah			Normal			ContainedWithinVerse
 1KI	22	30	Ahab, king of Israel			Normal			ContainedWithinVerse
 1KI	22	31	Ben-Hadad, king of Aram		king of Syria (Aram)	Normal			Unspecified
@@ -6366,7 +6366,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	1	11	captain, second			Normal			Unspecified
 2KI	1	12	Elijah			Normal			Unspecified
 2KI	1	13	captain, third			Normal			EndOfVerse
-2KI	1	14	captain, third			Implicit			EntireVerse
+2KI	1	14	captain, third			Normal			EntireVerse
 2KI	1	15	Yahweh's angel			Normal	Jesus		ContainedWithinVerse
 2KI	1	16	Elijah			Normal			EndOfVerse
 2KI	2	2	Elijah			Normal			
@@ -6407,21 +6407,21 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	3	15	Elisha			Normal			Unspecified
 2KI	3	16	Elisha			Normal			Unspecified
 2KI	3	17	Elisha			Normal			Unspecified
-2KI	3	18	Elisha			Implicit			EntireVerse
-2KI	3	19	Elisha			Implicit			EntireVerse
+2KI	3	18	Elisha			Normal			EntireVerse
+2KI	3	19	Elisha			Normal			EntireVerse
 2KI	3	23	Moabites			Normal			Unspecified
 2KI	4	1	widow (from company of prophets)			Dialogue			EndOfVerse
 2KI	4	2	Elisha			Dialogue			Unspecified
 2KI	4	2	widow (from company of prophets)			Dialogue			Unspecified
 2KI	4	3	Elisha			Dialogue			EndOfVerse
-2KI	4	4	Elisha			Implicit			EntireVerse
+2KI	4	4	Elisha			Dialogue			EntireVerse
 2KI	4	6	son of widow			Dialogue			Unspecified
 2KI	4	6	widow (from company of prophets)			Dialogue			Unspecified
 2KI	4	7	Elisha			Dialogue			ContainedWithinVerse
 2KI	4	7	widow (from company of prophets)			Rare			
 2KI	4	7	Needs Review			Rare			
 2KI	4	9	Shunammite woman			Normal			EndOfVerse
-2KI	4	10	Shunammite woman			Implicit			EntireVerse
+2KI	4	10	Shunammite woman			Normal			EntireVerse
 2KI	4	12	Elisha			Dialogue			Unspecified
 2KI	4	13	Elisha			Dialogue			Unspecified
 2KI	4	13	Shunammite woman			Dialogue			Unspecified
@@ -6468,7 +6468,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	5	15	Naaman			Normal			EndOfVerse
 2KI	5	16	Elisha			Normal			Unspecified
 2KI	5	17	Naaman			Normal			Unspecified
-2KI	5	18	Naaman			Implicit			EntireVerse
+2KI	5	18	Naaman			Normal			EntireVerse
 2KI	5	19	Elisha			Normal			Unspecified
 2KI	5	20	Gehazi		Gehazi, servant of Elisha	Normal			EndOfVerse
 2KI	5	21	Naaman			Normal			Unspecified
@@ -6504,7 +6504,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	6	27	Joram (Jehoram), king of Israel			Normal			Unspecified
 2KI	6	28	Joram (Jehoram), king of Israel			Normal			
 2KI	6	28	woman in famine			Normal			
-2KI	6	29	woman in famine			Implicit			EntireVerse
+2KI	6	29	woman in famine			Normal			EntireVerse
 2KI	6	31	Joram (Jehoram), king of Israel			Normal			Unspecified
 2KI	6	32	Elisha			Normal			EndOfVerse
 2KI	6	33	Joram (Jehoram), king of Israel			Normal			EndOfVerse
@@ -6512,7 +6512,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	7	2	Elisha			Normal			
 2KI	7	2	officer of king of Israel, on whose arm the king leaned			Normal			
 2KI	7	3	men with leprosy, four			Normal			Unspecified
-2KI	7	4	men with leprosy, four			Implicit			EntireVerse
+2KI	7	4	men with leprosy, four			Normal			EntireVerse
 2KI	7	6	Aramean soldiers			Normal			Unspecified
 2KI	7	9	men with leprosy, four			Normal			EndOfVerse
 2KI	7	10	men with leprosy, four			Normal			EndOfVerse
@@ -6549,9 +6549,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	9	5	company of the prophets, one of (young man)			Normal			
 2KI	9	5	Jehu, son of Nimshi			Normal			
 2KI	9	6	company of the prophets, one of (young man)			Normal			EndOfVerse
-2KI	9	7	company of the prophets, one of (young man)			Implicit			EntireVerse
-2KI	9	8	company of the prophets, one of (young man)			Implicit			EntireVerse
-2KI	9	9	company of the prophets, one of (young man)			Implicit			EntireVerse
+2KI	9	7	company of the prophets, one of (young man)			Normal			EntireVerse
+2KI	9	8	company of the prophets, one of (young man)			Normal			EntireVerse
+2KI	9	9	company of the prophets, one of (young man)			Normal			EntireVerse
 2KI	9	10	company of the prophets, one of (young man)			Normal			StartOfVerse
 2KI	9	11	army officer, one of			Normal			
 2KI	9	11	Jehu, son of Nimshi			Normal			
@@ -6579,9 +6579,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	9	33	Jehu, son of Nimshi			Normal			ContainedWithinVerse
 2KI	9	34	Jehu, son of Nimshi			Normal			EndOfVerse
 2KI	9	36	Jehu, son of Nimshi			Normal			EndOfVerse
-2KI	9	37	Jehu, son of Nimshi	letter		Implicit			EntireVerse
-2KI	10	2	Jehu, son of Nimshi	letter		Implicit			EntireVerse
-2KI	10	3	Jehu, son of Nimshi	letter		Implicit			EntireVerse
+2KI	9	37	Jehu, son of Nimshi	letter		Normal			EntireVerse
+2KI	10	2	Jehu, son of Nimshi	letter		Normal			EntireVerse
+2KI	10	3	Jehu, son of Nimshi	letter		Normal			EntireVerse
 2KI	10	4	officials of Samaria/guardians of Ahab's sons		officials (elders) of Samaria (Jezreel) and the guardians of Ahab's sons	Normal			EndOfVerse
 2KI	10	5	palace administrator and overseer (elder) of the city			Normal			
 2KI	10	5	officials of Samaria/guardians of Ahab's sons		officials (elders) of Samaria (Jezreel) and the guardians of Ahab's sons	Normal			
@@ -6589,7 +6589,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	10	8	Jehu, son of Nimshi			Normal			
 2KI	10	8	messenger from guardians of Ahab's children			Normal			
 2KI	10	9	Jehu, son of Nimshi			Normal			EndOfVerse
-2KI	10	10	Jehu, son of Nimshi			Implicit			EntireVerse
+2KI	10	10	Jehu, son of Nimshi			Normal			EntireVerse
 2KI	10	13	Jehu, son of Nimshi			Normal			
 2KI	10	13	relatives of Ahaziah, king of Judah			Normal			
 2KI	10	14	Jehu, son of Nimshi			Normal			Unspecified
@@ -6605,14 +6605,14 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	10	25	Jehu, son of Nimshi			Normal			ContainedWithinVerse
 2KI	10	30	God		God (Yahweh)	Normal			EndOfVerse
 2KI	11	5	Jehoiada the priest			Normal			EndOfVerse
-2KI	11	6	Jehoiada the priest			Implicit			EntireVerse
-2KI	11	7	Jehoiada the priest			Implicit			EntireVerse
-2KI	11	8	Jehoiada the priest			Implicit			EntireVerse
+2KI	11	6	Jehoiada the priest			Normal			EntireVerse
+2KI	11	7	Jehoiada the priest			Normal			EntireVerse
+2KI	11	8	Jehoiada the priest			Normal			EntireVerse
 2KI	11	12	people at coronation of King Joash	shouting		Normal			EndOfVerse
 2KI	11	14	Athaliah, mother of Ahaziah (Queen)		Athaliah	Normal			EndOfVerse
 2KI	11	15	Jehoiada the priest			Normal			Unspecified
 2KI	12	4	Joash, king of Judah		Jehoash (Joash), king of Judah	Normal			EndOfVerse
-2KI	12	5	Joash, king of Judah		Jehoash (Joash), king of Judah	Implicit			EntireVerse
+2KI	12	5	Joash, king of Judah		Jehoash (Joash), king of Judah	Normal			EntireVerse
 2KI	12	7	Joash, king of Judah		Jehoash (Joash), king of Judah	Normal			EndOfVerse
 2KI	13	14	Jehoash, king of Israel		Joash (Jehoash), king of Israel	Normal			EndOfVerse
 2KI	13	15	Elisha (old)			Normal			Unspecified
@@ -6625,7 +6625,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	14	6	narrator-2KI			Quotation			Unspecified
 2KI	14	8	Amaziah, king of Judah			Normal			EndOfVerse
 2KI	14	9	Jehoash, king of Israel			Normal			Unspecified
-2KI	14	10	Jehoash, king of Israel			Implicit			EntireVerse
+2KI	14	10	Jehoash, king of Israel			Normal			EntireVerse
 2KI	15	12	God		God (Yahweh)	Quotation			Unspecified
 2KI	15	12	narrator-2KI			Quotation			Unspecified
 2KI	16	7	Ahaz, king of Judah			Normal			EndOfVerse
@@ -6651,56 +6651,56 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	17	39	narrator-2KI			Quotation			Unspecified
 2KI	18	14	Hezekiah, king of Judah			Normal			ContainedWithinVerse
 2KI	18	19	Rabshakeh			Normal		2KI 18:19; 2CH 32:10; ISA 36:4	EndOfVerse
-2KI	18	20	Rabshakeh			Implicit		2KI 18:20; ISA 36:5	EntireVerse
-2KI	18	21	Rabshakeh			Implicit		2KI 18:21; ISA 36:6	EntireVerse
-2KI	18	22	Rabshakeh			Implicit		2KI 18:22; 2CH 32:12; ISA 36:7	EntireVerse
-2KI	18	23	Rabshakeh			Implicit		2KI 18:23; ISA 36:8	EntireVerse
-2KI	18	24	Rabshakeh			Implicit		2KI 18:24; ISA 36:9	EntireVerse
-2KI	18	25	Rabshakeh			Implicit		2KI 18:25; ISA 36:10	EntireVerse
+2KI	18	20	Rabshakeh			Normal		2KI 18:20; ISA 36:5	EntireVerse
+2KI	18	21	Rabshakeh			Normal		2KI 18:21; ISA 36:6	EntireVerse
+2KI	18	22	Rabshakeh			Normal		2KI 18:22; 2CH 32:12; ISA 36:7	EntireVerse
+2KI	18	23	Rabshakeh			Normal		2KI 18:23; ISA 36:8	EntireVerse
+2KI	18	24	Rabshakeh			Normal		2KI 18:24; ISA 36:9	EntireVerse
+2KI	18	25	Rabshakeh			Normal		2KI 18:25; ISA 36:10	EntireVerse
 2KI	18	26	Eliakim/Shebna/Joah			Normal	Eliakim		EndOfVerse
 2KI	18	27	Rabshakeh			Normal		2KI 18:27; ISA 36:12	EndOfVerse
 2KI	18	28	Rabshakeh			Normal		2KI 18:28; ISA 36:13	EndOfVerse
-2KI	18	29	Rabshakeh			Implicit		2KI 18:29; ISA 36:14	EntireVerse
-2KI	18	30	Rabshakeh			Implicit		2KI 18:30; 2CH 32:11; ISA 36:15	EntireVerse
-2KI	18	31	Rabshakeh			Implicit		2KI 18:31; ISA 36:16	EntireVerse
-2KI	18	32	Rabshakeh			Implicit		2KI 18:32; ISA 36:17-18a	EntireVerse
-2KI	18	33	Rabshakeh			Implicit		2KI 18:33; 2CH 32:13; ISA 36:18b	EntireVerse
-2KI	18	34	Rabshakeh			Implicit		2KI 18:34; ISA 36:19	EntireVerse
-2KI	18	35	Rabshakeh			Implicit		2KI 18:35; 2CH 32:14; ISA 36:20	EntireVerse
+2KI	18	29	Rabshakeh			Normal		2KI 18:29; ISA 36:14	EntireVerse
+2KI	18	30	Rabshakeh			Normal		2KI 18:30; 2CH 32:11; ISA 36:15	EntireVerse
+2KI	18	31	Rabshakeh			Normal		2KI 18:31; ISA 36:16	EntireVerse
+2KI	18	32	Rabshakeh			Normal		2KI 18:32; ISA 36:17-18a	EntireVerse
+2KI	18	33	Rabshakeh			Normal		2KI 18:33; 2CH 32:13; ISA 36:18b	EntireVerse
+2KI	18	34	Rabshakeh			Normal		2KI 18:34; ISA 36:19	EntireVerse
+2KI	18	35	Rabshakeh			Normal		2KI 18:35; 2CH 32:14; ISA 36:20	EntireVerse
 2KI	18	36	Hezekiah, king of Judah			Normal			Unspecified
 2KI	19	3	Eliakim/Shebna/chief priests			Normal	Eliakim		Unspecified
-2KI	19	4	Eliakim/Shebna/chief priests			Implicit	Eliakim		EntireVerse
+2KI	19	4	Eliakim/Shebna/chief priests			Normal	Eliakim		EntireVerse
 2KI	19	6	Isaiah			Normal			EndOfVerse
 2KI	19	7	Isaiah			Normal			Unspecified
 2KI	19	9	person who informed Rabshakeh			Normal			Unspecified
 2KI	19	10	Rabshakeh			Normal		2KI 19:10; ISA 37:10	Unspecified
-2KI	19	11	Rabshakeh			Implicit		2KI 19:11; ISA 37:11	EntireVerse
-2KI	19	12	Rabshakeh			Implicit		2KI 19:12; ISA 37:12	EntireVerse
+2KI	19	11	Rabshakeh			Normal		2KI 19:11; ISA 37:11	EntireVerse
+2KI	19	12	Rabshakeh			Normal		2KI 19:12; ISA 37:12	EntireVerse
 2KI	19	13	Rabshakeh			Normal		2KI 19:13; ISA 37:13	StartOfVerse
 2KI	19	15	Hezekiah, king of Judah			Normal			EndOfVerse
-2KI	19	16	Hezekiah, king of Judah			Implicit			EntireVerse
-2KI	19	17	Hezekiah, king of Judah			Implicit			EntireVerse
-2KI	19	18	Hezekiah, king of Judah			Implicit			EntireVerse
+2KI	19	16	Hezekiah, king of Judah			Normal			EntireVerse
+2KI	19	17	Hezekiah, king of Judah			Normal			EntireVerse
+2KI	19	18	Hezekiah, king of Judah			Normal			EntireVerse
 2KI	19	19	Hezekiah, king of Judah			Normal			StartOfVerse
 2KI	19	20	Isaiah			Normal			EndOfVerse
-2KI	19	21	Isaiah			Implicit			EntireVerse
+2KI	19	21	Isaiah			Normal			EntireVerse
 2KI	19	22	Isaiah			Normal			Unspecified
 2KI	19	23	Isaiah			Normal			Unspecified
-2KI	19	24	Isaiah			Implicit			EntireVerse
+2KI	19	24	Isaiah			Normal			EntireVerse
 2KI	19	25	Isaiah			Normal			Unspecified
 2KI	19	26	Isaiah			Normal			Unspecified
 2KI	19	27	Isaiah			Normal			Unspecified
 2KI	19	28	Isaiah			Normal			Unspecified
-2KI	19	29	Isaiah			Implicit			EntireVerse
-2KI	19	30	Isaiah			Implicit			EntireVerse
-2KI	19	31	Isaiah			Implicit			EntireVerse
-2KI	19	32	Isaiah			Implicit			EntireVerse
-2KI	19	33	Isaiah			Implicit			EntireVerse
+2KI	19	29	Isaiah			Normal			EntireVerse
+2KI	19	30	Isaiah			Normal			EntireVerse
+2KI	19	31	Isaiah			Normal			EntireVerse
+2KI	19	32	Isaiah			Normal			EntireVerse
+2KI	19	33	Isaiah			Normal			EntireVerse
 2KI	19	34	Isaiah			Normal			Unspecified
 2KI	20	1	Isaiah			Normal			EndOfVerse
 2KI	20	3	Hezekiah, king of Judah			Normal			StartOfVerse
 2KI	20	5	God		God (Yahweh)	Normal			Unspecified
-2KI	20	6	God		God (Yahweh)	Implicit			EntireVerse
+2KI	20	6	God		God (Yahweh)	Normal			EntireVerse
 2KI	20	7	Isaiah		Isaiah the prophet	Normal			Unspecified
 2KI	20	8	Hezekiah, king of Judah			Normal			EndOfVerse
 2KI	20	9	Isaiah			Normal			EndOfVerse
@@ -6711,7 +6711,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	20	15	Isaiah		Isaiah the prophet	Normal			
 2KI	20	16	Isaiah			Normal			EndOfVerse
 2KI	20	17	Isaiah			Normal			Unspecified
-2KI	20	18	Isaiah			Implicit			EntireVerse
+2KI	20	18	Isaiah			Normal			EntireVerse
 2KI	20	19	Hezekiah, king of Judah			Normal			Unspecified
 2KI	21	4	God		God (Yahweh)	Quotation			Unspecified
 2KI	21	4	narrator-2KI			Quotation			Unspecified
@@ -6736,12 +6736,12 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2KI	22	8	Hilkiah, high priest			Normal			ContainedWithinVerse
 2KI	22	9	Shaphan, secretary			Normal			EndOfVerse
 2KI	22	10	Shaphan, secretary			Normal			Unspecified
-2KI	22	13	Josiah, king of Judah			Implicit			EntireVerse
+2KI	22	13	Josiah, king of Judah			Normal			EntireVerse
 2KI	22	15	Huldah, prophetess			Normal			Unspecified
-2KI	22	16	Huldah, prophetess			Implicit			EntireVerse
-2KI	22	17	Huldah, prophetess			Implicit			EntireVerse
-2KI	22	18	Huldah, prophetess			Implicit			EntireVerse
-2KI	22	19	Huldah, prophetess			Implicit			EntireVerse
+2KI	22	16	Huldah, prophetess			Normal			EntireVerse
+2KI	22	17	Huldah, prophetess			Normal			EntireVerse
+2KI	22	18	Huldah, prophetess			Normal			EntireVerse
+2KI	22	19	Huldah, prophetess			Normal			EntireVerse
 2KI	22	20	Huldah, prophetess			Normal			StartOfVerse
 2KI	23	17	Josiah, king of Judah			Normal			
 2KI	23	17	men of Bethel			Normal			
@@ -6776,10 +6776,10 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	14	14	God			Normal			
 1CH	14	14	David			Rare			
 1CH	14	14	Needs Review			Rare			
-1CH	14	15	God		God (Yahweh)	Implicit			EntireVerse
+1CH	14	15	God		God (Yahweh)	Normal			EntireVerse
 1CH	15	2	David		David, king	Normal			Unspecified
 1CH	15	12	David		David, king	Normal			EndOfVerse
-1CH	15	13	David		David, king	Implicit			EntireVerse
+1CH	15	13	David		David, king	Normal			EntireVerse
 1CH	16	8	David	psalm	David, king	Implicit			
 1CH	16	9	David	psalm	David, king	Implicit			
 1CH	16	10	David	psalm	David, king	Implicit			
@@ -6816,16 +6816,16 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	17	1	David		David, king	Normal			EndOfVerse
 1CH	17	2	Nathan			Normal			Unspecified
 1CH	17	4	God		God (Yahweh)	Normal			Unspecified
-1CH	17	5	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	6	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	7	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	8	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	9	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	10	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	11	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	12	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	13	God		God (Yahweh)	Implicit			EntireVerse
-1CH	17	14	God		God (Yahweh)	Implicit			EntireVerse
+1CH	17	5	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	6	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	7	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	8	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	9	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	10	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	11	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	12	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	13	God		God (Yahweh)	Normal			EntireVerse
+1CH	17	14	God		God (Yahweh)	Normal			EntireVerse
 1CH	17	16	David		David, king	Normal			Unspecified
 1CH	17	17	David		David, king	Normal			Unspecified
 1CH	17	18	David		David, king	Normal			Unspecified
@@ -6835,21 +6835,21 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	17	22	David		David, king	Normal			Unspecified
 1CH	17	23	David		David, king	Normal			Unspecified
 1CH	17	24	David		David, king	Normal			Unspecified
-1CH	17	25	David		David, king	Implicit			EntireVerse
-1CH	17	26	David		David, king	Implicit			EntireVerse
-1CH	17	27	David		David, king	Implicit			EntireVerse
+1CH	17	25	David		David, king	Normal			EntireVerse
+1CH	17	26	David		David, king	Normal			EntireVerse
+1CH	17	27	David		David, king	Normal			EntireVerse
 1CH	19	2	David			Normal			ContainedWithinVerse
 1CH	19	3	Ammonite nobles			Normal		2SA 10:3; 1CH 19:3	EndOfVerse
 1CH	19	5	David			Normal			EndOfVerse
 1CH	19	12	Joab			Normal			EndOfVerse
-1CH	19	13	Joab			Implicit			EntireVerse
+1CH	19	13	Joab			Normal			EntireVerse
 1CH	21	2	David		David, king	Normal			EndOfVerse
 1CH	21	1	Satan (Devil)			Potential			
 1CH	21	3	Joab			Normal			EndOfVerse
 1CH	21	8	David		David, king	Normal			EndOfVerse
-1CH	21	10	God		God (Yahweh)	Implicit			EntireVerse
+1CH	21	10	God		God (Yahweh)	Normal			EntireVerse
 1CH	21	11	Gad the prophet, David's seer			Normal			EndOfVerse
-1CH	21	12	Gad the prophet, David's seer			Implicit			EntireVerse
+1CH	21	12	Gad the prophet, David's seer			Normal			EntireVerse
 1CH	21	13	David		David, king	Normal			Unspecified
 1CH	21	15	God		God (Yahweh)	Normal			ContainedWithinVerse
 1CH	21	17	David			Normal			ContainedWithinVerse
@@ -6860,16 +6860,16 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	22	5	David		David, king	Normal			Unspecified
 1CH	22	7	David		David, king	Normal			Unspecified
 1CH	22	8	David		David, king	Normal			Unspecified
-1CH	22	9	David		David, king	Implicit			EntireVerse
-1CH	22	10	David		David, king	Implicit			EntireVerse
-1CH	22	11	David		David, king	Implicit			EntireVerse
-1CH	22	12	David		David, king	Implicit			EntireVerse
-1CH	22	13	David		David, king	Implicit			EntireVerse
-1CH	22	14	David		David, king	Implicit			EntireVerse
-1CH	22	15	David		David, king	Implicit			EntireVerse
-1CH	22	16	David		David, king	Implicit			EntireVerse
+1CH	22	9	David		David, king	Normal			EntireVerse
+1CH	22	10	David		David, king	Normal			EntireVerse
+1CH	22	11	David		David, king	Normal			EntireVerse
+1CH	22	12	David		David, king	Normal			EntireVerse
+1CH	22	13	David		David, king	Normal			EntireVerse
+1CH	22	14	David		David, king	Normal			EntireVerse
+1CH	22	15	David		David, king	Normal			EntireVerse
+1CH	22	16	David		David, king	Normal			EntireVerse
 1CH	22	18	David		David, king	Normal			Unspecified
-1CH	22	19	David		David, king	Implicit			EntireVerse
+1CH	22	19	David		David, king	Normal			EntireVerse
 1CH	23	4	David		David, king	Normal			Unspecified
 1CH	23	5	David		David, king	Normal			Unspecified
 1CH	23	25	David		David, king	Normal			Unspecified
@@ -6879,48 +6879,48 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	28	4	David		David, king	Normal			Unspecified
 1CH	28	5	David		David, king	Normal			Unspecified
 1CH	28	6	David		David, king	Normal			Unspecified
-1CH	28	7	David		David, king	Implicit			EntireVerse
+1CH	28	7	David		David, king	Normal			EntireVerse
 1CH	28	8	David		David, king	Normal			Unspecified
-1CH	28	9	David		David, king	Implicit			EntireVerse
-1CH	28	10	David		David, king	Implicit			EntireVerse
+1CH	28	9	David		David, king	Normal			EntireVerse
+1CH	28	10	David		David, king	Normal			EntireVerse
 1CH	28	19	David		David, king	Normal			Unspecified
 1CH	28	20	David		David, king	Normal			Unspecified
-1CH	28	21	David		David, king	Implicit			EntireVerse
+1CH	28	21	David		David, king	Normal			EntireVerse
 1CH	29	1	David		David, king	Normal			EndOfVerse
-1CH	29	2	David		David, king	Implicit			EntireVerse
-1CH	29	3	David		David, king	Implicit			EntireVerse
-1CH	29	4	David		David, king	Implicit			EntireVerse
-1CH	29	5	David		David, king	Implicit			EntireVerse
+1CH	29	2	David		David, king	Normal			EntireVerse
+1CH	29	3	David		David, king	Normal			EntireVerse
+1CH	29	4	David		David, king	Normal			EntireVerse
+1CH	29	5	David		David, king	Normal			EntireVerse
 1CH	29	10	David		David, king	Normal			EndOfVerse
-1CH	29	11	David		David, king	Implicit			EntireVerse
-1CH	29	12	David		David, king	Implicit			EntireVerse
-1CH	29	13	David		David, king	Implicit			EntireVerse
-1CH	29	14	David		David, king	Implicit			EntireVerse
-1CH	29	15	David		David, king	Implicit			EntireVerse
-1CH	29	16	David		David, king	Implicit			EntireVerse
-1CH	29	17	David		David, king	Implicit			EntireVerse
-1CH	29	18	David		David, king	Implicit			EntireVerse
-1CH	29	19	David		David, king	Implicit			EntireVerse
+1CH	29	11	David		David, king	Normal			EntireVerse
+1CH	29	12	David		David, king	Normal			EntireVerse
+1CH	29	13	David		David, king	Normal			EntireVerse
+1CH	29	14	David		David, king	Normal			EntireVerse
+1CH	29	15	David		David, king	Normal			EntireVerse
+1CH	29	16	David		David, king	Normal			EntireVerse
+1CH	29	17	David		David, king	Normal			EntireVerse
+1CH	29	18	David		David, king	Normal			EntireVerse
+1CH	29	19	David		David, king	Normal			EntireVerse
 1CH	29	20	David		David, king	Normal			ContainedWithinVerse
 2CH	1	7	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 2CH	1	8	Solomon, king			Normal			EndOfVerse
-2CH	1	9	Solomon, king			Implicit			EntireVerse
-2CH	1	10	Solomon, king			Implicit			EntireVerse
+2CH	1	9	Solomon, king			Normal			EntireVerse
+2CH	1	10	Solomon, king			Normal			EntireVerse
 2CH	1	11	God		God (Yahweh) (in vision)	Normal			EndOfVerse
-2CH	1	12	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+2CH	1	12	God		God (Yahweh) (in vision)	Normal			EntireVerse
 2CH	2	3	Solomon, king	sent message		Normal			EndOfVerse
-2CH	2	4	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	5	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	6	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	7	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	8	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	9	Solomon, king	sent message		Implicit			EntireVerse
-2CH	2	10	Solomon, king	sent message		Implicit			EntireVerse
+2CH	2	4	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	5	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	6	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	7	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	8	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	9	Solomon, king	sent message		Normal			EntireVerse
+2CH	2	10	Solomon, king	sent message		Normal			EntireVerse
 2CH	2	11	Hiram, king of Tyre	sent letter		Normal			EndOfVerse
 2CH	2	12	Hiram, king of Tyre	sent letter		Normal			Unspecified
-2CH	2	13	Hiram, king of Tyre	sent letter		Implicit			EntireVerse
-2CH	2	14	Hiram, king of Tyre	sent letter		Implicit			EntireVerse
-2CH	2	15	Hiram, king of Tyre	sent letter		Implicit			EntireVerse
+2CH	2	13	Hiram, king of Tyre	sent letter		Normal			EntireVerse
+2CH	2	14	Hiram, king of Tyre	sent letter		Normal			EntireVerse
+2CH	2	15	Hiram, king of Tyre	sent letter		Normal			EntireVerse
 2CH	2	16	Hiram, king of Tyre	sent letter		Normal			Unspecified
 2CH	5	13	singers, and relatives	singing		Normal			ContainedWithinVerse
 2CH	6	1	Solomon, king			Normal			EndOfVerse
@@ -6930,8 +6930,8 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	6	6	Solomon, king			Normal			Unspecified
 2CH	6	7	Solomon, king			Normal			Unspecified
 2CH	6	8	Solomon, king			Normal			Unspecified
-2CH	6	9	Solomon, king			Implicit			EntireVerse
-2CH	6	10	Solomon, king			Implicit			EntireVerse
+2CH	6	9	Solomon, king			Normal			EntireVerse
+2CH	6	10	Solomon, king			Normal			EntireVerse
 2CH	6	11	Solomon, king			Normal			StartOfVerse
 2CH	6	14	Solomon, king			Normal			Unspecified
 2CH	6	15	Solomon, king			Normal			Unspecified
@@ -6942,26 +6942,26 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	6	20	Solomon, king			Normal			Unspecified
 2CH	6	21	Solomon, king			Normal			Unspecified
 2CH	6	22	Solomon, king			Normal			Unspecified
-2CH	6	23	Solomon, king			Implicit			EntireVerse
-2CH	6	24	Solomon, king			Implicit			EntireVerse
-2CH	6	25	Solomon, king			Implicit			EntireVerse
-2CH	6	26	Solomon, king			Implicit			EntireVerse
-2CH	6	27	Solomon, king			Implicit			EntireVerse
-2CH	6	28	Solomon, king			Implicit			EntireVerse
-2CH	6	29	Solomon, king			Implicit			EntireVerse
-2CH	6	30	Solomon, king			Implicit			EntireVerse
-2CH	6	31	Solomon, king			Implicit			EntireVerse
-2CH	6	32	Solomon, king			Implicit			EntireVerse
-2CH	6	33	Solomon, king			Implicit			EntireVerse
-2CH	6	34	Solomon, king			Implicit			EntireVerse
-2CH	6	35	Solomon, king			Implicit			EntireVerse
-2CH	6	36	Solomon, king			Implicit			EntireVerse
-2CH	6	37	Solomon, king			Implicit			EntireVerse
-2CH	6	38	Solomon, king			Implicit			EntireVerse
-2CH	6	39	Solomon, king			Implicit			EntireVerse
-2CH	6	40	Solomon, king			Implicit			EntireVerse
-2CH	6	41	Solomon, king			Implicit			EntireVerse
-2CH	6	42	Solomon, king			Implicit			EntireVerse
+2CH	6	23	Solomon, king			Normal			EntireVerse
+2CH	6	24	Solomon, king			Normal			EntireVerse
+2CH	6	25	Solomon, king			Normal			EntireVerse
+2CH	6	26	Solomon, king			Normal			EntireVerse
+2CH	6	27	Solomon, king			Normal			EntireVerse
+2CH	6	28	Solomon, king			Normal			EntireVerse
+2CH	6	29	Solomon, king			Normal			EntireVerse
+2CH	6	30	Solomon, king			Normal			EntireVerse
+2CH	6	31	Solomon, king			Normal			EntireVerse
+2CH	6	32	Solomon, king			Normal			EntireVerse
+2CH	6	33	Solomon, king			Normal			EntireVerse
+2CH	6	34	Solomon, king			Normal			EntireVerse
+2CH	6	35	Solomon, king			Normal			EntireVerse
+2CH	6	36	Solomon, king			Normal			EntireVerse
+2CH	6	37	Solomon, king			Normal			EntireVerse
+2CH	6	38	Solomon, king			Normal			EntireVerse
+2CH	6	39	Solomon, king			Normal			EntireVerse
+2CH	6	40	Solomon, king			Normal			EntireVerse
+2CH	6	41	Solomon, king			Normal			EntireVerse
+2CH	6	42	Solomon, king			Normal			EntireVerse
 2CH	7	3	Israel	worshiping God		Normal			Unspecified
 2CH	7	6	priests/Levites			Normal			
 2CH	7	6	David			Quotation			Unspecified
@@ -6980,16 +6980,16 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	7	22	God		God (Yahweh) (in vision)	Normal			Unspecified
 2CH	8	11	Solomon, king			Normal			Unspecified
 2CH	9	5	queen of Sheba			Normal			EndOfVerse
-2CH	9	6	queen of Sheba			Implicit			EntireVerse
-2CH	9	7	queen of Sheba			Implicit			EntireVerse
-2CH	9	8	queen of Sheba			Implicit			EntireVerse
-2CH	10	4	Jeroboam/Israel, all			Implicit	Jeroboam		EntireVerse
+2CH	9	6	queen of Sheba			Normal			EntireVerse
+2CH	9	7	queen of Sheba			Normal			EntireVerse
+2CH	9	8	queen of Sheba			Normal			EntireVerse
+2CH	10	4	Jeroboam/Israel, all			Normal	Jeroboam		EntireVerse
 2CH	10	5	Rehoboam, king			Normal			Unspecified
 2CH	10	6	Rehoboam, king			Normal			Unspecified
 2CH	10	7	elders in Shechem		elders	Normal		1KI 12.7;2CH 10.7	EndOfVerse
 2CH	10	9	Rehoboam, king			Normal			Unspecified
 2CH	10	10	young men (advisors of Rehoboam)			Normal		1KI 12.10;2CH 10.10	EndOfVerse
-2CH	10	11	young men (advisors of Rehoboam)			Implicit		1KI 12.11;2CH 10.11	EntireVerse
+2CH	10	11	young men (advisors of Rehoboam)			Normal		1KI 12.11;2CH 10.11	EntireVerse
 2CH	10	12	Rehoboam, king			Quotation			Unspecified
 2CH	10	12	narrator-2CH			Quotation			Unspecified
 2CH	10	14	Rehoboam, king			Normal			EndOfVerse
@@ -7002,28 +7002,28 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	12	5	Shemaiah, prophet			Normal			EndOfVerse
 2CH	12	6	Israel, leaders of/Rehoboam, king		leaders of Israel and the king (Rehoboam)	Normal			EndOfVerse
 2CH	12	7	God		God (Yahweh)	Normal			EndOfVerse
-2CH	12	8	God		God (Yahweh)	Implicit			EntireVerse
+2CH	12	8	God		God (Yahweh)	Normal			EntireVerse
 2CH	13	4	Abijah, king of Judah			Normal			EndOfVerse
-2CH	13	5	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	6	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	7	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	8	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	9	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	10	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	11	Abijah, king of Judah			Implicit			EntireVerse
-2CH	13	12	Abijah, king of Judah			Implicit			EntireVerse
+2CH	13	5	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	6	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	7	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	8	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	9	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	10	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	11	Abijah, king of Judah			Normal			EntireVerse
+2CH	13	12	Abijah, king of Judah			Normal			EntireVerse
 2CH	14	7	Asa, king of Judah			Normal			ContainedWithinVerse
 2CH	14	11	Asa, king of Judah			Normal			Unspecified
 2CH	15	2	Azariah, son of Oded			Normal			Unspecified
-2CH	15	3	Azariah, son of Oded			Implicit			EntireVerse
-2CH	15	4	Azariah, son of Oded			Implicit			EntireVerse
-2CH	15	5	Azariah, son of Oded			Implicit			EntireVerse
-2CH	15	6	Azariah, son of Oded			Implicit			EntireVerse
-2CH	15	7	Azariah, son of Oded			Implicit			EntireVerse
-2CH	16	3	Asa, king of Judah			Implicit			EntireVerse
+2CH	15	3	Azariah, son of Oded			Normal			EntireVerse
+2CH	15	4	Azariah, son of Oded			Normal			EntireVerse
+2CH	15	5	Azariah, son of Oded			Normal			EntireVerse
+2CH	15	6	Azariah, son of Oded			Normal			EntireVerse
+2CH	15	7	Azariah, son of Oded			Normal			EntireVerse
+2CH	16	3	Asa, king of Judah			Normal			EntireVerse
 2CH	16	7	Hanani the seer			Normal			EndOfVerse
-2CH	16	8	Hanani the seer			Implicit			EntireVerse
-2CH	16	9	Hanani the seer			Implicit			EntireVerse
+2CH	16	8	Hanani the seer			Normal			EntireVerse
+2CH	16	9	Hanani the seer			Normal			EntireVerse
 2CH	18	3	Ahab, king of Israel			Normal			
 2CH	18	3	Jehoshaphat, king of Judah			Normal			
 2CH	18	4	Jehoshaphat, king of Judah			Normal			Unspecified
@@ -7046,11 +7046,11 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	18	19	Micaiah, son of Imlah			Normal			Unspecified
 2CH	18	20	Micaiah, son of Imlah			Normal			Unspecified
 2CH	18	21	Micaiah, son of Imlah			Normal			Unspecified
-2CH	18	22	Micaiah, son of Imlah			Implicit			EntireVerse
+2CH	18	22	Micaiah, son of Imlah			Normal			EntireVerse
 2CH	18	23	Zedekiah, son of Kenaanah, false prophet			Normal		1KI 22.24;2CH 18.23	Unspecified
 2CH	18	24	Micaiah, son of Imlah			Normal			EndOfVerse
 2CH	18	25	Ahab, king of Israel			Normal			EndOfVerse
-2CH	18	26	Ahab, king of Israel			Implicit			EntireVerse
+2CH	18	26	Ahab, king of Israel			Normal			EntireVerse
 2CH	18	27	Micaiah, son of Imlah			Normal			ContainedWithinVerse
 2CH	18	29	Ahab, king of Israel			Normal			ContainedWithinVerse
 2CH	18	30	Ben-Hadad, king of Aram	commanding	king of Syria (Aram)	Normal			Unspecified
@@ -7059,39 +7059,39 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	19	2	Jehu, son of Hanani			Normal			EndOfVerse
 2CH	19	3	Jehu, son of Hanani			Normal			Unspecified
 2CH	19	6	Jehoshaphat, king of Judah			Normal			EndOfVerse
-2CH	19	7	Jehoshaphat, king of Judah			Implicit			EntireVerse
+2CH	19	7	Jehoshaphat, king of Judah			Normal			EntireVerse
 2CH	19	9	Jehoshaphat, king of Judah			Normal			EndOfVerse
-2CH	19	10	Jehoshaphat, king of Judah			Implicit			EntireVerse
-2CH	19	11	Jehoshaphat, king of Judah			Implicit			EntireVerse
+2CH	19	10	Jehoshaphat, king of Judah			Normal			EntireVerse
+2CH	19	11	Jehoshaphat, king of Judah			Normal			EntireVerse
 2CH	20	2	men, some			Normal			
 2CH	20	2	narrator-2CH			Interruption			
 2CH	20	3	Jehoshaphat, king of Judah	alarmed		Rare			
 2CH	20	3	Jehoshaphat, king of Judah	proclamation		Rare			
 2CH	20	3	Needs Review			Potential			
 2CH	20	6	Jehoshaphat, king of Judah	praying		Normal			EndOfVerse
-2CH	20	7	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
-2CH	20	8	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
-2CH	20	9	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
-2CH	20	10	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
-2CH	20	11	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
-2CH	20	12	Jehoshaphat, king of Judah	praying		Implicit			EntireVerse
+2CH	20	7	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
+2CH	20	8	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
+2CH	20	9	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
+2CH	20	10	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
+2CH	20	11	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
+2CH	20	12	Jehoshaphat, king of Judah	praying		Normal			EntireVerse
 2CH	20	15	Jahaziel			Normal			EndOfVerse
-2CH	20	16	Jahaziel			Implicit			EntireVerse
-2CH	20	17	Jahaziel			Implicit			EntireVerse
+2CH	20	16	Jahaziel			Normal			EntireVerse
+2CH	20	17	Jahaziel			Normal			EntireVerse
 2CH	20	20	Jehoshaphat, king of Judah			Normal			EndOfVerse
 2CH	20	21	men appointed to sing and praise	singing		Normal			EndOfVerse
 2CH	20	26	narrator-2CH			Quotation			Unspecified
 2CH	20	37	Eliezer the prophet, son of Dodavahu			Normal			ContainedWithinVerse
 2CH	21	12	Elijah	letter		Normal			EndOfVerse
-2CH	21	13	Elijah	letter		Implicit			EntireVerse
-2CH	21	14	Elijah	letter		Implicit			EntireVerse
-2CH	21	15	Elijah	letter		Implicit			EntireVerse
+2CH	21	13	Elijah	letter		Normal			EntireVerse
+2CH	21	14	Elijah	letter		Normal			EntireVerse
+2CH	21	15	Elijah	letter		Normal			EntireVerse
 2CH	22	9	men, some			Normal			Unspecified
 2CH	23	3	Jehoiada the priest			Normal			EndOfVerse
-2CH	23	4	Jehoiada the priest			Implicit			EntireVerse
-2CH	23	5	Jehoiada the priest			Implicit			EntireVerse
-2CH	23	6	Jehoiada the priest			Implicit			EntireVerse
-2CH	23	7	Jehoiada the priest			Implicit			EntireVerse
+2CH	23	4	Jehoiada the priest			Normal			EntireVerse
+2CH	23	5	Jehoiada the priest			Normal			EntireVerse
+2CH	23	6	Jehoiada the priest			Normal			EntireVerse
+2CH	23	7	Jehoiada the priest			Normal			EntireVerse
 2CH	23	11	Jehoiada the priest/Jehoiada's sons			Normal	Jehoiada the priest		Unspecified
 2CH	23	13	Athaliah, mother of Ahaziah (Queen)	angry	Athaliah, queen	Normal			EndOfVerse
 2CH	23	14	Jehoiada the priest			Normal			Unspecified
@@ -7107,7 +7107,7 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	25	4	God			Quotation			Unspecified
 2CH	25	4	Needs Review			Normal			
 2CH	25	7	man of God (prophet to Amaziah)			Normal			EndOfVerse
-2CH	25	8	man of God (prophet to Amaziah)			Implicit			EntireVerse
+2CH	25	8	man of God (prophet to Amaziah)			Normal			EntireVerse
 2CH	25	9	Amaziah, king of Judah			Normal			
 2CH	25	9	man of God (prophet to Amaziah)			Normal			
 2CH	25	15	prophet sent to Amaziah			Normal			EndOfVerse
@@ -7115,40 +7115,40 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	25	16	prophet sent to Amaziah			Normal			
 2CH	25	17	Amaziah, king of Judah			Normal			EndOfVerse
 2CH	25	18	Jehoash, king of Israel		Joash (Jehoash), king of Israel	Normal			Unspecified
-2CH	25	19	Jehoash, king of Israel		Joash (Jehoash), king of Israel	Implicit			EntireVerse
+2CH	25	19	Jehoash, king of Israel		Joash (Jehoash), king of Israel	Normal			EntireVerse
 2CH	26	18	Azariah the priest (during reign of Uzziah)/eighty other priests	courageous	Azariah the priest/eighty other priests	Normal	Azariah the priest (during reign of Uzziah)		EndOfVerse
 2CH	26	23	people			Normal			Unspecified
 2CH	28	9	Oded, prophet			Normal			EndOfVerse
-2CH	28	10	Oded, prophet			Implicit			EntireVerse
-2CH	28	11	Oded, prophet			Implicit			EntireVerse
+2CH	28	10	Oded, prophet			Normal			EntireVerse
+2CH	28	11	Oded, prophet			Normal			EntireVerse
 2CH	28	13	Azariah, son of Jehohanan/Berekiah/Jehizkiah/Amasa		leaders in Ephraim (Azariah/Berekiah/Jehizkiah/Amasa)	Normal			Unspecified
 2CH	28	23	Ahaz, king of Judah	thought		Normal			ContainedWithinVerse
 2CH	29	5	Hezekiah, king of Judah			Normal			EndOfVerse
-2CH	29	6	Hezekiah, king of Judah			Implicit			EntireVerse
-2CH	29	7	Hezekiah, king of Judah			Implicit			EntireVerse
-2CH	29	8	Hezekiah, king of Judah			Implicit			EntireVerse
-2CH	29	9	Hezekiah, king of Judah			Implicit			EntireVerse
-2CH	29	10	Hezekiah, king of Judah			Implicit			EntireVerse
-2CH	29	11	Hezekiah, king of Judah			Implicit			EntireVerse
+2CH	29	6	Hezekiah, king of Judah			Normal			EntireVerse
+2CH	29	7	Hezekiah, king of Judah			Normal			EntireVerse
+2CH	29	8	Hezekiah, king of Judah			Normal			EntireVerse
+2CH	29	9	Hezekiah, king of Judah			Normal			EntireVerse
+2CH	29	10	Hezekiah, king of Judah			Normal			EntireVerse
+2CH	29	11	Hezekiah, king of Judah			Normal			EntireVerse
 2CH	29	18	priests/Levites		priests	Normal			EndOfVerse
 2CH	29	19	priests/Levites		priests	Normal			Unspecified
 2CH	29	31	Hezekiah, king of Judah			Normal			Unspecified
 2CH	30	6	Hezekiah, king of Judah	letter		Normal			EndOfVerse
-2CH	30	7	Hezekiah, king of Judah	letter		Implicit			EntireVerse
-2CH	30	8	Hezekiah, king of Judah	letter		Implicit			EntireVerse
-2CH	30	9	Hezekiah, king of Judah	letter		Implicit			EntireVerse
+2CH	30	7	Hezekiah, king of Judah	letter		Normal			EntireVerse
+2CH	30	8	Hezekiah, king of Judah	letter		Normal			EntireVerse
+2CH	30	9	Hezekiah, king of Judah	letter		Normal			EntireVerse
 2CH	30	18	Hezekiah, king of Judah			Normal			EndOfVerse
 2CH	30	19	Hezekiah, king of Judah			Normal			Unspecified
 2CH	31	10	Azariah the chief priest (during reign of Hezekiah)		Azariah the chief priest	Normal			EndOfVerse
 2CH	32	4	men, large force of			Normal			Unspecified
-2CH	32	7	Hezekiah, king of Judah			Implicit			EntireVerse
+2CH	32	7	Hezekiah, king of Judah			Normal			EntireVerse
 2CH	32	8	Hezekiah, king of Judah			Normal			StartOfVerse
-2CH	32	10	Rabshakeh		Sennacherib's officers	Implicit		2KI 18:19; 2CH 32:10; ISA 36:4	EntireVerse
-2CH	32	11	Rabshakeh		Sennacherib's officers	Implicit		2KI 18:30; 2CH 32:11; ISA 36:15	EntireVerse
-2CH	32	12	Rabshakeh		Sennacherib's officers	Implicit		2KI 18:22; 2CH 32:12; ISA 36:7	EntireVerse
-2CH	32	13	Rabshakeh		Sennacherib's officers	Implicit		2KI 18:33; 2CH 32:13; ISA 36:18b	EntireVerse
-2CH	32	14	Rabshakeh		Sennacherib's officers	Implicit		2KI 18:35; 2CH 32:14; ISA 36:20	EntireVerse
-2CH	32	15	Rabshakeh		Sennacherib's officers	Implicit			EntireVerse
+2CH	32	10	Rabshakeh		Sennacherib's officers	Normal		2KI 18:19; 2CH 32:10; ISA 36:4	EntireVerse
+2CH	32	11	Rabshakeh		Sennacherib's officers	Normal		2KI 18:30; 2CH 32:11; ISA 36:15	EntireVerse
+2CH	32	12	Rabshakeh		Sennacherib's officers	Normal		2KI 18:22; 2CH 32:12; ISA 36:7	EntireVerse
+2CH	32	13	Rabshakeh		Sennacherib's officers	Normal		2KI 18:33; 2CH 32:13; ISA 36:18b	EntireVerse
+2CH	32	14	Rabshakeh		Sennacherib's officers	Normal		2KI 18:35; 2CH 32:14; ISA 36:20	EntireVerse
+2CH	32	15	Rabshakeh		Sennacherib's officers	Normal			EntireVerse
 2CH	32	16	Rabshakeh		Sennacherib's officers	Indirect			
 2CH	32	17	Rabshakeh	letter	letter from Sennacherib	Normal			
 2CH	32	17	Sennacherib, king of Assyria	letter		Normal			
@@ -7162,19 +7162,19 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	33	8	narrator-2CH			Indirect			
 2CH	34	15	Hilkiah, high priest			Normal			Unspecified
 2CH	34	16	Shaphan, secretary			Normal			EndOfVerse
-2CH	34	17	Shaphan, secretary			Implicit			EntireVerse
+2CH	34	17	Shaphan, secretary			Normal			EntireVerse
 2CH	34	18	Shaphan, secretary			Normal			Unspecified
 2CH	34	21	Josiah, king of Judah			Normal			Unspecified
 2CH	34	23	Huldah, prophetess			Normal			Unspecified
-2CH	34	24	Huldah, prophetess			Implicit			EntireVerse
-2CH	34	25	Huldah, prophetess			Implicit			EntireVerse
-2CH	34	26	Huldah, prophetess			Implicit			EntireVerse
-2CH	34	27	Huldah, prophetess			Implicit			EntireVerse
+2CH	34	24	Huldah, prophetess			Normal			EntireVerse
+2CH	34	25	Huldah, prophetess			Normal			EntireVerse
+2CH	34	26	Huldah, prophetess			Normal			EntireVerse
+2CH	34	27	Huldah, prophetess			Normal			EntireVerse
 2CH	34	28	Huldah, prophetess			Normal			StartOfVerse
 2CH	35	3	Josiah, king of Judah			Normal			EndOfVerse
-2CH	35	4	Josiah, king of Judah			Implicit			EntireVerse
-2CH	35	5	Josiah, king of Judah			Implicit			EntireVerse
-2CH	35	6	Josiah, king of Judah			Implicit			EntireVerse
+2CH	35	4	Josiah, king of Judah			Normal			EntireVerse
+2CH	35	5	Josiah, king of Judah			Normal			EntireVerse
+2CH	35	6	Josiah, king of Judah			Normal			EntireVerse
 2CH	35	21	Neco, king of Egypt		ambassador from Neco, king of Egypt	Normal			Unspecified
 2CH	35	23	Josiah, king of Judah			Normal			EndOfVerse
 2CH	36	23	Cyrus, king of Persia			Normal			Unspecified
@@ -7270,15 +7270,15 @@ EZR	9	13	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate
 EZR	9	14	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate			
 EZR	9	15	Ezra, priest and teacher	prayer (ashamed and disgraced)		Alternate			
 EZR	10	2	Shecaniah, son of Jehiel	suggesting solution		Normal			EndOfVerse
-EZR	10	3	Shecaniah, son of Jehiel	suggesting solution		Implicit			EntireVerse
-EZR	10	4	Shecaniah, son of Jehiel	suggesting solution		Implicit			EntireVerse
+EZR	10	3	Shecaniah, son of Jehiel	suggesting solution		Normal			EntireVerse
+EZR	10	4	Shecaniah, son of Jehiel	suggesting solution		Normal			EntireVerse
 EZR	10	7	proclamation			Indirect			
 EZR	10	8	proclamation			Indirect			
 EZR	10	10	Ezra, priest and teacher			Normal			EndOfVerse
-EZR	10	11	Ezra, priest and teacher			Implicit			EntireVerse
+EZR	10	11	Ezra, priest and teacher			Normal			EntireVerse
 EZR	10	12	assembly, whole			Normal			EndOfVerse
-EZR	10	13	assembly, whole			Implicit			EntireVerse
-EZR	10	14	assembly, whole			Implicit			EntireVerse
+EZR	10	13	assembly, whole			Normal			EntireVerse
+EZR	10	14	assembly, whole			Normal			EntireVerse
 # The preferred way to handle Nehemiah 1:1b is to manually split the verse into 2 blocks (if necessary) but assign both parts to narrator;
 # then let Glyssen apply the narrator override to the second block.
 NEH	1	2	Nehemiah			Indirect			
@@ -7439,20 +7439,20 @@ NEH	13	31	Nehemiah	praying		Potential
 EST	1	15	Xerxes, king of Persia and Media (Ahasuerus)			Normal			Unspecified
 EST	1	16	Memucan, noble advisor to Xerxes, king			Normal			Unspecified
 EST	1	17	Memucan, noble advisor to Xerxes, king			Normal			Unspecified
-EST	1	18	Memucan, noble advisor to Xerxes, king			Implicit			EntireVerse
-EST	1	19	Memucan, noble advisor to Xerxes, king			Implicit			EntireVerse
-EST	1	20	Memucan, noble advisor to Xerxes, king			Implicit			EntireVerse
+EST	1	18	Memucan, noble advisor to Xerxes, king			Normal			EntireVerse
+EST	1	19	Memucan, noble advisor to Xerxes, king			Normal			EntireVerse
+EST	1	20	Memucan, noble advisor to Xerxes, king			Normal			EntireVerse
 EST	2	2	King Xerxes' personal servants			Normal			EndOfVerse
-EST	2	3	King Xerxes' personal servants			Implicit			EntireVerse
+EST	2	3	King Xerxes' personal servants			Normal			EntireVerse
 EST	2	4	King Xerxes' personal servants			Normal			StartOfVerse
 EST	3	3	King Xerxes' servants at the gate			Normal			Unspecified
 EST	3	8	Haman, highest noble to Xerxes, king			Normal			EndOfVerse
-EST	3	9	Haman, highest noble to Xerxes, king			Implicit			EntireVerse
+EST	3	9	Haman, highest noble to Xerxes, king			Normal			EntireVerse
 EST	3	11	Xerxes, king of Persia and Media (Ahasuerus)			Normal			Unspecified
 EST	4	11	Esther, queen			Normal			Unspecified
 EST	4	13	Mordecai, cousin of Esther			Normal			EndOfVerse
-EST	4	14	Mordecai, cousin of Esther			Implicit			EntireVerse
-EST	4	16	Esther, queen			Implicit			EntireVerse
+EST	4	14	Mordecai, cousin of Esther			Normal			EntireVerse
+EST	4	16	Esther, queen			Normal			EntireVerse
 EST	5	3	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EndOfVerse
 EST	5	4	Esther, queen			Normal			Unspecified
 EST	5	5	Xerxes, king of Persia and Media (Ahasuerus)			Normal			Unspecified
@@ -7460,7 +7460,7 @@ EST	5	6	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EndOfVerse
 EST	5	7	Esther, queen			Normal			Unspecified
 EST	5	8	Esther, queen			Normal			Unspecified
 EST	5	12	Haman, highest noble to Xerxes, king			Normal			Unspecified
-EST	5	13	Haman, highest noble to Xerxes, king			Implicit			EntireVerse
+EST	5	13	Haman, highest noble to Xerxes, king			Normal			EntireVerse
 EST	5	14	Zeresh, wife of Haman/friends of Haman			Normal			ContainedWithinVerse
 EST	6	3	King Xerxes' personal servants			Normal			
 EST	6	3	Xerxes, king of Persia and Media (Ahasuerus)			Normal			
@@ -7470,23 +7470,23 @@ EST	6	5	Xerxes, king of Persia and Media (Ahasuerus)			Normal
 EST	6	6	Haman, highest noble to Xerxes, king			Normal			
 EST	6	6	Xerxes, king of Persia and Media (Ahasuerus)			Normal			
 EST	6	7	Haman, highest noble to Xerxes, king			Normal			EndOfVerse
-EST	6	8	Haman, highest noble to Xerxes, king			Implicit			EntireVerse
-EST	6	9	Haman, highest noble to Xerxes, king			Implicit			EntireVerse
+EST	6	8	Haman, highest noble to Xerxes, king			Normal			EntireVerse
+EST	6	9	Haman, highest noble to Xerxes, king			Normal			EntireVerse
 EST	6	10	Xerxes, king of Persia and Media (Ahasuerus)			Normal			Unspecified
 EST	6	11	Haman, highest noble to Xerxes, king			Normal			EndOfVerse
 EST	6	13	Zeresh, wife of Haman/friends of Haman			Normal			Unspecified
 EST	7	2	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EndOfVerse
 EST	7	3	Esther, queen			Normal			EndOfVerse
-EST	7	4	Esther, queen			Implicit			EntireVerse
+EST	7	4	Esther, queen			Normal			EntireVerse
 EST	7	5	Xerxes, king of Persia and Media (Ahasuerus)			Normal			Unspecified
 EST	7	6	Esther, queen			Normal			Unspecified
 EST	7	8	Xerxes, king of Persia and Media (Ahasuerus)			Normal			ContainedWithinVerse
 EST	7	9	Harbona, eunuch attending Xerxes, king			Normal			
 EST	7	9	Xerxes, king of Persia and Media (Ahasuerus)			Normal			
 EST	8	5	Esther, queen			Normal			EndOfVerse
-EST	8	6	Esther, queen			Implicit			EntireVerse
+EST	8	6	Esther, queen			Normal			EntireVerse
 EST	8	7	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EndOfVerse
-EST	8	8	Xerxes, king of Persia and Media (Ahasuerus)			Implicit			EntireVerse
+EST	8	8	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EntireVerse
 EST	9	12	Xerxes, king of Persia and Media (Ahasuerus)			Normal			EndOfVerse
 EST	9	13	Esther, queen			Normal			Unspecified
 EST	9	24	narrator-EST			Quotation			Unspecified
@@ -7496,21 +7496,21 @@ JOB	1	7	God		God (Yahweh)	Normal
 JOB	1	7	Satan (Devil)			Normal			
 JOB	1	8	God		God (Yahweh)	Normal			Unspecified
 JOB	1	9	Satan (Devil)			Normal			Unspecified
-JOB	1	10	Satan (Devil)			Implicit			EntireVerse
-JOB	1	11	Satan (Devil)			Implicit			EntireVerse
+JOB	1	10	Satan (Devil)			Normal			EntireVerse
+JOB	1	11	Satan (Devil)			Normal			EntireVerse
 JOB	1	12	God		God (Yahweh)	Normal			Unspecified
 JOB	1	14	messenger to Job			Normal			EndOfVerse
-JOB	1	15	messenger to Job			Implicit			EntireVerse
+JOB	1	15	messenger to Job			Normal			EntireVerse
 JOB	1	16	messenger to Job, another			Normal			EndOfVerse
 JOB	1	17	messenger to Job, still another			Normal			EndOfVerse
 JOB	1	18	messenger to Job, yet another			Normal			EndOfVerse
-JOB	1	19	messenger to Job, yet another			Implicit			EntireVerse
+JOB	1	19	messenger to Job, yet another			Normal			EntireVerse
 JOB	1	21	Job			Normal			EndOfVerse
 JOB	2	2	God		God (Yahweh)	Normal			
 JOB	2	2	Satan (Devil)			Normal			
 JOB	2	3	God		God (Yahweh)	Normal			Unspecified
 JOB	2	4	Satan (Devil)			Normal			Unspecified
-JOB	2	5	Satan (Devil)			Implicit			EntireVerse
+JOB	2	5	Satan (Devil)			Normal			EntireVerse
 JOB	2	6	God		God (Yahweh)	Normal			Unspecified
 JOB	2	9	Job's wife			Normal			EndOfVerse
 JOB	2	10	Job			Normal			ContainedWithinVerse
@@ -8506,7 +8506,7 @@ JOB	42	4	Job			Implicit
 JOB	42	5	Job			Implicit			
 JOB	42	6	Job			Implicit			
 JOB	42	7	God		God (Yahweh)	Normal			EndOfVerse
-JOB	42	8	God		God (Yahweh)	Implicit			EntireVerse
+JOB	42	8	God		God (Yahweh)	Normal			EntireVerse
 PSA	2	3	kings of the earth			Normal			
 PSA	2	6	God		God (Yahweh)	Normal			
 PSA	2	7	God		God (Yahweh)	Normal			
@@ -9320,13 +9320,13 @@ ISA	7	13	Isaiah			Normal			EndOfVerse
 # God is speaking. Nonetheless, the ISV does explicitly attribute it to God.
 ISA	7	13	God		God (Yahweh)	Alternate			
 ISA	7	13	Needs Review			Alternate			
-ISA	7	14	Isaiah			Implicit			EntireVerse
+ISA	7	14	Isaiah			Normal			EntireVerse
 ISA	7	14	God		God (Yahweh)	Alternate			
 ISA	7	14	Needs Review			Alternate			
-ISA	7	15	Isaiah			Implicit			EntireVerse
+ISA	7	15	Isaiah			Normal			EntireVerse
 ISA	7	15	God		God (Yahweh)	Alternate			
 ISA	7	15	Needs Review			Alternate			
-ISA	7	16	Isaiah			Implicit			EntireVerse
+ISA	7	16	Isaiah			Normal			EntireVerse
 ISA	7	16	God		God (Yahweh)	Alternate			
 ISA	7	16	Needs Review			Alternate			
 ISA	7	17	Isaiah			Normal			Unspecified
@@ -9954,7 +9954,7 @@ ISA	39	4	Hezekiah, king of Judah			Normal
 ISA	39	5	Isaiah			Normal			EndOfVerse
 ISA	39	6	Isaiah			Normal			Unspecified
 ISA	39	6	God		God (Yahweh)	Alternate			
-ISA	39	7	Isaiah			Implicit			EntireVerse
+ISA	39	7	Isaiah			Normal			EntireVerse
 ISA	39	7	God		God (Yahweh)	Alternate			
 ISA	39	8	Hezekiah, king of Judah	response to Isaiah		Normal			
 ISA	39	8	Hezekiah, king of Judah	thought		Normal			
@@ -11259,7 +11259,7 @@ JER	20	15	messenger			Quotation
 JER	20	16	Jeremiah			Potential			
 JER	20	17	Jeremiah			Potential			
 JER	20	18	Jeremiah			Potential			
-JER	21	2	Pashur/Zephaniah, priest			Implicit			EntireVerse
+JER	21	2	Pashur/Zephaniah, priest			Normal			EntireVerse
 JER	21	3	Jeremiah			Normal			Unspecified
 JER	21	4	Jeremiah			Normal			
 JER	21	4	God		God (Yahweh)	Normal			
@@ -11931,9 +11931,9 @@ JER	38	23	Jeremiah		Jeremiah (Yahweh says)	Implicit
 JER	38	24	Zedekiah, king of Judah			Normal			EndOfVerse
 JER	38	25	Zedekiah, king of Judah			Implicit			
 JER	38	25	Shephatiah/Gedaliah, son of Pashur/Jehucal/Pashur		officials (Shephatiah, Gedaliah, Jehucal, and Pashur)	Hypothetical			Unspecified
-JER	38	26	Zedekiah, king of Judah			Implicit			EntireVerse
+JER	38	26	Zedekiah, king of Judah			Normal			EntireVerse
 JER	38	27	Jeremiah		Jeremiah (Yahweh says)	Indirect			
-JER	39	12	Nebuchadnezzar, king of Babylon			Implicit			EntireVerse
+JER	39	12	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
 JER	39	14	Nebuzaradan			Indirect			
 JER	39	14	officers of king of Babylon		Nebushazban/Rabsaris/Nergal Sharezer/Rabmag/all the chief officers of the king of Babylon	Indirect			
 JER	39	16	God		God (Yahweh)	Normal			
@@ -14292,17 +14292,17 @@ EZK	48	33	God		God (Yahweh)	Implicit
 EZK	48	34	God		God (Yahweh)	Implicit			
 EZK	48	35	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
 DAN	1	10	chief official			Normal			EndOfVerse
-DAN	1	12	Daniel			Implicit			EntireVerse
-DAN	1	13	Daniel			Implicit			EntireVerse
+DAN	1	12	Daniel			Normal			EntireVerse
+DAN	1	13	Daniel			Normal			EntireVerse
 DAN	2	3	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
 DAN	2	4	astrologers			Normal			EndOfVerse
 DAN	2	5	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
-DAN	2	6	Nebuchadnezzar, king of Babylon			Implicit			EntireVerse
+DAN	2	6	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
 DAN	2	7	astrologers			Normal			Unspecified
 DAN	2	8	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
-DAN	2	9	Nebuchadnezzar, king of Babylon			Implicit			EntireVerse
+DAN	2	9	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
 DAN	2	10	astrologers			Normal			EndOfVerse
-DAN	2	11	astrologers			Implicit			EntireVerse
+DAN	2	11	astrologers			Normal			EntireVerse
 DAN	2	12	Nebuchadnezzar, king of Babylon			Indirect			
 DAN	2	15	Daniel			Normal			ContainedWithinVerse
 DAN	2	16	Daniel			Indirect			
@@ -14340,18 +14340,18 @@ DAN	2	48	Nebuchadnezzar, king of Babylon			Potential
 DAN	2	49	Daniel	requesting		Indirect			
 DAN	3	2	Nebuchadnezzar, king of Babylon			Potential			
 DAN	3	4	herald			Normal			EndOfVerse
-DAN	3	5	herald			Implicit			EntireVerse
-DAN	3	6	herald			Implicit			EntireVerse
+DAN	3	5	herald			Normal			EntireVerse
+DAN	3	6	herald			Normal			EntireVerse
 DAN	3	9	astrologers			Normal			Unspecified
 DAN	3	10	astrologers			Implicit			
 DAN	3	11	astrologers			Implicit			
 DAN	3	12	astrologers			Implicit			
 DAN	3	13	Nebuchadnezzar, king of Babylon	commanding		Indirect			
 DAN	3	14	Nebuchadnezzar, king of Babylon			Normal			Unspecified
-DAN	3	15	Nebuchadnezzar, king of Babylon			Implicit			EntireVerse
+DAN	3	15	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
 DAN	3	16	Shadrach/Meshach/Abednego			Normal			EndOfVerse
-DAN	3	17	Shadrach/Meshach/Abednego			Implicit			EntireVerse
-DAN	3	18	Shadrach/Meshach/Abednego			Implicit			EntireVerse
+DAN	3	17	Shadrach/Meshach/Abednego			Normal			EntireVerse
+DAN	3	18	Shadrach/Meshach/Abednego			Normal			EntireVerse
 DAN	3	19	Nebuchadnezzar, king of Babylon	commanding		Indirect			
 DAN	3	20	Nebuchadnezzar, king of Babylon	commanding		Indirect			
 DAN	3	24	advisers to king			Normal			
@@ -14359,7 +14359,7 @@ DAN	3	24	Nebuchadnezzar, king of Babylon			Normal
 DAN	3	25	Nebuchadnezzar, king of Babylon			Normal			Unspecified
 DAN	3	26	Nebuchadnezzar, king of Babylon			Normal			ContainedWithinVerse
 DAN	3	28	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
-DAN	3	29	Nebuchadnezzar, king of Babylon			Implicit			EntireVerse
+DAN	3	29	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
 DAN	4	1	Nebuchadnezzar, king of Babylon	letter		Implicit			
 DAN	4	2	Nebuchadnezzar, king of Babylon	letter		Implicit			
 DAN	4	3	Nebuchadnezzar, king of Babylon	letter		Implicit			
@@ -14426,7 +14426,7 @@ DAN	5	4	Belshazzar, king of Babylon/officials of Belshazzar/wives and concubines
 DAN	5	7	Belshazzar, king of Babylon	commanding loudly (probably drunk)		Indirect			
 DAN	5	7	Belshazzar, king of Babylon	frightened (probably drunk)		Normal			
 DAN	5	10	queen of Babylon		queen (Belshazzar's mother)	Normal			EndOfVerse
-DAN	5	11	queen of Babylon		queen (Belshazzar's mother)	Implicit			EntireVerse
+DAN	5	11	queen of Babylon		queen (Belshazzar's mother)	Normal			EntireVerse
 DAN	5	12	queen of Babylon		queen (Belshazzar's mother)	Normal			Unspecified
 DAN	5	13	Belshazzar, king of Babylon			Normal			EndOfVerse
 DAN	5	14	Belshazzar, king of Babylon			Implicit			
@@ -14447,8 +14447,8 @@ DAN	5	28	Daniel			Implicit
 DAN	5	29	Belshazzar, king of Babylon	commanding		Indirect			
 DAN	6	5	satraps			Normal			EndOfVerse
 DAN	6	6	satraps/three administrators			Normal	satraps		EndOfVerse
-DAN	6	7	satraps/three administrators			Implicit	satraps		EntireVerse
-DAN	6	8	satraps/three administrators			Implicit	satraps		EntireVerse
+DAN	6	7	satraps/three administrators			Normal	satraps		EntireVerse
+DAN	6	8	satraps/three administrators			Normal	satraps		EntireVerse
 DAN	6	12	Darius, king of Medes and Persians			Normal			
 DAN	6	12	satraps/three administrators			Normal	satraps		
 DAN	6	13	satraps/three administrators			Normal	satraps		Unspecified
@@ -14456,7 +14456,7 @@ DAN	6	15	satraps/three administrators			Normal	satraps		EndOfVerse
 DAN	6	16	Darius, king of Medes and Persians			Normal			EndOfVerse
 DAN	6	20	Darius, king of Medes and Persians	calling out in anguish		Normal			EndOfVerse
 DAN	6	21	Daniel			Normal			Unspecified
-DAN	6	22	Daniel			Implicit			EntireVerse
+DAN	6	22	Daniel			Normal			EntireVerse
 DAN	6	23	Darius, king of Medes and Persians	commanding (happily)		Indirect			
 DAN	6	24	Darius, king of Medes and Persians	commanding		Indirect			
 DAN	6	25	Darius, king of Medes and Persians	letter		Normal			EndOfVerse
@@ -14703,9 +14703,9 @@ DAN	12	13	man in linen above river			Normal
 DAN	12	13	Daniel	vision		Potential			
 HOS	1	2	God		God (Yahweh)	Normal			EndOfVerse
 HOS	1	4	God		God (Yahweh)	Normal			EndOfVerse
-HOS	1	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	1	5	God		God (Yahweh)	Normal			EntireVerse
 HOS	1	6	God		God (Yahweh)	Normal			EndOfVerse
-HOS	1	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	1	7	God		God (Yahweh)	Normal			EntireVerse
 HOS	1	9	God		God (Yahweh)	Normal			Unspecified
 HOS	1	10	God		God (Yahweh)	Potential			
 HOS	1	10	narrator-HOS			Quotation			Unspecified
@@ -15117,20 +15117,16 @@ AMO	7	8	Amos			Quotation
 AMO	7	8	God		God (Yahweh/Lord)	Dialogue			
 AMO	7	9	God		God (Yahweh)	Dialogue			
 AMO	7	10	Amaziah, priest of Bethel			Normal			EndOfVerse
-AMO	7	11	Amaziah, priest of Bethel			Implicit			EntireVerse
+AMO	7	11	Amaziah, priest of Bethel			Normal			EntireVerse
 AMO	7	12	Amaziah, priest of Bethel			Dialogue			EndOfVerse
-AMO	7	13	Amaziah, priest of Bethel			Implicit			EntireVerse
+AMO	7	13	Amaziah, priest of Bethel			Dialogue			EntireVerse
 AMO	7	14	Amos			Dialogue			EndOfVerse
-# We probably want vv. 15-17 to be Implicit, but there is the possibility that
-# some projects would want/need God to speak the parts where Amos is declaring His words.
-# Glyssen doesn't allow us to have Implicit together with Quotation and it wouldn't make
-# sense to regard the quotes in theses verses as "self-quotes".
-AMO	7	15	Amos			Normal			Unspecified
-AMO	7	15	God		God (Yahweh)	Quotation			EndOfVerse
-AMO	7	16	Amos			Normal			Unspecified
-AMO	7	16	God		God (Yahweh)	Quotation			
-AMO	7	17	Amos		Amos (Yahweh says)	Implicit			EntireVerse
-AMO	7	17	God		God (Yahweh)	Alternate			
+AMO	7	15	Amos			Dialogue			EntireVerse
+AMO	7	15	God		God (Yahweh)	Quotation			Unspecified
+AMO	7	16	Amos			Dialogue			EntireVerse
+AMO	7	16	God		God (Yahweh)	Normal			
+AMO	7	17	Amos		Amos (Yahweh says)	Normal			
+AMO	7	17	God		God (Yahweh)	Normal			
 AMO	8	2	Amos			Quotation			
 AMO	8	2	God		God (Yahweh)	Dialogue			
 AMO	8	3	God		God (Yahweh)	Normal			
@@ -15241,13 +15237,13 @@ JON	3	7	king of Nineveh	proclamation		Normal			EndOfVerse
 JON	3	8	king of Nineveh	proclamation		Normal			Unspecified
 JON	3	9	king of Nineveh	proclamation		Normal			Unspecified
 JON	4	2	Jonah	praying		Normal			Unspecified
-JON	4	3	Jonah	praying		Implicit			EntireVerse
+JON	4	3	Jonah	praying		Normal			EntireVerse
 JON	4	4	God		God (Yahweh)	Normal			Unspecified
 JON	4	8	Jonah			Normal			EndOfVerse
 JON	4	9	God		God (Yahweh)	Normal			
 JON	4	9	Jonah			Normal			
 JON	4	10	God		God (Yahweh)	Normal			EndOfVerse
-JON	4	11	God		God (Yahweh)	Implicit			EntireVerse
+JON	4	11	God		God (Yahweh)	Normal			EntireVerse
 MIC	1	2	God		God (Yahweh)	Potential			
 MIC	1	2	Micah, prophet			Potential			
 MIC	1	3	God		God (Yahweh)	Potential			
@@ -16032,7 +16028,7 @@ MAT	1	16	narrator-MAT			Quotation			Unspecified
 MAT	1	19	Joseph, the carpenter	thinking		Rare			
 MAT	1	19	Needs Review			Potential			
 MAT	1	20	angel		angel of the Lord	Normal			EndOfVerse
-MAT	1	21	angel		angel of the Lord	Implicit			EntireVerse
+MAT	1	21	angel		angel of the Lord	Normal			EntireVerse
 MAT	1	23	narrator-MAT			Quotation			Unspecified
 MAT	1	23	interruption-MAT			Interruption			
 MAT	1	23	scripture		scripture (prophet)	Quotation	Isaiah		Unspecified
@@ -16045,7 +16041,7 @@ MAT	2	2	magi (wise men from East)			Dialogue			Unspecified
 MAT	2	3	narrator-MAT			Quotation			Unspecified
 MAT	2	4	Herod the Great			Indirect			
 MAT	2	5	chief priests/teachers of religious law			Dialogue	Good Priest		Unspecified
-MAT	2	6	chief priests/teachers of religious law			Implicit	Good Priest		EntireVerse
+MAT	2	6	chief priests/teachers of religious law			Normal	Good Priest		EntireVerse
 MAT	2	7	narrator-MAT			Quotation			Unspecified
 MAT	2	7	Herod the Great			Indirect			
 MAT	2	8	Herod the Great	sly		Dialogue			EndOfVerse
@@ -16062,10 +16058,10 @@ MAT	3	3	scripture			Quotation	Isaiah		EndOfVerse
 MAT	3	6	people from Jerusalem, Judea and the region around the Jordan			Rare			
 MAT	3	6	Needs Review			Potential			
 MAT	3	7	John the Baptist	rebuking		Normal			EndOfVerse
-MAT	3	8	John the Baptist	rebuking		Implicit			EntireVerse
-MAT	3	9	John the Baptist	rebuking		Implicit			EntireVerse
-MAT	3	10	John the Baptist	rebuking		Implicit			EntireVerse
-MAT	3	11	John the Baptist	humble		Implicit			EntireVerse
+MAT	3	8	John the Baptist	rebuking		Normal			EntireVerse
+MAT	3	9	John the Baptist	rebuking		Normal			EntireVerse
+MAT	3	10	John the Baptist	rebuking		Normal			EntireVerse
+MAT	3	11	John the Baptist	humble		Normal			EntireVerse
 MAT	3	12	John the Baptist	humble		Normal			StartOfVerse
 MAT	3	14	John the Baptist	humble		Dialogue			Unspecified
 MAT	3	15	Jesus			Dialogue			Unspecified
@@ -16080,8 +16076,8 @@ MAT	4	9	Satan (Devil)			Dialogue			Unspecified
 MAT	4	10	Jesus	rebuking		Dialogue			Unspecified
 MAT	4	12	messenger to Jesus	reporting		Rare			
 MAT	4	12	Needs Review			Potential			
-MAT	4	15	scripture			Implicit	Isaiah		EntireVerse
-MAT	4	16	scripture			Implicit	Isaiah		EntireVerse
+MAT	4	15	scripture			Quotation	Isaiah		EntireVerse
+MAT	4	16	scripture			Quotation	Isaiah		EntireVerse
 MAT	4	17	Jesus	preaching		Normal			ContainedWithinVerse
 MAT	4	19	Jesus	inviting		Dialogue			Unspecified
 MAT	4	21	Jesus	inviting		Indirect			
@@ -16201,13 +16197,13 @@ MAT	8	3	Jesus			Dialogue			ContainedWithinVerse
 MAT	8	4	Jesus	giving orders		Dialogue			Unspecified
 MAT	8	5	centurion with great faith	entreating		Rare			
 MAT	8	5	Needs Review			Potential			
-MAT	8	6	centurion with great faith	entreating		Implicit			EntireVerse
+MAT	8	6	centurion with great faith	entreating		Dialogue			EntireVerse
 MAT	8	7	Jesus			Dialogue			Unspecified
 MAT	8	8	centurion with great faith	humbly		Dialogue		MAT 8.8-9;LUK 7.6-8	Unspecified
-MAT	8	9	centurion with great faith	humbly		Implicit		MAT 8.9;LUK 7.8	EntireVerse
+MAT	8	9	centurion with great faith	humbly		Normal		MAT 8.9;LUK 7.8	EntireVerse
 MAT	8	10	Jesus			Dialogue			EndOfVerse
-MAT	8	11	Jesus			Implicit			EntireVerse
-MAT	8	12	Jesus			Implicit			EntireVerse
+MAT	8	11	Jesus			Dialogue			EntireVerse
+MAT	8	12	Jesus			Dialogue			EntireVerse
 MAT	8	13	Jesus	giving orders		Dialogue			ContainedWithinVerse
 MAT	8	17	scripture			Quotation	Isaiah		ContainedWithinVerse
 MAT	8	18	Jesus	giving orders		Indirect			
@@ -16227,7 +16223,7 @@ MAT	8	34	Gadarene (or Gerasenes) people	pleading	the whole town (of the region o
 MAT	9	2	Jesus	compassionately		Dialogue			EndOfVerse
 MAT	9	3	teachers of religious law	indignant		Normal			Unspecified
 MAT	9	4	Jesus	rebuking		Dialogue			EndOfVerse
-MAT	9	5	Jesus			Implicit			EntireVerse
+MAT	9	5	Jesus			Normal			EntireVerse
 MAT	9	6	Jesus			Dialogue			Unspecified
 MAT	9	8	crowd			Indirect			
 MAT	9	9	Jesus	giving orders		Normal			ContainedWithinVerse
@@ -16237,7 +16233,7 @@ MAT	9	12	Jesus			Dialogue			EndOfVerse
 MAT	9	13	Jesus			Dialogue			StartOfVerse
 MAT	9	14	disciples of John the Baptist	puzzled		Dialogue			Unspecified
 MAT	9	15	Jesus			Dialogue			Unspecified
-MAT	9	16	Jesus			Implicit			EntireVerse
+MAT	9	16	Jesus			Normal			EntireVerse
 MAT	9	17	Jesus			Normal			StartOfVerse
 MAT	9	18	Jairus (synagogue leader)	pleading	synagogue leader	Dialogue		MAT 9.18;MRK 5.23;LUK 8.41	EndOfVerse
 MAT	9	21	woman, bleeding for twelve years	thinking		Normal		MAT 9.21;MRK 5.28,33;LUK 8.47	EndOfVerse
@@ -16257,7 +16253,7 @@ MAT	9	36	scripture			Quotation	Micaiah, son of Imlah		Unspecified
 MAT	9	36	Jesus			Rare			
 MAT	9	36	Needs Review			Rare			
 MAT	9	37	Jesus			Dialogue			Unspecified
-MAT	9	38	Jesus			Implicit			EntireVerse
+MAT	9	38	Jesus			Normal			EntireVerse
 MAT	10	1	Jesus			Indirect			
 MAT	10	2	narrator-MAT			Quotation			Unspecified
 MAT	10	4	narrator-MAT			Quotation			Unspecified
@@ -16304,8 +16300,8 @@ MAT	11	2	John the Baptist			Rare
 MAT	11	2	Needs Review			Potential			
 MAT	11	3	disciples of John the Baptist	puzzled		Dialogue		MAT 11.3;LUK 7.20	Unspecified
 MAT	11	4	Jesus			Normal			EndOfVerse
-MAT	11	5	Jesus			Implicit			EntireVerse
-MAT	11	6	Jesus			Implicit			EntireVerse
+MAT	11	5	Jesus			Normal			EntireVerse
+MAT	11	6	Jesus			Normal			EntireVerse
 MAT	11	7	Jesus			Normal			EndOfVerse
 MAT	11	8	Jesus			Implicit			
 MAT	11	9	Jesus			Implicit			
@@ -16324,11 +16320,11 @@ MAT	11	22	Jesus	rebuking		Implicit
 MAT	11	23	Jesus	rebuking		Implicit			
 MAT	11	24	Jesus	rebuking		Implicit			
 MAT	11	25	Jesus	praying		Normal			EndOfVerse
-MAT	11	26	Jesus	praying		Implicit			EntireVerse
-MAT	11	27	Jesus			Implicit			EntireVerse
-MAT	11	28	Jesus	compassionately		Implicit			EntireVerse
-MAT	11	29	Jesus	compassionately		Implicit			EntireVerse
-MAT	11	30	Jesus	compassionately		Implicit			EntireVerse
+MAT	11	26	Jesus	praying		Normal			EntireVerse
+MAT	11	27	Jesus			Normal			EntireVerse
+MAT	11	28	Jesus	compassionately		Normal			EntireVerse
+MAT	11	29	Jesus	compassionately		Normal			EntireVerse
+MAT	11	30	Jesus	compassionately		Normal			EntireVerse
 MAT	12	2	Pharisees, some	angry		Dialogue			EndOfVerse
 MAT	12	3	Jesus			Normal			EndOfVerse
 MAT	12	4	Jesus			Implicit			
@@ -16338,12 +16334,12 @@ MAT	12	7	Jesus			Implicit
 MAT	12	8	Jesus			Implicit			
 MAT	12	10	Pharisees, some	testing		Dialogue			Unspecified
 MAT	12	11	Jesus			Dialogue			EndOfVerse
-MAT	12	12	Jesus			Implicit			EntireVerse
+MAT	12	12	Jesus			Normal			EntireVerse
 MAT	12	13	Jesus	giving orders		Dialogue			ContainedWithinVerse
 MAT	12	16	Jesus	warning		Indirect			
-MAT	12	18	scripture			Implicit	God		EntireVerse
-MAT	12	19	scripture			Implicit	God		EntireVerse
-MAT	12	20	scripture			Implicit	God		EntireVerse
+MAT	12	18	scripture			Quotation	God		EntireVerse
+MAT	12	19	scripture			Quotation	God		EntireVerse
+MAT	12	20	scripture			Quotation	God		EntireVerse
 MAT	12	21	scripture			Quotation	God		StartOfVerse
 MAT	12	23	people who saw healing of demon-possessed man who was blind and mute	astonished	all the people	Normal			EndOfVerse
 MAT	12	24	Pharisees			Normal			EndOfVerse
@@ -16374,7 +16370,7 @@ MAT	12	46	Jesus' family		Jesus' mother and brothers	Indirect	Mary, Jesus' mother
 MAT	12	47	crowd	announcing	someone	Potential		MAT 12.47;MRK 3.32;LUK 8.20	
 MAT	12	48	Jesus	questioning		Dialogue			Unspecified
 MAT	12	49	Jesus			Dialogue			EndOfVerse
-MAT	12	50	Jesus			Implicit			EntireVerse
+MAT	12	50	Jesus			Normal			EntireVerse
 MAT	13	3	Jesus			Normal			EndOfVerse
 MAT	13	4	Jesus			Implicit			
 MAT	13	5	Jesus			Implicit			
@@ -16384,9 +16380,9 @@ MAT	13	8	Jesus			Implicit
 MAT	13	9	Jesus			Implicit			
 MAT	13	10	disciples	questioning		Dialogue			Unspecified
 MAT	13	11	Jesus			Normal			Unspecified
-MAT	13	12	Jesus			Implicit			EntireVerse
-MAT	13	13	Jesus			Implicit			EntireVerse
-MAT	13	14	Jesus			Implicit			EntireVerse
+MAT	13	12	Jesus			Normal			EntireVerse
+MAT	13	13	Jesus			Normal			EntireVerse
+MAT	13	14	Jesus			Normal			EntireVerse
 MAT	13	15	Jesus			Normal			Unspecified
 MAT	13	16	Jesus			Implicit			
 MAT	13	17	Jesus			Implicit			
@@ -16404,7 +16400,7 @@ MAT	13	28	Jesus			Implicit
 MAT	13	29	Jesus			Implicit			
 MAT	13	30	Jesus			Normal			StartOfVerse
 MAT	13	31	Jesus			Normal			EndOfVerse
-MAT	13	32	Jesus			Implicit			EntireVerse
+MAT	13	32	Jesus			Normal			EntireVerse
 MAT	13	33	Jesus			Normal			Unspecified
 MAT	13	35	scripture			Quotation	Asaph		Unspecified
 MAT	13	36	disciples			Normal			EndOfVerse
@@ -16426,8 +16422,8 @@ MAT	13	51	disciples			Dialogue			Unspecified
 MAT	13	51	Jesus	questioning		Dialogue			Unspecified
 MAT	13	52	Jesus			Dialogue			Unspecified
 MAT	13	54	men in Nazareth synagogue	amazed		Dialogue			Unspecified
-MAT	13	55	men in Nazareth synagogue	offended		Implicit			EntireVerse
-MAT	13	56	men in Nazareth synagogue	offended		Implicit			EntireVerse
+MAT	13	55	men in Nazareth synagogue	offended		Normal			EntireVerse
+MAT	13	56	men in Nazareth synagogue	offended		Normal			EntireVerse
 MAT	13	57	Jesus			Dialogue			EndOfVerse
 MAT	14	2	Herod Antipas (the tetrarch)	fearful		Normal			EndOfVerse
 MAT	14	4	John the Baptist	rebuking		Normal			EndOfVerse
@@ -16462,24 +16458,24 @@ MAT	14	31	Jesus	questioning		Dialogue			EndOfVerse
 MAT	14	33	disciples	awe	disciples (those in the boat)	Dialogue			Unspecified
 MAT	14	35	men of Gennesaret			Indirect			
 MAT	14	36	people at Gennesaret (sick)			Indirect		MAT 14.36;MRK 6.56	
-MAT	15	2	Pharisees/teachers of religious law	critical	Pharisees and teachers of the law	Implicit		MAT 15.2;MRK 7.5	EntireVerse
+MAT	15	2	Pharisees/teachers of religious law	critical	Pharisees and teachers of the law	Dialogue		MAT 15.2;MRK 7.5	EntireVerse
 MAT	15	3	Jesus			Dialogue			EndOfVerse
-MAT	15	4	Jesus			Implicit			EntireVerse
-MAT	15	5	Jesus			Implicit			EntireVerse
-MAT	15	6	Jesus			Implicit			EntireVerse
-MAT	15	7	Jesus			Implicit			EntireVerse
-MAT	15	8	Jesus			Implicit			EntireVerse
+MAT	15	4	Jesus			Normal			EntireVerse
+MAT	15	5	Jesus			Normal			EntireVerse
+MAT	15	6	Jesus			Normal			EntireVerse
+MAT	15	7	Jesus			Normal			EntireVerse
+MAT	15	8	Jesus			Normal			EntireVerse
 MAT	15	9	Jesus			Normal			Unspecified
 MAT	15	10	Jesus			Dialogue			EndOfVerse
-MAT	15	11	Jesus			Implicit			EntireVerse
+MAT	15	11	Jesus			Dialogue			EntireVerse
 MAT	15	12	disciples	rebuking		Dialogue			EndOfVerse
 MAT	15	13	Jesus			Dialogue			Unspecified
-MAT	15	14	Jesus			Implicit			EntireVerse
+MAT	15	14	Jesus			Normal			EntireVerse
 MAT	15	15	Peter (Simon)	puzzled		Dialogue			Unspecified
 MAT	15	16	Jesus			Dialogue			Unspecified
-MAT	15	17	Jesus			Implicit			EntireVerse
-MAT	15	18	Jesus			Implicit			EntireVerse
-MAT	15	19	Jesus			Implicit			EntireVerse
+MAT	15	17	Jesus			Normal			EntireVerse
+MAT	15	18	Jesus			Normal			EntireVerse
+MAT	15	19	Jesus			Normal			EntireVerse
 MAT	15	20	Jesus			Normal			StartOfVerse
 MAT	15	22	Canaanite (Syrophoenician) mother of possessed girl	pleading		Dialogue		MAT 15.22;MRK 7.26	EndOfVerse
 MAT	15	23	disciples	impatient		Dialogue			Unspecified
@@ -16498,14 +16494,14 @@ MAT	15	36	Jesus			Indirect
 MAT	15	39	Jesus			Indirect			
 MAT	16	1	Pharisees/Sadducees			Indirect			
 MAT	16	2	Jesus			Normal			EndOfVerse
-MAT	16	3	Jesus			Implicit			EntireVerse
+MAT	16	3	Jesus			Normal			EntireVerse
 MAT	16	4	Jesus			Normal			StartOfVerse
 MAT	16	6	Jesus	warning		Dialogue			Unspecified
 MAT	16	7	disciples	defensive		Normal			EndOfVerse
 MAT	16	8	Jesus			Dialogue			EndOfVerse
-MAT	16	9	Jesus			Implicit			EntireVerse
-MAT	16	10	Jesus			Implicit			EntireVerse
-MAT	16	11	Jesus			Implicit			EntireVerse
+MAT	16	9	Jesus			Dialogue			EntireVerse
+MAT	16	10	Jesus			Dialogue			EntireVerse
+MAT	16	11	Jesus			Dialogue			EntireVerse
 # It's possible for what Jesus meant to be in quotes. It's also possible for what he didn't say
 # to be in quotes (to be spoken by the narrator). If there are quotes here, it will likely need
 # review by a speaker of the target language.
@@ -16518,23 +16514,23 @@ MAT	16	15	Jesus			Dialogue			Unspecified
 MAT	16	16	Peter (Simon)			Dialogue			Unspecified
 MAT	16	17	Jesus			Dialogue			Unspecified
 MAT	16	18	Jesus			Dialogue			Unspecified
-MAT	16	19	Jesus			Implicit			EntireVerse
+MAT	16	19	Jesus			Dialogue			EntireVerse
 MAT	16	20	Jesus			Indirect			
 MAT	16	21	Jesus			Indirect			
 MAT	16	22	Peter (Simon)			Dialogue			EndOfVerse
 MAT	16	23	Jesus	rebuking		Dialogue			Unspecified
 MAT	16	24	Jesus			Dialogue			EndOfVerse
-MAT	16	25	Jesus			Implicit			EntireVerse
-MAT	16	26	Jesus			Implicit			EntireVerse
-MAT	16	27	Jesus			Implicit			EntireVerse
-MAT	16	28	Jesus			Implicit			EntireVerse
+MAT	16	25	Jesus			Normal			EntireVerse
+MAT	16	26	Jesus			Normal			EntireVerse
+MAT	16	27	Jesus			Normal			EntireVerse
+MAT	16	28	Jesus			Normal			EntireVerse
 MAT	17	4	Peter (Simon)	afraid		Dialogue			EndOfVerse
 MAT	17	5	God		voice from bright cloud (God)	Normal			EndOfVerse
 MAT	17	7	Jesus	giving orders		Dialogue			Unspecified
 MAT	17	9	Jesus	forcefully		Dialogue			Unspecified
 MAT	17	10	Peter (Simon)/James, the disciple/John	puzzled	the disciples (Peter/James/John)	Dialogue	John	MAT 17.10;MRK 9.11	EndOfVerse
 MAT	17	11	Jesus			Dialogue			Unspecified
-MAT	17	12	Jesus			Implicit			EntireVerse
+MAT	17	12	Jesus			Normal			EntireVerse
 # It's possible for what Jesus meant to be in quotes. It's also possible for what the disciples thought
 # or understood to be in quotes. If there are quotes here, it will likely need review by a speaker of
 # the target language.
@@ -16544,7 +16540,7 @@ MAT	17	13	disciples	thinking		Rare
 MAT	17	13	disciples	saying to each other		Rare			
 MAT	17	13	Needs Review			Potential			
 MAT	17	15	father of demon-possessed boy	distraught	a man (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	Unspecified
-MAT	17	16	father of demon-possessed boy	distraught	a man (father of demon-possessed boy)	Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
+MAT	17	16	father of demon-possessed boy	distraught	a man (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
 MAT	17	17	Jesus	exasperated		Dialogue			Unspecified
 MAT	17	17	Jesus	giving orders		Dialogue			Unspecified
 MAT	17	18	Jesus	rebuking		Indirect			
@@ -16558,25 +16554,25 @@ MAT	17	25	Jesus	questioning		Dialogue			Unspecified
 MAT	17	25	Peter (Simon)			Dialogue			Unspecified
 MAT	17	26	Jesus			Dialogue			Unspecified
 MAT	17	26	Peter (Simon)			Dialogue			Unspecified
-MAT	17	27	Jesus			Implicit			EntireVerse
+MAT	17	27	Jesus			Normal			EntireVerse
 MAT	18	1	disciples			Dialogue		MAT 18.1;MRK 9.34;LUK 9.46	Unspecified
 MAT	18	3	Jesus			Dialogue			EndOfVerse
-MAT	18	4	Jesus			Implicit			EntireVerse
+MAT	18	4	Jesus			Normal			EntireVerse
 MAT	18	5	Jesus			Normal			Unspecified
 MAT	18	6	Jesus			Normal			Unspecified
-MAT	18	7	Jesus			Implicit			EntireVerse
-MAT	18	8	Jesus			Implicit			EntireVerse
+MAT	18	7	Jesus			Normal			EntireVerse
+MAT	18	8	Jesus			Normal			EntireVerse
 MAT	18	9	Jesus			Normal			StartOfVerse
-MAT	18	10	Jesus	warning		Implicit			EntireVerse
+MAT	18	10	Jesus	warning		Normal			EntireVerse
 MAT	18	11	Jesus			Potential			
-MAT	18	12	Jesus			Implicit			EntireVerse
-MAT	18	13	Jesus			Implicit			EntireVerse
+MAT	18	12	Jesus			Normal			EntireVerse
+MAT	18	13	Jesus			Normal			EntireVerse
 MAT	18	14	Jesus			Normal			StartOfVerse
-MAT	18	15	Jesus			Implicit			EntireVerse
-MAT	18	16	Jesus			Implicit			EntireVerse
+MAT	18	15	Jesus			Normal			EntireVerse
+MAT	18	16	Jesus			Normal			EntireVerse
 MAT	18	17	Jesus			Normal			Unspecified
-MAT	18	18	Jesus			Implicit			EntireVerse
-MAT	18	19	Jesus			Implicit			EntireVerse
+MAT	18	18	Jesus			Normal			EntireVerse
+MAT	18	19	Jesus			Normal			EntireVerse
 MAT	18	20	Jesus			Normal			StartOfVerse
 MAT	18	21	Peter (Simon)	asking question		Dialogue			EndOfVerse
 MAT	18	22	Jesus			Dialogue			Unspecified
@@ -16590,16 +16586,16 @@ MAT	18	29	Jesus			Normal			Unspecified
 MAT	18	30	Jesus			Normal			Unspecified
 MAT	18	31	Jesus			Normal			Unspecified
 MAT	18	32	Jesus			Normal			Unspecified
-MAT	18	33	Jesus			Implicit			EntireVerse
-MAT	18	34	Jesus			Implicit			EntireVerse
-MAT	18	35	Jesus			Implicit			EntireVerse
+MAT	18	33	Jesus			Normal			EntireVerse
+MAT	18	34	Jesus			Normal			EntireVerse
+MAT	18	35	Jesus			Normal			EntireVerse
 MAT	19	3	Pharisees, some	challenging		Dialogue		MAT 19.3;MRK 10.2	EndOfVerse
 MAT	19	4	Jesus			Dialogue			Unspecified
-MAT	19	5	Jesus			Implicit			EntireVerse
-MAT	19	6	Jesus			Implicit			EntireVerse
+MAT	19	5	Jesus			Normal			EntireVerse
+MAT	19	6	Jesus			Normal			EntireVerse
 MAT	19	7	Pharisees, some	challenging		Dialogue		MAT 19.7;MRK 10.4	EndOfVerse
 MAT	19	8	Jesus			Dialogue			Unspecified
-MAT	19	9	Jesus			Implicit			EntireVerse
+MAT	19	9	Jesus			Normal			EntireVerse
 MAT	19	10	disciples	shocked		Dialogue			Unspecified
 MAT	19	11	Jesus			Dialogue			Unspecified
 MAT	19	12	Jesus			Normal			StartOfVerse
@@ -16609,17 +16605,17 @@ MAT	19	16	rich young ruler	respectful	man (young)	Dialogue		MAT 19.16;MRK 10.17;
 MAT	19	17	Jesus			Dialogue			Unspecified
 MAT	19	18	rich young ruler		man (young)	Dialogue			Unspecified
 MAT	19	18	Jesus			Dialogue			EndOfVerse
-MAT	19	19	Jesus			Implicit			EntireVerse
+MAT	19	19	Jesus			Dialogue			EntireVerse
 MAT	19	20	rich young ruler	upset	man (young)	Dialogue		MAT 19.20;MRK 10.20;LUK 18.21	Unspecified
 MAT	19	21	Jesus			Dialogue			Unspecified
 MAT	19	23	Jesus			Dialogue			Unspecified
-MAT	19	24	Jesus			Implicit			EntireVerse
+MAT	19	24	Jesus			Normal			EntireVerse
 MAT	19	25	disciples	shocked		Dialogue		MAT 19.25;MRK 10.26;LUK 18.26	EndOfVerse
 MAT	19	26	Jesus			Dialogue			Unspecified
 MAT	19	27	Peter (Simon)	confused		Dialogue			Unspecified
 MAT	19	28	Jesus			Dialogue			Unspecified
-MAT	19	29	Jesus			Implicit			EntireVerse
-MAT	19	30	Jesus			Implicit			EntireVerse
+MAT	19	29	Jesus			Normal			EntireVerse
+MAT	19	30	Jesus			Normal			EntireVerse
 MAT	20	1	Jesus			Normal			Unspecified
 MAT	20	2	Jesus			Normal			Unspecified
 MAT	20	3	Jesus			Normal			Unspecified
@@ -16633,10 +16629,10 @@ MAT	20	10	Jesus			Normal			Unspecified
 MAT	20	11	Jesus			Normal			Unspecified
 MAT	20	12	Jesus			Normal			Unspecified
 MAT	20	13	Jesus			Normal			Unspecified
-MAT	20	14	Jesus			Implicit			EntireVerse
-MAT	20	15	Jesus			Implicit			EntireVerse
+MAT	20	14	Jesus			Normal			EntireVerse
+MAT	20	15	Jesus			Normal			EntireVerse
 MAT	20	16	Jesus			Normal			Unspecified
-MAT	20	18	Jesus			Implicit			EntireVerse
+MAT	20	18	Jesus			Normal			EntireVerse
 MAT	20	19	Jesus			Normal			StartOfVerse
 MAT	20	20	mother of the sons of Zebedee (James and John)			Indirect			
 MAT	20	21	Jesus			Dialogue			Unspecified
@@ -16645,8 +16641,8 @@ MAT	20	22	Jesus			Dialogue			Unspecified
 MAT	20	22	James, the disciple/John	boldly	sons of Zebedee (James/John)	Dialogue	John		Unspecified
 MAT	20	23	Jesus			Dialogue			Unspecified
 MAT	20	25	Jesus			Dialogue			EndOfVerse
-MAT	20	26	Jesus			Implicit			EntireVerse
-MAT	20	27	Jesus			Implicit			EntireVerse
+MAT	20	26	Jesus			Normal			EntireVerse
+MAT	20	27	Jesus			Normal			EntireVerse
 MAT	20	28	Jesus			Normal			StartOfVerse
 MAT	20	30	crowd at Jericho			Indirect		MAT 20.30;MRK 10.47;LUK 18.37	
 # Although the Matthew account says "two blind men" the parallel accounts in Mark and Luke suggest
@@ -16657,8 +16653,8 @@ MAT	20	31	Bartimaeus (a blind man)	shouting	two blind men	Dialogue		MAT 20.31;MR
 MAT	20	32	Jesus			Dialogue			EndOfVerse
 MAT	20	33	Bartimaeus (a blind man)	begging	two blind men	Dialogue		MAT 20.33;MRK 10.51;LUK 18.41	Unspecified
 MAT	21	2	Jesus			Normal			EndOfVerse
-MAT	21	3	Jesus			Implicit			EntireVerse
-MAT	21	5	scripture			Implicit	Zechariah the prophet, son of Berechiah	MAT 21:5; JHN 12:15	EntireVerse
+MAT	21	3	Jesus			Normal			EntireVerse
+MAT	21	5	scripture			Quotation	Zechariah the prophet, son of Berechiah	MAT 21:5; JHN 12:15	EntireVerse
 MAT	21	9	crowd preparing for Passover Feast	praising	crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EndOfVerse
 MAT	21	10	people of Jerusalem		the whole city	Dialogue			Unspecified
 MAT	21	11	crowd	praising		Dialogue			Unspecified
@@ -16679,8 +16675,8 @@ MAT	21	26	chief priests/teachers of religious law/elders	to themselves	chief pri
 MAT	21	27	chief priests/teachers of religious law/elders		chief priests and the elders of the people	Dialogue		MAT 21.27;MRK 11.33;LUK 20.7	Unspecified
 MAT	21	27	Jesus			Dialogue		MAT 21.27;MRK 11.33;LUK 20.8	Unspecified
 MAT	21	28	Jesus			Dialogue			Unspecified
-MAT	21	29	Jesus			Implicit			EntireVerse
-MAT	21	30	Jesus			Implicit			EntireVerse
+MAT	21	29	Jesus			Normal			EntireVerse
+MAT	21	30	Jesus			Normal			EntireVerse
 MAT	21	31	chief priests/elders		chief priests and the elders of the people	Dialogue	Good Priest		Unspecified
 MAT	21	31	Jesus			Dialogue			Unspecified
 MAT	21	32	Jesus			Normal			StartOfVerse
@@ -16690,12 +16686,12 @@ MAT	21	35	Jesus			Normal			Unspecified
 MAT	21	36	Jesus			Normal			Unspecified
 MAT	21	37	Jesus			Normal			Unspecified
 MAT	21	38	Jesus			Normal			Unspecified
-MAT	21	39	Jesus			Implicit			EntireVerse
+MAT	21	39	Jesus			Normal			EntireVerse
 MAT	21	40	Jesus			Normal			Unspecified
 MAT	21	41	chief priests/elders	serious	chief priests/elders of people	Dialogue	Good Priest		Unspecified
 MAT	21	42	Jesus			Dialogue			Unspecified
-MAT	21	43	Jesus			Implicit			EntireVerse
-MAT	21	44	Jesus			Implicit			EntireVerse
+MAT	21	43	Jesus			Normal			EntireVerse
+MAT	21	44	Jesus			Normal			EntireVerse
 MAT	21	45	chief priests/Pharisees	angry		Indirect			
 MAT	21	46	chief priests/Pharisees			Indirect			
 MAT	22	2	Jesus			Normal			Unspecified
@@ -16705,16 +16701,16 @@ MAT	22	5	Jesus			Normal			Unspecified
 MAT	22	6	Jesus			Normal			Unspecified
 MAT	22	7	Jesus			Normal			Unspecified
 MAT	22	8	Jesus			Normal			Unspecified
-MAT	22	9	Jesus			Implicit			EntireVerse
+MAT	22	9	Jesus			Normal			EntireVerse
 MAT	22	10	Jesus			Normal			Unspecified
 MAT	22	11	Jesus			Normal			Unspecified
 MAT	22	12	Jesus			Normal			Unspecified
-MAT	22	13	Jesus			Implicit			EntireVerse
+MAT	22	13	Jesus			Normal			EntireVerse
 MAT	22	14	Jesus			Normal			StartOfVerse
 MAT	22	15	Pharisees			Rare			
 MAT	22	15	Needs Review			Potential			
 MAT	22	16	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EndOfVerse
-MAT	22	17	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Implicit		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
+MAT	22	17	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
 MAT	22	18	Jesus	rebuking		Dialogue			EndOfVerse
 MAT	22	19	Jesus	rebuking		Dialogue			StartOfVerse
 MAT	22	20	Jesus	questioning		Dialogue			Unspecified
@@ -16724,14 +16720,14 @@ MAT	22	22	spies (from Pharisees and Herodians)		disciples of Pharisees/Herodians
 MAT	22	22	Needs Review			Potential			
 MAT	22	23	Sadducees			Hypothetical			Unspecified
 MAT	22	24	Sadducees			Dialogue			Unspecified
-MAT	22	25	Sadducees			Implicit			EntireVerse
-MAT	22	26	Sadducees			Implicit			EntireVerse
-MAT	22	27	Sadducees			Implicit			EntireVerse
-MAT	22	28	Sadducees			Implicit			EntireVerse
+MAT	22	25	Sadducees			Normal			EntireVerse
+MAT	22	26	Sadducees			Normal			EntireVerse
+MAT	22	27	Sadducees			Normal			EntireVerse
+MAT	22	28	Sadducees			Normal			EntireVerse
 MAT	22	29	Jesus			Dialogue			Unspecified
 MAT	22	30	Jesus			Normal			Unspecified
 MAT	22	31	Jesus			Normal			Unspecified
-MAT	22	32	Jesus			Implicit			EntireVerse
+MAT	22	32	Jesus			Normal			EntireVerse
 # Although Matthew's account here identifies the amazed people as just the crowd, it seems to parallel the
 # reaction of some of the scribes in Luke's account, so it's best to allow for both possibilities here.
 MAT	22	33	crowd			Rare			
@@ -16739,7 +16735,7 @@ MAT	22	33	expert in religious law			Rare
 MAT	22	33	Needs Review			Potential			
 MAT	22	34	report about Jesus			Rare			
 MAT	22	34	Needs Review			Potential			
-MAT	22	36	Pharisee (expert in religious law)	testing		Implicit			EntireVerse
+MAT	22	36	Pharisee (expert in religious law)	testing		Dialogue			EntireVerse
 MAT	22	37	Jesus			Dialogue			Unspecified
 MAT	22	38	Jesus			Normal			Unspecified
 MAT	22	39	Jesus			Normal			Unspecified
@@ -16748,45 +16744,45 @@ MAT	22	42	Jesus	questioning		Dialogue			Unspecified
 MAT	22	42	Pharisees			Dialogue			Unspecified
 MAT	22	43	Jesus			Dialogue			Unspecified
 MAT	22	44	Jesus			Normal			Unspecified
-MAT	22	45	Jesus			Implicit			EntireVerse
-MAT	23	2	Jesus			Implicit			EntireVerse
-MAT	23	3	Jesus			Implicit			EntireVerse
-MAT	23	4	Jesus			Implicit			EntireVerse
-MAT	23	5	Jesus			Implicit			EntireVerse
-MAT	23	6	Jesus			Implicit			EntireVerse
-MAT	23	7	Jesus			Implicit			EntireVerse
-MAT	23	8	Jesus			Implicit			EntireVerse
-MAT	23	9	Jesus			Implicit			EntireVerse
-MAT	23	10	Jesus			Implicit			EntireVerse
-MAT	23	11	Jesus			Implicit			EntireVerse
-MAT	23	12	Jesus			Implicit			EntireVerse
-MAT	23	13	Jesus	rebuking		Implicit			EntireVerse
+MAT	22	45	Jesus			Normal			EntireVerse
+MAT	23	2	Jesus			Normal			EntireVerse
+MAT	23	3	Jesus			Normal			EntireVerse
+MAT	23	4	Jesus			Normal			EntireVerse
+MAT	23	5	Jesus			Normal			EntireVerse
+MAT	23	6	Jesus			Normal			EntireVerse
+MAT	23	7	Jesus			Normal			EntireVerse
+MAT	23	8	Jesus			Normal			EntireVerse
+MAT	23	9	Jesus			Normal			EntireVerse
+MAT	23	10	Jesus			Normal			EntireVerse
+MAT	23	11	Jesus			Normal			EntireVerse
+MAT	23	12	Jesus			Normal			EntireVerse
+MAT	23	13	Jesus	rebuking		Normal			EntireVerse
 MAT	23	14	Jesus	rebuking		Normal			Unspecified
-MAT	23	15	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	16	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	17	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	18	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	19	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	20	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	21	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	22	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	23	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	24	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	25	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	26	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	27	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	28	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	29	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	30	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	31	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	32	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	33	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	34	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	35	Jesus	rebuking		Implicit			EntireVerse
+MAT	23	15	Jesus	rebuking		Normal			EntireVerse
+MAT	23	16	Jesus	rebuking		Normal			EntireVerse
+MAT	23	17	Jesus	rebuking		Normal			EntireVerse
+MAT	23	18	Jesus	rebuking		Normal			EntireVerse
+MAT	23	19	Jesus	rebuking		Normal			EntireVerse
+MAT	23	20	Jesus	rebuking		Normal			EntireVerse
+MAT	23	21	Jesus	rebuking		Normal			EntireVerse
+MAT	23	22	Jesus	rebuking		Normal			EntireVerse
+MAT	23	23	Jesus	rebuking		Normal			EntireVerse
+MAT	23	24	Jesus	rebuking		Normal			EntireVerse
+MAT	23	25	Jesus	rebuking		Normal			EntireVerse
+MAT	23	26	Jesus	rebuking		Normal			EntireVerse
+MAT	23	27	Jesus	rebuking		Normal			EntireVerse
+MAT	23	28	Jesus	rebuking		Normal			EntireVerse
+MAT	23	29	Jesus	rebuking		Normal			EntireVerse
+MAT	23	30	Jesus	rebuking		Normal			EntireVerse
+MAT	23	31	Jesus	rebuking		Normal			EntireVerse
+MAT	23	32	Jesus	rebuking		Normal			EntireVerse
+MAT	23	33	Jesus	rebuking		Normal			EntireVerse
+MAT	23	34	Jesus	rebuking		Normal			EntireVerse
+MAT	23	35	Jesus	rebuking		Normal			EntireVerse
 MAT	23	36	Jesus	rebuking		Normal			Unspecified
-MAT	23	37	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	38	Jesus	rebuking		Implicit			EntireVerse
-MAT	23	39	Jesus	rebuking		Implicit			EntireVerse
+MAT	23	37	Jesus	rebuking		Normal			EntireVerse
+MAT	23	38	Jesus	rebuking		Normal			EntireVerse
+MAT	23	39	Jesus	rebuking		Normal			EntireVerse
 MAT	24	1	Peter (Simon)/James, the disciple/John/Andrew		the disciples	Indirect	Peter (Simon)		
 MAT	24	2	Jesus			Dialogue			Unspecified
 MAT	24	3	Peter (Simon)/James, the disciple/John/Andrew		the disciples	Dialogue	Peter (Simon)	MAT 24.3;MRK 13.4;LUK 21.7	EndOfVerse
@@ -16811,12 +16807,12 @@ MAT	24	20	Jesus			Normal			Unspecified
 MAT	24	21	Jesus			Normal			Unspecified
 MAT	24	22	Jesus			Normal			Unspecified
 MAT	24	23	Jesus			Normal			Unspecified
-MAT	24	24	Jesus			Implicit			EntireVerse
-MAT	24	25	Jesus			Implicit			EntireVerse
-MAT	24	26	Jesus			Implicit			EntireVerse
-MAT	24	27	Jesus			Implicit			EntireVerse
+MAT	24	24	Jesus			Normal			EntireVerse
+MAT	24	25	Jesus			Normal			EntireVerse
+MAT	24	26	Jesus			Normal			EntireVerse
+MAT	24	27	Jesus			Normal			EntireVerse
 MAT	24	28	Jesus			Normal			Unspecified
-MAT	24	29	Jesus			Implicit			EntireVerse
+MAT	24	29	Jesus			Normal			EntireVerse
 MAT	24	30	Jesus			Normal			Unspecified
 MAT	24	31	Jesus			Normal			Unspecified
 MAT	24	32	Jesus			Normal			Unspecified
@@ -16863,36 +16859,36 @@ MAT	25	21	Jesus			Normal			Unspecified
 MAT	25	22	Jesus			Normal			Unspecified
 MAT	25	23	Jesus			Normal			Unspecified
 MAT	25	24	Jesus			Normal			Unspecified
-MAT	25	25	Jesus			Implicit			EntireVerse
+MAT	25	25	Jesus			Normal			EntireVerse
 MAT	25	26	Jesus			Normal			Unspecified
-MAT	25	27	Jesus			Implicit			EntireVerse
+MAT	25	27	Jesus			Normal			EntireVerse
 MAT	25	28	Jesus			Normal			Unspecified
-MAT	25	29	Jesus			Implicit			EntireVerse
+MAT	25	29	Jesus			Normal			EntireVerse
 MAT	25	30	Jesus			Normal			StartOfVerse
 MAT	25	31	Jesus			Normal			Unspecified
 MAT	25	32	Jesus			Normal			Unspecified
 MAT	25	33	Jesus			Normal			Unspecified
 MAT	25	34	Jesus			Normal			Unspecified
-MAT	25	35	Jesus			Implicit			EntireVerse
-MAT	25	36	Jesus			Implicit			EntireVerse
+MAT	25	35	Jesus			Normal			EntireVerse
+MAT	25	36	Jesus			Normal			EntireVerse
 MAT	25	37	Jesus			Normal			Unspecified
-MAT	25	38	Jesus			Implicit			EntireVerse
-MAT	25	39	Jesus			Implicit			EntireVerse
+MAT	25	38	Jesus			Normal			EntireVerse
+MAT	25	39	Jesus			Normal			EntireVerse
 MAT	25	40	Jesus			Normal			Unspecified
 MAT	25	41	Jesus			Normal			Unspecified
-MAT	25	42	Jesus			Implicit			EntireVerse
-MAT	25	43	Jesus			Implicit			EntireVerse
+MAT	25	42	Jesus			Normal			EntireVerse
+MAT	25	43	Jesus			Normal			EntireVerse
 MAT	25	44	Jesus			Normal			Unspecified
 MAT	25	45	Jesus			Normal			Unspecified
 MAT	25	46	Jesus			Normal			Unspecified
-MAT	26	2	Jesus			Implicit			EntireVerse
+MAT	26	2	Jesus			Normal			EntireVerse
 MAT	26	5	chief priests/teachers of religious law/elders		chief priests/elders	Dialogue		MAT 26.5;MRK 14.2	Unspecified
 # Judas Iscariot was the main spokesman, if the accounts in Matthew 26 and Mark 14 are held to be the same as the one in John 12.								
 MAT	26	8	disciples	indignant		Dialogue	Judas Iscariot	MAT 26.8-9;MRK 14.4-5;JHN 12.5	Unspecified
-MAT	26	9	disciples	indignant		Implicit	Judas Iscariot	MAT 26.8-9;MRK 14.4-5;JHN 12.5	EntireVerse
+MAT	26	9	disciples	indignant		Normal	Judas Iscariot	MAT 26.8-9;MRK 14.4-5;JHN 12.5	EntireVerse
 MAT	26	10	Jesus			Dialogue			EndOfVerse
-MAT	26	11	Jesus			Implicit			EntireVerse
-MAT	26	12	Jesus			Implicit			EntireVerse
+MAT	26	11	Jesus			Normal			EntireVerse
+MAT	26	12	Jesus			Normal			EntireVerse
 MAT	26	13	Jesus			Normal			StartOfVerse
 MAT	26	15	Judas Iscariot	plotting		Dialogue			Unspecified
 MAT	26	17	Peter (Simon)/John		the disciples	Dialogue	John	MAT 26.17;MRK 14.12;LUK 22.9	EndOfVerse
@@ -16900,15 +16896,15 @@ MAT	26	18	Jesus			Normal			EndOfVerse
 MAT	26	21	Jesus			Dialogue		MAT 26.21;MRK 14.18	EndOfVerse
 MAT	26	22	disciples	sad		Dialogue		MAT 26.22;MRK 14.19;LUK 22.23	EndOfVerse
 MAT	26	23	Jesus			Dialogue		MAT 26.23;MRK 14.20	Unspecified
-MAT	26	24	Jesus			Implicit			EntireVerse
+MAT	26	24	Jesus			Dialogue			EntireVerse
 MAT	26	25	Jesus			Dialogue			Unspecified
 MAT	26	25	Judas Iscariot	fake innocence		Dialogue			Unspecified
 MAT	26	26	Jesus			Dialogue			EndOfVerse
 MAT	26	27	Jesus			Dialogue			EndOfVerse
-MAT	26	28	Jesus			Implicit			EntireVerse
+MAT	26	28	Jesus			Normal			EntireVerse
 MAT	26	29	Jesus			Normal			Unspecified
 MAT	26	31	Jesus			Dialogue			Unspecified
-MAT	26	32	Jesus			Implicit			EntireVerse
+MAT	26	32	Jesus			Normal			EntireVerse
 MAT	26	33	Peter (Simon)	passionate		Dialogue			Unspecified
 MAT	26	34	Jesus			Dialogue			Unspecified
 MAT	26	35	Peter (Simon)	denial, stronger		Dialogue			Unspecified
@@ -16916,7 +16912,7 @@ MAT	26	36	Jesus	giving orders		Normal			EndOfVerse
 MAT	26	38	Jesus			Dialogue			Unspecified
 MAT	26	39	Jesus	praying		Normal			EndOfVerse
 MAT	26	40	Jesus			Dialogue			Unspecified
-MAT	26	41	Jesus			Implicit			EntireVerse
+MAT	26	41	Jesus			Normal			EntireVerse
 MAT	26	42	Jesus	deeply distressed		Normal			EndOfVerse
 MAT	26	45	Jesus	resigned		Normal			EndOfVerse
 MAT	26	46	Jesus			Normal			StartOfVerse
@@ -16926,8 +16922,8 @@ MAT	26	48	Judas Iscariot	plotting		Normal			EndOfVerse
 MAT	26	49	Judas Iscariot	fake respect		Dialogue			ContainedWithinVerse
 MAT	26	50	Jesus			Dialogue			Unspecified
 MAT	26	52	Jesus			Dialogue			Unspecified
-MAT	26	53	Jesus			Implicit			EntireVerse
-MAT	26	54	Jesus			Implicit			EntireVerse
+MAT	26	53	Jesus			Normal			EntireVerse
+MAT	26	54	Jesus			Normal			EntireVerse
 MAT	26	55	Jesus			Dialogue			EndOfVerse
 MAT	26	56	Jesus			Normal			StartOfVerse
 MAT	26	59	chief priests/Sanhedrin			Rare		MAT 26.59; MRK 14.55	
@@ -16984,7 +16980,7 @@ MAT	27	37	sign on the cross			Quotation	narrator-MAT		Unspecified
 MAT	27	39	passers by	mocking		Potential			
 MAT	27	40	passers by	mocking		Dialogue			Unspecified
 MAT	27	42	chief priests/teachers of religious law/elders	sneering		Dialogue		MAT 27.42;MRK 15.31-32;LUK 23.35	Unspecified
-MAT	27	43	chief priests/teachers of religious law/elders	sneering		Implicit			EntireVerse
+MAT	27	43	chief priests/teachers of religious law/elders	sneering		Dialogue			EntireVerse
 MAT	27	44	criminal on cross, insulting		the robbers who were crucified with Jesus	Potential		MAT 27.44;LUK 23.39	
 MAT	27	46	Jesus	deeply distressed		Normal			
 MAT	27	46	narrator-MAT			Quotation			Unspecified
@@ -16995,16 +16991,16 @@ MAT	27	54	centurion at crucifixion	amazed		Dialogue			EndOfVerse
 MAT	27	58	Joseph of Arimathaea			Indirect			
 MAT	27	58	Pilate			Indirect			
 MAT	27	63	chief priests/Pharisees	negotiating		Dialogue			Unspecified
-MAT	27	64	chief priests/Pharisees	negotiating		Implicit			EntireVerse
+MAT	27	64	chief priests/Pharisees	negotiating		Dialogue			EntireVerse
 MAT	27	65	Pilate	impatient		Dialogue			Unspecified
 MAT	28	5	angels in white, two		angel	Dialogue		MAT 28.5-6;MRK 16.6;LUK 24.6	EndOfVerse
-MAT	28	6	angels in white, two		angel	Implicit		MAT 28.5-6;MRK 16.6;LUK 24.6	EntireVerse
-MAT	28	7	angels in white, two		angel	Implicit		MAT 28.7;MRK 16.7	EntireVerse
+MAT	28	6	angels in white, two		angel	Dialogue		MAT 28.5-6;MRK 16.6;LUK 24.6	EntireVerse
+MAT	28	7	angels in white, two		angel	Dialogue		MAT 28.7;MRK 16.7	EntireVerse
 MAT	28	9	Jesus			Normal			Unspecified
 MAT	28	10	Jesus			Dialogue			Unspecified
 MAT	28	11	soldiers, Roman		some of the guard	Potential			
 MAT	28	13	chief priests/elders	bribing		Normal			EndOfVerse
-MAT	28	14	chief priests/elders	bribing		Implicit			EntireVerse
+MAT	28	14	chief priests/elders	bribing		Normal			EntireVerse
 MAT	28	15	saying (lie about disciples stealing Jesus' body)			Rare			
 MAT	28	15	chief priests/elders			Rare			
 MAT	28	15	Jews, the			Rare			
@@ -17014,10 +17010,10 @@ MAT	28	16	Needs Review			Potential
 MAT	28	17	disciples			Rare			
 MAT	28	17	Needs Review			Potential			
 MAT	28	18	Jesus			Dialogue			EndOfVerse
-MAT	28	19	Jesus			Implicit			EntireVerse
-MAT	28	20	Jesus			Implicit			EntireVerse
+MAT	28	19	Jesus			Normal			EntireVerse
+MAT	28	20	Jesus			Normal			EntireVerse
 MRK	1	2	scripture			Quotation	Isaiah		EndOfVerse
-MRK	1	3	scripture			Implicit	Isaiah		EntireVerse
+MRK	1	3	scripture			Quotation	Isaiah		EntireVerse
 MRK	1	4	John the Baptist			Indirect			
 MRK	1	5	people from Jerusalem, Judea and the region around the Jordan			Rare			
 MRK	1	5	Needs Review			Potential			
@@ -17029,7 +17025,7 @@ MRK	1	17	Jesus			Dialogue			Unspecified
 MRK	1	20	Jesus			Indirect			
 MRK	1	22	people in Capernaum synagogue	amazed		Rare			
 MRK	1	22	Needs Review			Potential			
-MRK	1	24	man possessed by evil spirit			Implicit			EntireVerse
+MRK	1	24	man possessed by evil spirit			Dialogue			EntireVerse
 MRK	1	25	Jesus	giving orders		Dialogue			Unspecified
 MRK	1	27	men in Capernaum synagogue	amazed		Normal			Unspecified
 MRK	1	30	people in Capernaum			Indirect			
@@ -17046,11 +17042,11 @@ MRK	1	45	leper	proclaim		Rare
 MRK	1	45	Needs Review			Potential			
 MRK	2	1	people in Capernaum			Indirect			
 MRK	2	5	Jesus			Dialogue			EndOfVerse
-MRK	2	7	teachers of religious law/Pharisees	thinking	teachers of religious law	Implicit		MRK 2.7;LUK 5.21	EntireVerse
+MRK	2	7	teachers of religious law/Pharisees	thinking	teachers of religious law	Normal		MRK 2.7;LUK 5.21	EntireVerse
 MRK	2	8	Jesus	rebuking		Dialogue			Unspecified
-MRK	2	9	Jesus			Implicit			EntireVerse
+MRK	2	9	Jesus			Normal			EntireVerse
 MRK	2	10	Jesus			Normal			StartOfVerse
-MRK	2	11	Jesus	giving orders		Implicit			EntireVerse
+MRK	2	11	Jesus	giving orders		Normal			EntireVerse
 MRK	2	12	everyone who saw healing of paralytic	praising		Dialogue			ContainedWithinVerse
 MRK	2	14	Jesus	inviting		Dialogue			ContainedWithinVerse
 MRK	2	15	narrator-MRK			Quotation			Unspecified
@@ -17058,14 +17054,14 @@ MRK	2	16	teachers of religious law	contempt	teachers of religious law (Pharisees
 MRK	2	17	Jesus			Dialogue			ContainedWithinVerse
 MRK	2	18	people, some	critical		Dialogue			EndOfVerse
 MRK	2	19	Jesus			Dialogue			EndOfVerse
-MRK	2	20	Jesus			Implicit			EntireVerse
-MRK	2	21	Jesus			Implicit			EntireVerse
+MRK	2	20	Jesus			Normal			EntireVerse
+MRK	2	21	Jesus			Normal			EntireVerse
 MRK	2	22	Jesus			Normal			StartOfVerse
 MRK	2	24	Pharisees, some	accusing		Dialogue			Unspecified
 MRK	2	25	Jesus			Dialogue			EndOfVerse
-MRK	2	26	Jesus			Implicit			EntireVerse
+MRK	2	26	Jesus			Normal			EntireVerse
 MRK	2	27	Jesus			Normal			Unspecified
-MRK	2	28	Jesus			Implicit			EntireVerse
+MRK	2	28	Jesus			Normal			EntireVerse
 MRK	3	2	Pharisees	accusing		Rare			
 MRK	3	2	Needs Review			Potential			
 MRK	3	3	Jesus	giving orders		Dialogue			Unspecified
@@ -17085,48 +17081,48 @@ MRK	3	17	narrator-MRK			Quotation			Unspecified
 MRK	3	21	Jesus' family			Normal			Unspecified
 MRK	3	22	teachers of religious law	insulting	teachers of religious law (from Jerusalem)	Normal			Unspecified
 MRK	3	23	Jesus			Normal			EndOfVerse
-MRK	3	24	Jesus			Implicit			EntireVerse
-MRK	3	25	Jesus			Implicit			EntireVerse
-MRK	3	26	Jesus			Implicit			EntireVerse
-MRK	3	27	Jesus			Implicit			EntireVerse
-MRK	3	28	Jesus			Implicit			EntireVerse
-MRK	3	29	Jesus			Implicit			EntireVerse
+MRK	3	24	Jesus			Normal			EntireVerse
+MRK	3	25	Jesus			Normal			EntireVerse
+MRK	3	26	Jesus			Normal			EntireVerse
+MRK	3	27	Jesus			Normal			EntireVerse
+MRK	3	28	Jesus			Normal			EntireVerse
+MRK	3	29	Jesus			Normal			EntireVerse
 MRK	3	30	narrator-MRK			Quotation			Unspecified
 MRK	3	30	teachers of religious law	insulting	teachers of religious law (from Jerusalem)	Quotation			Unspecified
 MRK	3	31	Jesus' family			Indirect			
 MRK	3	32	crowd	announcing		Dialogue		MAT 12.47;MRK 3.32;LUK 8.20	Unspecified
 MRK	3	33	Jesus	questioning		Dialogue			Unspecified
 MRK	3	34	Jesus			Dialogue			EndOfVerse
-MRK	3	35	Jesus			Implicit			EntireVerse
-MRK	4	3	Jesus			Implicit			EntireVerse
-MRK	4	4	Jesus			Implicit			EntireVerse
-MRK	4	5	Jesus			Implicit			EntireVerse
-MRK	4	6	Jesus			Implicit			EntireVerse
-MRK	4	7	Jesus			Implicit			EntireVerse
-MRK	4	8	Jesus			Implicit			EntireVerse
+MRK	3	35	Jesus			Normal			EntireVerse
+MRK	4	3	Jesus			Normal			EntireVerse
+MRK	4	4	Jesus			Normal			EntireVerse
+MRK	4	5	Jesus			Normal			EntireVerse
+MRK	4	6	Jesus			Normal			EntireVerse
+MRK	4	7	Jesus			Normal			EntireVerse
+MRK	4	8	Jesus			Normal			EntireVerse
 MRK	4	9	Jesus			Normal			Unspecified
 MRK	4	10	disciples			Indirect			
 MRK	4	11	Jesus			Normal			Unspecified
 MRK	4	12	Jesus			Normal			Unspecified
 MRK	4	13	Jesus			Normal			Unspecified
-MRK	4	14	Jesus			Implicit			EntireVerse
-MRK	4	15	Jesus			Implicit			EntireVerse
-MRK	4	16	Jesus			Implicit			EntireVerse
-MRK	4	17	Jesus			Implicit			EntireVerse
-MRK	4	18	Jesus			Implicit			EntireVerse
-MRK	4	19	Jesus			Implicit			EntireVerse
+MRK	4	14	Jesus			Normal			EntireVerse
+MRK	4	15	Jesus			Normal			EntireVerse
+MRK	4	16	Jesus			Normal			EntireVerse
+MRK	4	17	Jesus			Normal			EntireVerse
+MRK	4	18	Jesus			Normal			EntireVerse
+MRK	4	19	Jesus			Normal			EntireVerse
 MRK	4	20	Jesus			Normal			StartOfVerse
 MRK	4	21	Jesus			Normal			EndOfVerse
-MRK	4	22	Jesus			Implicit			EntireVerse
-MRK	4	23	Jesus			Implicit			EntireVerse
+MRK	4	22	Jesus			Normal			EntireVerse
+MRK	4	23	Jesus			Normal			EntireVerse
 MRK	4	24	Jesus			Normal			Unspecified
 MRK	4	25	Jesus			Normal			StartOfVerse
 MRK	4	26	Jesus			Normal			EndOfVerse
-MRK	4	27	Jesus			Implicit			EntireVerse
-MRK	4	28	Jesus			Implicit			EntireVerse
+MRK	4	27	Jesus			Normal			EntireVerse
+MRK	4	28	Jesus			Normal			EntireVerse
 MRK	4	29	Jesus			Normal			StartOfVerse
 MRK	4	30	Jesus			Normal			EndOfVerse
-MRK	4	31	Jesus			Implicit			EntireVerse
+MRK	4	31	Jesus			Normal			EntireVerse
 MRK	4	32	Jesus			Normal			Unspecified
 MRK	4	35	Jesus	giving orders		Dialogue			EndOfVerse
 MRK	4	38	disciples	terrified		Dialogue			Unspecified
@@ -17190,7 +17186,7 @@ MRK	6	7	Jesus	giving orders		Indirect
 MRK	6	8	Jesus			Indirect			
 MRK	6	9	Jesus			Indirect			
 MRK	6	10	Jesus			Normal			Unspecified
-MRK	6	11	Jesus			Implicit			EntireVerse
+MRK	6	11	Jesus			Normal			EntireVerse
 MRK	6	12	disciples			Indirect			
 MRK	6	14	people, some	excited		Normal			
 MRK	6	14	Herod Antipas (the tetrarch)			Normal			
@@ -17221,7 +17217,7 @@ MRK	6	33	Needs Review			Potential
 MRK	6	34	Jesus			Rare			
 MRK	6	34	Needs Review			Potential			
 MRK	6	35	disciples	taking charge		Dialogue		MAT 14.15;MRK 6.35-36;LUK 9.12	EndOfVerse
-MRK	6	36	disciples	taking charge		Implicit			EntireVerse
+MRK	6	36	disciples	taking charge		Normal			EntireVerse
 MRK	6	37	Jesus			Dialogue			Unspecified
 MRK	6	37	Philip the apostle	frustrated	disciples (Philip, see John 6:7)	Dialogue		MRK 6.37;JHN 6.7	Unspecified
 MRK	6	38	Andrew		disciples (Andrew, see John 6:9)	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9	Unspecified
@@ -17240,24 +17236,24 @@ MRK	6	56	people at Gennesaret (sick)			Indirect		MAT 14.36;MRK 6.56
 MRK	7	2	narrator-MRK			Quotation			Unspecified
 MRK	7	5	Pharisees/teachers of religious law	critical		Dialogue		MAT 15.2;MRK 7.5	EndOfVerse
 MRK	7	6	Jesus	rebuking		Dialogue			EndOfVerse
-MRK	7	7	Jesus	rebuking		Implicit			EntireVerse
-MRK	7	8	Jesus	rebuking		Implicit			EntireVerse
+MRK	7	7	Jesus	rebuking		Normal			EntireVerse
+MRK	7	8	Jesus	rebuking		Normal			EntireVerse
 MRK	7	9	Jesus	rebuking		Normal			Unspecified
-MRK	7	10	Jesus	rebuking		Implicit			EntireVerse
+MRK	7	10	Jesus	rebuking		Normal			EntireVerse
 MRK	7	11	Jesus	rebuking		Normal			
 MRK	7	11	narrator-MRK			Interruption			
-MRK	7	12	Jesus	rebuking		Implicit			EntireVerse
+MRK	7	12	Jesus	rebuking		Normal			EntireVerse
 MRK	7	13	Jesus	rebuking		Normal			Unspecified
 MRK	7	14	Jesus			Normal			Unspecified
-MRK	7	15	Jesus			Implicit			EntireVerse
+MRK	7	15	Jesus			Normal			EntireVerse
 MRK	7	16	Jesus			Potential			
 MRK	7	17	disciples	puzzled		Indirect			
 MRK	7	18	Jesus			Dialogue			Unspecified
 MRK	7	19	Jesus			Dialogue			StartOfVerse
 MRK	7	19	narrator-MRK			Quotation			Unspecified
 MRK	7	20	Jesus	instructing		Dialogue			EndOfVerse
-MRK	7	21	Jesus	instructing		Implicit			EntireVerse
-MRK	7	22	Jesus	instructing		Implicit			EntireVerse
+MRK	7	21	Jesus	instructing		Normal			EntireVerse
+MRK	7	22	Jesus	instructing		Normal			EntireVerse
 MRK	7	23	Jesus	instructing		Normal			StartOfVerse
 MRK	7	24	Jesus			Rare			
 MRK	7	24	Needs Review			Potential			
@@ -17271,8 +17267,8 @@ MRK	7	34	narrator-MRK			Quotation			Unspecified
 MRK	7	36	Jesus	warning		Indirect			
 MRK	7	36	people of Decapolis			Indirect			
 MRK	7	37	people of Decapolis			Normal			EndOfVerse
-MRK	8	2	Jesus			Implicit			EntireVerse
-MRK	8	3	Jesus			Implicit			EntireVerse
+MRK	8	2	Jesus			Dialogue			EntireVerse
+MRK	8	3	Jesus			Normal			EntireVerse
 MRK	8	4	disciples	questioning		Dialogue			EndOfVerse
 MRK	8	5	disciples			Dialogue			Unspecified
 MRK	8	5	Jesus	questioning		Dialogue			Unspecified
@@ -17283,7 +17279,7 @@ MRK	8	12	Jesus	exasperated		Normal			EndOfVerse
 MRK	8	15	Jesus	warning		Dialogue			Unspecified
 MRK	8	16	disciples	defensive		Normal			Unspecified
 MRK	8	17	Jesus	rebuking		Dialogue			EndOfVerse
-MRK	8	18	Jesus	rebuking		Implicit			EntireVerse
+MRK	8	18	Jesus	rebuking		Normal			EntireVerse
 MRK	8	19	Jesus	rebuking		Normal			
 MRK	8	19	disciples	hesitant		Dialogue			Unspecified
 MRK	8	20	disciples			Dialogue			Unspecified
@@ -17302,10 +17298,10 @@ MRK	8	31	Jesus	instructing		Indirect
 MRK	8	32	Peter (Simon)			Indirect			
 MRK	8	33	Jesus	rebuking		Dialogue			Unspecified
 MRK	8	34	Jesus			Dialogue			Unspecified
-MRK	8	35	Jesus			Implicit			EntireVerse
-MRK	8	36	Jesus			Implicit			EntireVerse
-MRK	8	37	Jesus			Implicit			EntireVerse
-MRK	8	38	Jesus			Implicit			EntireVerse
+MRK	8	35	Jesus			Dialogue			EntireVerse
+MRK	8	36	Jesus			Dialogue			EntireVerse
+MRK	8	37	Jesus			Dialogue			EntireVerse
+MRK	8	38	Jesus			Dialogue			EntireVerse
 MRK	9	1	Jesus			Dialogue			Unspecified
 MRK	9	5	Peter (Simon)	afraid		Dialogue			EndOfVerse
 MRK	9	7	God		voice from cloud (God)	Normal			EndOfVerse
@@ -17318,12 +17314,12 @@ MRK	9	13	Jesus			Dialogue			StartOfVerse
 MRK	9	15	people, all the			Indirect			
 MRK	9	16	Jesus	questioning		Dialogue			Unspecified
 MRK	9	17	father of demon-possessed boy		man in crowd (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	Unspecified
-MRK	9	18	father of demon-possessed boy		man in crowd (father of demon-possessed boy)	Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
+MRK	9	18	father of demon-possessed boy		man in crowd (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
 MRK	9	19	Jesus	exasperated		Dialogue			Unspecified
 MRK	9	19	Jesus	giving orders		Dialogue			Unspecified
 MRK	9	21	Jesus	questioning		Dialogue			Unspecified
 MRK	9	21	father of demon-possessed boy	distraught		Dialogue			Unspecified
-MRK	9	22	father of demon-possessed boy	distraught		Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
+MRK	9	22	father of demon-possessed boy	distraught		Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
 MRK	9	23	Jesus			Dialogue			Unspecified
 MRK	9	24	father of demon-possessed boy			Dialogue			Unspecified
 MRK	9	25	Jesus	giving orders		Dialogue			Unspecified
@@ -17337,45 +17333,45 @@ MRK	9	35	Jesus	instructing		Normal			EndOfVerse
 MRK	9	37	Jesus	instructing		Normal			StartOfVerse
 MRK	9	38	John		John (disciple whom Jesus loved)	Dialogue			Unspecified
 MRK	9	39	Jesus			Dialogue			Unspecified
-MRK	9	40	Jesus			Implicit			EntireVerse
+MRK	9	40	Jesus			Normal			EntireVerse
 MRK	9	41	Jesus			Normal			StartOfVerse
-MRK	9	42	Jesus			Implicit			EntireVerse
-MRK	9	43	Jesus			Implicit			EntireVerse
-MRK	9	44	Jesus			Implicit			EntireVerse
-MRK	9	45	Jesus			Implicit			EntireVerse
-MRK	9	46	Jesus			Implicit			EntireVerse
-MRK	9	47	Jesus			Implicit			EntireVerse
-MRK	9	48	Jesus			Implicit			EntireVerse
-MRK	9	49	Jesus			Implicit			EntireVerse
-MRK	9	50	Jesus			Implicit			EntireVerse
+MRK	9	42	Jesus			Normal			EntireVerse
+MRK	9	43	Jesus			Normal			EntireVerse
+MRK	9	44	Jesus			Normal			EntireVerse
+MRK	9	45	Jesus			Normal			EntireVerse
+MRK	9	46	Jesus			Normal			EntireVerse
+MRK	9	47	Jesus			Normal			EntireVerse
+MRK	9	48	Jesus			Normal			EntireVerse
+MRK	9	49	Jesus			Normal			EntireVerse
+MRK	9	50	Jesus			Normal			EntireVerse
 MRK	10	2	Pharisees, some	questioning		Normal		MAT 19.3;MRK 10.2	Unspecified
 MRK	10	3	Jesus	questioning		Dialogue			Unspecified
 MRK	10	4	Pharisees, some			Dialogue		MAT 19.7;MRK 10.4	Unspecified
 MRK	10	5	Jesus			Dialogue			Unspecified
-MRK	10	6	Jesus			Implicit			EntireVerse
-MRK	10	7	Jesus			Implicit			EntireVerse
-MRK	10	8	Jesus			Implicit			EntireVerse
-MRK	10	9	Jesus			Implicit			EntireVerse
+MRK	10	6	Jesus			Normal			EntireVerse
+MRK	10	7	Jesus			Normal			EntireVerse
+MRK	10	8	Jesus			Normal			EntireVerse
+MRK	10	9	Jesus			Normal			EntireVerse
 MRK	10	10	disciples			Indirect			
 MRK	10	11	Jesus			Dialogue			Unspecified
 MRK	10	12	Jesus			Normal			StartOfVerse
 MRK	10	13	disciples	rebuking		Indirect		MAT 19.13;MRK 10.13;LUK 18.15	
 MRK	10	14	Jesus			Normal			EndOfVerse
-MRK	10	15	Jesus			Implicit			EntireVerse
+MRK	10	15	Jesus			Normal			EntireVerse
 MRK	10	16	Jesus			Indirect			
 MRK	10	17	rich young ruler	respectful	man	Dialogue		MAT 19.16;MRK 10.17;LUK 18.18	Unspecified
 MRK	10	18	Jesus			Dialogue			Unspecified
-MRK	10	19	Jesus			Implicit			EntireVerse
+MRK	10	19	Jesus			Normal			EntireVerse
 MRK	10	20	rich young ruler	upset	man	Dialogue		MAT 19.20;MRK 10.20;LUK 18.21	Unspecified
 MRK	10	21	Jesus			Dialogue			EndOfVerse
 MRK	10	23	Jesus			Dialogue			EndOfVerse
 MRK	10	24	Jesus			Dialogue			Unspecified
-MRK	10	25	Jesus			Implicit			EntireVerse
+MRK	10	25	Jesus			Normal			EntireVerse
 MRK	10	26	disciples	shocked		Normal		MAT 19.25;MRK 10.26;LUK 18.26	EndOfVerse
 MRK	10	27	Jesus			Dialogue			Unspecified
 MRK	10	28	Peter (Simon)			Dialogue			Unspecified
 MRK	10	29	Jesus			Dialogue			Unspecified
-MRK	10	30	Jesus			Implicit			EntireVerse
+MRK	10	30	Jesus			Normal			EntireVerse
 MRK	10	31	Jesus			Normal			StartOfVerse
 MRK	10	32	disciples	amazed and afraid		Rare			
 MRK	10	32	Jesus			Rare			
@@ -17388,10 +17384,10 @@ MRK	10	37	James, the disciple/John	boldly	James/John (sons of Zebedee)	Dialogue	
 MRK	10	38	Jesus			Dialogue			Unspecified
 MRK	10	39	Jesus			Dialogue			Unspecified
 MRK	10	39	James, the disciple/John	boldly	James/John (sons of Zebedee)	Dialogue	John		Unspecified
-MRK	10	40	Jesus			Implicit			EntireVerse
+MRK	10	40	Jesus			Normal			EntireVerse
 MRK	10	42	Jesus			Dialogue			EndOfVerse
-MRK	10	43	Jesus			Implicit			EntireVerse
-MRK	10	44	Jesus			Implicit			EntireVerse
+MRK	10	43	Jesus			Normal			EntireVerse
+MRK	10	44	Jesus			Normal			EntireVerse
 MRK	10	45	Jesus			Normal			StartOfVerse
 MRK	10	46	narrator-MRK			Quotation			Unspecified
 MRK	10	46	Bartimaeus (a blind man)	begging		Indirect		MRK 10.46;LUK 18.35	
@@ -17405,25 +17401,25 @@ MRK	10	51	Bartimaeus (a blind man)	pleading		Dialogue		MAT 20.33;MRK 10.51;LUK 1
 MRK	10	51	Jesus			Dialogue			Unspecified
 MRK	10	52	Jesus			Dialogue			Unspecified
 MRK	11	2	Jesus			Normal			EndOfVerse
-MRK	11	3	Jesus			Implicit			EntireVerse
+MRK	11	3	Jesus			Normal			EntireVerse
 MRK	11	5	owners of colt	suspicious	people standing there	Normal		MRK 11.5;LUK 19.33	Unspecified
 MRK	11	6	disciples		disciples, two of His	Indirect			
 MRK	11	6	people			Indirect			
 MRK	11	9	crowd preparing for Passover Feast	praising	crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EndOfVerse
-MRK	11	10	crowd preparing for Passover Feast	praising	crowd	Implicit		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EntireVerse
+MRK	11	10	crowd preparing for Passover Feast	praising	crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EntireVerse
 MRK	11	13	Jesus			Rare			
 MRK	11	13	Needs Review			Potential			
 MRK	11	14	Jesus			Normal			Unspecified
 MRK	11	17	Jesus			Normal			EndOfVerse
 MRK	11	21	Peter (Simon)	amazed		Dialogue			EndOfVerse
 MRK	11	22	Jesus			Dialogue			Unspecified
-MRK	11	23	Jesus			Implicit			EntireVerse
-MRK	11	24	Jesus			Implicit			EntireVerse
+MRK	11	23	Jesus			Normal			EntireVerse
+MRK	11	24	Jesus			Normal			EntireVerse
 MRK	11	25	Jesus			Normal			StartOfVerse
 MRK	11	26	Jesus			Normal			Unspecified
 MRK	11	28	chief priests/teachers of religious law/elders	challenging		Dialogue		MAT 21.23;MRK 11.28;LUK 20.2	Unspecified
 MRK	11	29	Jesus			Dialogue			Unspecified
-MRK	11	30	Jesus			Implicit			EntireVerse
+MRK	11	30	Jesus			Dialogue			EntireVerse
 MRK	11	31	chief priests/teachers of religious law/elders	to themselves		Normal		MAT 21.25;MRK 11.31;LUK 20.5	Unspecified
 MRK	11	32	chief priests/teachers of religious law/elders	to themselves		Normal		MAT 21.26;MRK 11.32;LUK 20.6	Unspecified
 MRK	11	33	chief priests/teachers of religious law/elders			Dialogue		MAT 21.27;MRK 11.33;LUK 20.7	Unspecified
@@ -17435,10 +17431,10 @@ MRK	12	4	Jesus	preaching		Normal			Unspecified
 MRK	12	5	Jesus	preaching		Normal			Unspecified
 MRK	12	6	Jesus	preaching		Normal			Unspecified
 MRK	12	7	Jesus	preaching		Normal			Unspecified
-MRK	12	8	Jesus	preaching		Implicit			EntireVerse
+MRK	12	8	Jesus	preaching		Normal			EntireVerse
 MRK	12	9	Jesus	preaching		Normal			Unspecified
-MRK	12	10	Jesus	preaching		Implicit			EntireVerse
-MRK	12	11	Jesus	preaching		Implicit			EntireVerse
+MRK	12	10	Jesus	preaching		Normal			EntireVerse
+MRK	12	11	Jesus	preaching		Normal			EntireVerse
 MRK	12	12	chief priests/teachers of religious law/elders			Rare			
 MRK	12	12	Needs Review			Potential			
 MRK	12	14	spies (from Pharisees and Herodians)		Pharisees/Herodians	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EndOfVerse
@@ -17450,30 +17446,30 @@ MRK	12	17	Jesus			Dialogue			Unspecified
 MRK	12	17	spies (from Pharisees and Herodians)		Pharisees/Herodians	Rare		MAT 22.22;MRK 12.17;LUK 20.26	
 MRK	12	17	Needs Review			Rare			
 MRK	12	18	Sadducees			Hypothetical			Unspecified
-MRK	12	19	Sadducees			Implicit			EntireVerse
-MRK	12	20	Sadducees			Implicit			EntireVerse
-MRK	12	21	Sadducees			Implicit			EntireVerse
-MRK	12	22	Sadducees			Implicit			EntireVerse
-MRK	12	23	Sadducees			Implicit			EntireVerse
+MRK	12	19	Sadducees			Dialogue			EntireVerse
+MRK	12	20	Sadducees			Normal			EntireVerse
+MRK	12	21	Sadducees			Normal			EntireVerse
+MRK	12	22	Sadducees			Normal			EntireVerse
+MRK	12	23	Sadducees			Normal			EntireVerse
 MRK	12	24	Jesus			Dialogue			Unspecified
 MRK	12	25	Jesus			Normal			Unspecified
 MRK	12	26	Jesus			Normal			Unspecified
 MRK	12	27	Jesus			Normal			StartOfVerse
 MRK	12	28	expert in religious law	respectful		Dialogue	Good Priest		EndOfVerse
 MRK	12	29	Jesus			Dialogue			Unspecified
-MRK	12	30	Jesus			Implicit			EntireVerse
-MRK	12	31	Jesus			Implicit			EntireVerse
+MRK	12	30	Jesus			Normal			EntireVerse
+MRK	12	31	Jesus			Normal			EntireVerse
 MRK	12	32	expert in religious law	approving		Dialogue	Good Priest		Unspecified
-MRK	12	33	expert in religious law			Implicit	Good Priest		EntireVerse
+MRK	12	33	expert in religious law			Normal	Good Priest		EntireVerse
 MRK	12	34	Jesus			Dialogue			ContainedWithinVerse
 MRK	12	35	Jesus			Dialogue			EndOfVerse
-MRK	12	36	Jesus			Implicit			EntireVerse
+MRK	12	36	Jesus			Normal			EntireVerse
 MRK	12	37	Jesus			Normal			StartOfVerse
 MRK	12	38	Jesus			Normal			EndOfVerse
-MRK	12	39	Jesus			Implicit			EntireVerse
+MRK	12	39	Jesus			Normal			EntireVerse
 MRK	12	40	Jesus			Normal			StartOfVerse
 MRK	12	43	Jesus			Normal			EndOfVerse
-MRK	12	44	Jesus			Implicit			EntireVerse
+MRK	12	44	Jesus			Normal			EntireVerse
 MRK	13	1	disciples	awe	disciples, one of His	Dialogue			EndOfVerse
 MRK	13	2	Jesus			Dialogue			Unspecified
 MRK	13	4	Peter (Simon)/James, the disciple/John/Andrew		Peter/James/John/Andrew	Dialogue	Peter (Simon)	MAT 24.3;MRK 13.4;LUK 21.7	Unspecified
@@ -17495,36 +17491,36 @@ MRK	13	18	Jesus			Normal			Unspecified
 MRK	13	19	Jesus			Normal			Unspecified
 MRK	13	20	Jesus			Normal			Unspecified
 MRK	13	21	Jesus			Normal			Unspecified
-MRK	13	22	Jesus			Implicit			EntireVerse
+MRK	13	22	Jesus			Normal			EntireVerse
 MRK	13	23	Jesus			Normal			Unspecified
-MRK	13	24	Jesus			Implicit			EntireVerse
-MRK	13	25	Jesus			Implicit			EntireVerse
-MRK	13	26	Jesus			Implicit			EntireVerse
+MRK	13	24	Jesus			Normal			EntireVerse
+MRK	13	25	Jesus			Normal			EntireVerse
+MRK	13	26	Jesus			Normal			EntireVerse
 MRK	13	27	Jesus			Normal			Unspecified
-MRK	13	28	Jesus			Implicit			EntireVerse
-MRK	13	29	Jesus			Implicit			EntireVerse
-MRK	13	30	Jesus			Implicit			EntireVerse
+MRK	13	28	Jesus			Normal			EntireVerse
+MRK	13	29	Jesus			Normal			EntireVerse
+MRK	13	30	Jesus			Normal			EntireVerse
 MRK	13	31	Jesus			Normal			StartOfVerse
-MRK	13	32	Jesus			Implicit			EntireVerse
-MRK	13	33	Jesus			Implicit			EntireVerse
-MRK	13	34	Jesus			Implicit			EntireVerse
-MRK	13	35	Jesus			Implicit			EntireVerse
-MRK	13	36	Jesus			Implicit			EntireVerse
-MRK	13	37	Jesus			Implicit			EntireVerse
+MRK	13	32	Jesus			Normal			EntireVerse
+MRK	13	33	Jesus			Normal			EntireVerse
+MRK	13	34	Jesus			Normal			EntireVerse
+MRK	13	35	Jesus			Normal			EntireVerse
+MRK	13	36	Jesus			Normal			EntireVerse
+MRK	13	37	Jesus			Normal			EntireVerse
 MRK	14	2	chief priests/teachers of religious law/elders		chief priests/teachers of the law	Normal		MAT 26.5;MRK 14.2	Unspecified
 # Judas Iscariot was the main spokesman, if the accounts in Matthew 26 and Mark 14 are held to be the same as the one in John 12.								
 MRK	14	4	disciples	scolding	some in home of Simon the leper	Dialogue	Judas Iscariot	MAT 26.8-9;MRK 14.4-5;JHN 12.5	EndOfVerse
 MRK	14	5	disciples	scolding	some in home of Simon the leper	Normal	Judas Iscariot	MAT 26.8-9;MRK 14.4-5;JHN 12.5	StartOfVerse
 MRK	14	6	Jesus			Dialogue			Unspecified
-MRK	14	7	Jesus			Implicit			EntireVerse
-MRK	14	8	Jesus			Implicit			EntireVerse
+MRK	14	7	Jesus			Normal			EntireVerse
+MRK	14	8	Jesus			Normal			EntireVerse
 MRK	14	9	Jesus			Normal			Unspecified
 MRK	14	10	Judas Iscariot			Indirect			
 MRK	14	11	chief priests			Indirect			
 MRK	14	12	Peter (Simon)/John		Jesus' disciples	Dialogue	John	MAT 26.17;MRK 14.12;LUK 22.9	EndOfVerse
 MRK	14	13	Jesus			Dialogue			EndOfVerse
-MRK	14	14	Jesus			Implicit			EntireVerse
-MRK	14	15	Jesus			Implicit			EntireVerse
+MRK	14	14	Jesus			Dialogue			EntireVerse
+MRK	14	15	Jesus			Dialogue			EntireVerse
 MRK	14	18	Jesus			Dialogue		MAT 26.21;MRK 14.18	EndOfVerse
 MRK	14	19	disciples	sad		Dialogue		MAT 26.22;MRK 14.19;LUK 22.23	EndOfVerse
 MRK	14	20	Jesus			Dialogue		MAT 26.23;MRK 14.20	Unspecified
@@ -17534,7 +17530,7 @@ MRK	14	23	Jesus			Indirect
 MRK	14	24	Jesus			Dialogue			Unspecified
 MRK	14	25	Jesus			Normal			Unspecified
 MRK	14	27	Jesus			Dialogue			Unspecified
-MRK	14	28	Jesus			Implicit			EntireVerse
+MRK	14	28	Jesus			Normal			EntireVerse
 MRK	14	29	Peter (Simon)	declare		Dialogue			Unspecified
 MRK	14	30	Jesus			Dialogue			Unspecified
 MRK	14	31	Peter (Simon)	passionate		Dialogue			Unspecified
@@ -17544,7 +17540,7 @@ MRK	14	34	Jesus	deeply distressed		Dialogue			Unspecified
 MRK	14	35	Jesus			Indirect			
 MRK	14	36	Jesus			Normal			EndOfVerse
 MRK	14	37	Jesus			Normal			Unspecified
-MRK	14	38	Jesus			Implicit			EntireVerse
+MRK	14	38	Jesus			Normal			EntireVerse
 MRK	14	41	Jesus			Normal			EndOfVerse
 MRK	14	42	Jesus			Normal			StartOfVerse
 MRK	14	43	Jesus			Rare			
@@ -17552,12 +17548,12 @@ MRK	14	43	Needs Review			Potential
 MRK	14	44	Judas Iscariot	plotting		Normal			EndOfVerse
 MRK	14	45	Judas Iscariot	fake respect		Dialogue			ContainedWithinVerse
 MRK	14	48	Jesus	questioning		Dialogue			Unspecified
-MRK	14	49	Jesus			Implicit			EntireVerse
+MRK	14	49	Jesus			Normal			EntireVerse
 MRK	14	55	chief priests/Sanhedrin			Rare		MAT 26.59; MRK 14.55	
 MRK	14	55	Needs Review			Potential			
 MRK	14	56	false witnesses, many			Rare			
 MRK	14	56	Needs Review			Potential			
-MRK	14	58	witnesses, false	mocking		Implicit		MAT 26.61;MRK 14.58	EntireVerse
+MRK	14	58	witnesses, false	mocking		Dialogue		MAT 26.61;MRK 14.58	EntireVerse
 MRK	14	60	Caiaphas, the high priest	demanding		Dialogue			EndOfVerse
 MRK	14	61	Caiaphas, the high priest	demanding		Dialogue			Unspecified
 MRK	14	62	Jesus			Dialogue			Unspecified
@@ -17599,7 +17595,7 @@ MRK	15	26	narrator-MRK			Quotation			Unspecified
 MRK	15	26	sign on the cross			Quotation	narrator-MRK		Unspecified
 MRK	15	28	scripture			Quotation			Unspecified
 MRK	15	29	passers by	insulting		Dialogue			Unspecified
-MRK	15	30	passers by	insulting		Implicit			EntireVerse
+MRK	15	30	passers by	insulting		Normal			EntireVerse
 MRK	15	31	chief priests/teachers of religious law/elders	sneering		Dialogue		MAT 27.42;MRK 15.31-32;LUK 23.35	Unspecified
 MRK	15	32	chief priests/teachers of religious law/elders	sneering		Normal		MAT 27.42;MRK 15.31-32;LUK 23.35	StartOfVerse
 MRK	15	34	Jesus			Normal			
@@ -17614,7 +17610,7 @@ MRK	15	45	centurion summoned by Pilate			Indirect
 MRK	15	45	Pilate			Indirect			
 MRK	16	3	Mary Magdalene/Mary mother of James/Salome			Normal	Mary Magdalene		EndOfVerse
 MRK	16	6	angels in white, two		young man in white robe (angel)	Dialogue		MAT 28.5-6;MRK 16.6;LUK 24.6	Unspecified
-MRK	16	7	angels in white, two		young man in white robe (angel)	Implicit		MAT 28.7;MRK 16.7	EntireVerse
+MRK	16	7	angels in white, two		young man in white robe (angel)	Dialogue		MAT 28.7;MRK 16.7	EntireVerse
 MRK	16	10	Mary Magdalene			Indirect			
 MRK	16	11	Mary Magdalene			Indirect			
 MRK	16	11	disciples		those who had been with him	Indirect			
@@ -17626,13 +17622,13 @@ MRK	16	18	Jesus			Potential
 MRK	16	20	disciples			Rare			
 MRK	16	20	Needs Review			Potential			
 LUK	1	13	Gabriel		angel of the Lord	Dialogue			EndOfVerse
-LUK	1	14	Gabriel		angel of the Lord	Implicit			EntireVerse
-LUK	1	15	Gabriel		angel of the Lord	Implicit			EntireVerse
-LUK	1	16	Gabriel		angel of the Lord	Implicit			EntireVerse
-LUK	1	17	Gabriel		angel of the Lord	Implicit			EntireVerse
+LUK	1	14	Gabriel		angel of the Lord	Normal			EntireVerse
+LUK	1	15	Gabriel		angel of the Lord	Normal			EntireVerse
+LUK	1	16	Gabriel		angel of the Lord	Normal			EntireVerse
+LUK	1	17	Gabriel		angel of the Lord	Normal			EntireVerse
 LUK	1	18	Zacharias (Zechariah)			Dialogue			Unspecified
 LUK	1	19	Gabriel		Gabriel (angel)	Dialogue			Unspecified
-LUK	1	20	Gabriel		Gabriel (angel)	Implicit			EntireVerse
+LUK	1	20	Gabriel		Gabriel (angel)	Normal			EntireVerse
 LUK	1	21	people	wondering		Indirect			
 LUK	1	22	people	wondering		Indirect			
 LUK	1	25	Elizabeth			Normal			StartOfVerse
@@ -17641,18 +17637,18 @@ LUK	1	26	narrator-LUK			Quotation			Unspecified
 LUK	1	28	Gabriel		Gabriel (angel)	Dialogue			EndOfVerse
 LUK	1	29	Mary, Jesus' mother	confused		Indirect			
 LUK	1	30	Gabriel		Gabriel (angel)	Dialogue			Unspecified
-LUK	1	31	Gabriel		Gabriel (angel)	Implicit			EntireVerse
-LUK	1	32	Gabriel		Gabriel (angel)	Implicit			EntireVerse
-LUK	1	33	Gabriel		Gabriel (angel)	Implicit			EntireVerse
+LUK	1	31	Gabriel		Gabriel (angel)	Normal			EntireVerse
+LUK	1	32	Gabriel		Gabriel (angel)	Normal			EntireVerse
+LUK	1	33	Gabriel		Gabriel (angel)	Normal			EntireVerse
 LUK	1	34	Mary, Jesus' mother			Dialogue			Unspecified
 LUK	1	35	Gabriel		Gabriel (angel)	Dialogue			Unspecified
-LUK	1	36	Gabriel		Gabriel (angel)	Implicit			EntireVerse
-LUK	1	37	Gabriel		Gabriel (angel)	Implicit			EntireVerse
+LUK	1	36	Gabriel		Gabriel (angel)	Normal			EntireVerse
+LUK	1	37	Gabriel		Gabriel (angel)	Normal			EntireVerse
 LUK	1	38	Mary, Jesus' mother			Dialogue			Unspecified
 LUK	1	40	Mary, Jesus' mother			Indirect			
 LUK	1	42	Elizabeth			Dialogue			EndOfVerse
-LUK	1	43	Elizabeth			Implicit			EntireVerse
-LUK	1	44	Elizabeth			Implicit			EntireVerse
+LUK	1	43	Elizabeth			Normal			EntireVerse
+LUK	1	44	Elizabeth			Normal			EntireVerse
 LUK	1	45	Elizabeth			Normal			StartOfVerse
 LUK	1	46	Mary, Jesus' mother			Normal			Unspecified
 LUK	1	47	Mary, Jesus' mother			Normal			Unspecified
@@ -17702,9 +17698,9 @@ LUK	1	78	Zacharias (Zechariah)	praising		Normal			Unspecified
 LUK	1	79	Zacharias (Zechariah)	praising		Normal			Unspecified
 LUK	2	1	Caesar Augustus			Indirect			
 LUK	2	10	angel		angel of the Lord	Normal			EndOfVerse
-LUK	2	11	angel		angel of the Lord	Implicit			EntireVerse
-LUK	2	12	angel		angel of the Lord	Implicit			EntireVerse
-LUK	2	14	great company of heavenly host			Implicit			EntireVerse
+LUK	2	11	angel		angel of the Lord	Normal			EntireVerse
+LUK	2	12	angel		angel of the Lord	Normal			EntireVerse
+LUK	2	14	great company of heavenly host			Normal			EntireVerse
 LUK	2	15	shepherds outside Bethlehem	awe		Normal			EndOfVerse
 LUK	2	17	shepherds outside Bethlehem			Rare			
 LUK	2	17	Needs Review			Potential			
@@ -17732,11 +17728,11 @@ LUK	2	48	Mary, Jesus' mother			Dialogue			Unspecified
 LUK	2	49	Jesus (child)			Dialogue			Unspecified
 LUK	3	3	John the Baptist			Indirect			
 LUK	3	4	scripture			Quotation	Isaiah		EndOfVerse
-LUK	3	5	scripture			Implicit	Isaiah		EntireVerse
-LUK	3	6	scripture			Implicit	Isaiah		EntireVerse
+LUK	3	5	scripture			Quotation	Isaiah		EntireVerse
+LUK	3	6	scripture			Quotation	Isaiah		EntireVerse
 LUK	3	7	John the Baptist			Normal			Unspecified
-LUK	3	8	John the Baptist			Implicit			EntireVerse
-LUK	3	9	John the Baptist			Implicit			EntireVerse
+LUK	3	8	John the Baptist			Normal			EntireVerse
+LUK	3	9	John the Baptist			Normal			EntireVerse
 LUK	3	10	crowd			Dialogue			Unspecified
 LUK	3	11	John the Baptist			Dialogue			Unspecified
 LUK	3	12	tax collectors	calling out		Dialogue			Unspecified
@@ -17745,7 +17741,7 @@ LUK	3	14	John the Baptist			Dialogue			Unspecified
 LUK	3	14	soldiers, some (near Jordan River)	calling out		Dialogue			Unspecified
 LUK	3	15	people near Jordan River			Indirect			
 LUK	3	16	John the Baptist			Normal			Unspecified
-LUK	3	17	John the Baptist			Implicit			EntireVerse
+LUK	3	17	John the Baptist			Normal			EntireVerse
 LUK	3	18	John the Baptist			Indirect			
 LUK	3	19	John the Baptist			Indirect			
 LUK	3	22	God		voice from heaven (God)	Normal			Unspecified
@@ -17755,21 +17751,21 @@ LUK	4	6	Satan (Devil)			Dialogue			Unspecified
 LUK	4	7	Satan (Devil)			Normal			Unspecified
 LUK	4	8	Jesus			Dialogue			Unspecified
 LUK	4	9	Satan (Devil)			Dialogue			EndOfVerse
-LUK	4	10	Satan (Devil)			Implicit			EntireVerse
-LUK	4	11	Satan (Devil)			Implicit			EntireVerse
+LUK	4	10	Satan (Devil)			Normal			EntireVerse
+LUK	4	11	Satan (Devil)			Normal			EntireVerse
 LUK	4	12	Jesus			Dialogue			Unspecified
 LUK	4	18	Jesus	reading		Normal			Unspecified
-LUK	4	19	Jesus	reading		Implicit			EntireVerse
+LUK	4	19	Jesus	reading		Normal			EntireVerse
 LUK	4	21	Jesus			Normal			EndOfVerse
 LUK	4	22	all in Nazareth synagogue	perplexed		Normal			Unspecified
 LUK	4	23	Jesus			Normal			EndOfVerse
 LUK	4	24	Jesus			Normal			Unspecified
-LUK	4	25	Jesus			Implicit			EntireVerse
-LUK	4	26	Jesus			Implicit			EntireVerse
-LUK	4	27	Jesus			Implicit			EntireVerse
+LUK	4	25	Jesus			Normal			EntireVerse
+LUK	4	26	Jesus			Normal			EntireVerse
+LUK	4	27	Jesus			Normal			EntireVerse
 LUK	4	32	men in Capernaum synagogue	amazed		Rare			
 LUK	4	32	Needs Review			Potential			
-LUK	4	34	man possessed by evil spirit			Implicit			EntireVerse
+LUK	4	34	man possessed by evil spirit			Dialogue			EntireVerse
 LUK	4	35	Jesus	giving orders		Dialogue			Unspecified
 LUK	4	36	men in Capernaum synagogue	amazed		Normal			Unspecified
 LUK	4	38	everyone			Indirect			
@@ -17787,7 +17783,7 @@ LUK	5	14	Jesus	forcefully		Dialogue			Unspecified
 LUK	5	20	Jesus			Dialogue			EndOfVerse
 LUK	5	21	teachers of religious law/Pharisees	thinking	Pharisees and the teachers of the law	Normal		MRK 2.7;LUK 5.21	EndOfVerse
 LUK	5	22	Jesus			Dialogue			EndOfVerse
-LUK	5	23	Jesus			Implicit			EntireVerse
+LUK	5	23	Jesus			Normal			EntireVerse
 LUK	5	24	Jesus	giving orders		Dialogue			Unspecified
 LUK	5	26	everyone seeing healing of paralyzed man			Normal			ContainedWithinVerse
 LUK	5	27	Jesus			Dialogue			Unspecified
@@ -17796,14 +17792,14 @@ LUK	5	31	Jesus			Dialogue			Unspecified
 LUK	5	32	Jesus			Normal			StartOfVerse
 LUK	5	33	Pharisees/teachers of religious law			Dialogue			EndOfVerse
 LUK	5	34	Jesus			Dialogue			EndOfVerse
-LUK	5	35	Jesus			Implicit			EntireVerse
+LUK	5	35	Jesus			Normal			EntireVerse
 LUK	5	36	Jesus			Dialogue			Unspecified
 LUK	5	37	Jesus			Normal			Unspecified
 LUK	5	38	Jesus			Normal			Unspecified
 LUK	5	39	Jesus			Normal			Unspecified
 LUK	6	2	Pharisees, some	angry		Dialogue			EndOfVerse
 LUK	6	3	Jesus			Dialogue			EndOfVerse
-LUK	6	4	Jesus			Implicit			EntireVerse
+LUK	6	4	Jesus			Normal			EntireVerse
 LUK	6	5	Jesus			Dialogue			Unspecified
 LUK	6	7	Pharisees/teachers of religious law			Indirect			
 LUK	6	8	Jesus	giving orders		Dialogue			Unspecified
@@ -17814,41 +17810,41 @@ LUK	6	13	Jesus			Indirect
 LUK	6	15	narrator-LUK			Quotation			Unspecified
 LUK	6	20	Jesus			Normal			Unspecified
 LUK	6	21	Jesus			Normal			Unspecified
-LUK	6	22	Jesus			Implicit			EntireVerse
+LUK	6	22	Jesus			Normal			EntireVerse
 LUK	6	23	Jesus			Normal			Unspecified
 LUK	6	24	Jesus			Normal			Unspecified
 LUK	6	25	Jesus			Normal			Unspecified
 LUK	6	26	Jesus			Normal			StartOfVerse
 LUK	6	27	Jesus			Normal			Unspecified
-LUK	6	28	Jesus			Implicit			EntireVerse
-LUK	6	29	Jesus			Implicit			EntireVerse
-LUK	6	30	Jesus			Implicit			EntireVerse
-LUK	6	31	Jesus			Implicit			EntireVerse
-LUK	6	32	Jesus			Implicit			EntireVerse
-LUK	6	33	Jesus			Implicit			EntireVerse
-LUK	6	34	Jesus			Implicit			EntireVerse
-LUK	6	35	Jesus			Implicit			EntireVerse
+LUK	6	28	Jesus			Normal			EntireVerse
+LUK	6	29	Jesus			Normal			EntireVerse
+LUK	6	30	Jesus			Normal			EntireVerse
+LUK	6	31	Jesus			Normal			EntireVerse
+LUK	6	32	Jesus			Normal			EntireVerse
+LUK	6	33	Jesus			Normal			EntireVerse
+LUK	6	34	Jesus			Normal			EntireVerse
+LUK	6	35	Jesus			Normal			EntireVerse
 LUK	6	36	Jesus			Normal			StartOfVerse
 LUK	6	37	Jesus			Normal			Unspecified
-LUK	6	38	Jesus			Implicit			EntireVerse
+LUK	6	38	Jesus			Normal			EntireVerse
 LUK	6	39	Jesus			Normal			Unspecified
 LUK	6	40	Jesus			Normal			Unspecified
 LUK	6	41	Jesus			Normal			Unspecified
 LUK	6	42	Jesus			Normal			Unspecified
-LUK	6	43	Jesus			Implicit			EntireVerse
-LUK	6	44	Jesus			Implicit			EntireVerse
+LUK	6	43	Jesus			Normal			EntireVerse
+LUK	6	44	Jesus			Normal			EntireVerse
 LUK	6	45	Jesus			Normal			StartOfVerse
-LUK	6	46	Jesus			Implicit			EntireVerse
-LUK	6	47	Jesus			Implicit			EntireVerse
-LUK	6	48	Jesus			Implicit			EntireVerse
-LUK	6	49	Jesus			Implicit			EntireVerse
+LUK	6	46	Jesus			Normal			EntireVerse
+LUK	6	47	Jesus			Normal			EntireVerse
+LUK	6	48	Jesus			Normal			EntireVerse
+LUK	6	49	Jesus			Normal			EntireVerse
 LUK	7	3	centurion with great faith			Indirect			
 LUK	7	3	elders of the Jews	interceding		Indirect	Good Priest		
 LUK	7	4	elders of the Jews	interceding		Dialogue	Good Priest		EndOfVerse
-LUK	7	5	elders of the Jews	interceding		Implicit	Good Priest		EntireVerse
+LUK	7	5	elders of the Jews	interceding		Dialogue	Good Priest		EntireVerse
 LUK	7	6	centurion with great faith	polite		Normal		MAT 8.8-9;LUK 7.6-8	EndOfVerse
-LUK	7	7	centurion with great faith	polite		Implicit		MAT 8.8-9;LUK 7.6-8	EntireVerse
-LUK	7	8	centurion with great faith	polite		Implicit		MAT 8.8-9;LUK 7.6-8	EntireVerse
+LUK	7	7	centurion with great faith	polite		Normal		MAT 8.8-9;LUK 7.6-8	EntireVerse
+LUK	7	8	centurion with great faith	polite		Normal		MAT 8.8-9;LUK 7.6-8	EntireVerse
 LUK	7	9	Jesus			Dialogue			EndOfVerse
 LUK	7	13	Jesus	compassionately		Dialogue			EndOfVerse
 LUK	7	14	Jesus	giving orders		Dialogue			EndOfVerse
@@ -17858,7 +17854,7 @@ LUK	7	18	disciples of John the Baptist			Potential		MAT 11.2;LUK 7.18
 LUK	7	19	John the Baptist	discouraged		Normal			Unspecified
 LUK	7	20	disciples of John the Baptist	puzzled	John's disciples, two	Dialogue		MAT 11.3;LUK 7.20	EndOfVerse
 LUK	7	22	Jesus			Dialogue			EndOfVerse
-LUK	7	23	Jesus			Implicit			EntireVerse
+LUK	7	23	Jesus			Normal			EntireVerse
 LUK	7	24	Jesus			Normal			Unspecified
 LUK	7	25	Jesus			Normal			Unspecified
 LUK	7	26	Jesus			Normal			Unspecified
@@ -17866,7 +17862,7 @@ LUK	7	27	Jesus			Normal			Unspecified
 LUK	7	28	Jesus			Normal			Unspecified
 LUK	7	29	people, all the			Indirect			
 LUK	7	31	Jesus			Normal			Unspecified
-LUK	7	32	Jesus			Implicit			EntireVerse
+LUK	7	32	Jesus			Normal			EntireVerse
 LUK	7	33	Jesus			Normal			Unspecified
 LUK	7	34	Jesus			Normal			Unspecified
 LUK	7	35	Jesus			Normal			Unspecified
@@ -17877,29 +17873,29 @@ LUK	7	39	Pharisee (Simon)	judgmental		Normal			EndOfVerse
 LUK	7	40	Jesus			Dialogue			Unspecified
 LUK	7	40	Pharisee (Simon)			Dialogue			Unspecified
 LUK	7	41	Jesus			Dialogue			Unspecified
-LUK	7	42	Jesus			Implicit			EntireVerse
+LUK	7	42	Jesus			Normal			EntireVerse
 LUK	7	43	Jesus			Dialogue			Unspecified
 LUK	7	43	Pharisee (Simon)			Dialogue			Unspecified
 LUK	7	44	Jesus			Dialogue			EndOfVerse
-LUK	7	45	Jesus			Implicit			EntireVerse
-LUK	7	46	Jesus			Implicit			EntireVerse
-LUK	7	47	Jesus			Implicit			EntireVerse
+LUK	7	45	Jesus			Normal			EntireVerse
+LUK	7	46	Jesus			Normal			EntireVerse
+LUK	7	47	Jesus			Normal			EntireVerse
 LUK	7	48	Jesus			Dialogue			EndOfVerse
 LUK	7	49	other guests at Pharisee (Simon)'s house	unhappy		Normal			Unspecified
 LUK	7	50	Jesus			Dialogue			Unspecified
-LUK	8	5	Jesus			Implicit			EntireVerse
-LUK	8	6	Jesus			Implicit			EntireVerse
-LUK	8	7	Jesus			Implicit			EntireVerse
+LUK	8	5	Jesus			Normal			EntireVerse
+LUK	8	6	Jesus			Normal			EntireVerse
+LUK	8	7	Jesus			Normal			EntireVerse
 LUK	8	8	Jesus			Normal			Unspecified
 LUK	8	9	disciples			Indirect			
 LUK	8	10	Jesus			Normal			Unspecified
-LUK	8	11	Jesus			Implicit			EntireVerse
-LUK	8	12	Jesus			Implicit			EntireVerse
-LUK	8	13	Jesus			Implicit			EntireVerse
-LUK	8	14	Jesus			Implicit			EntireVerse
+LUK	8	11	Jesus			Normal			EntireVerse
+LUK	8	12	Jesus			Normal			EntireVerse
+LUK	8	13	Jesus			Normal			EntireVerse
+LUK	8	14	Jesus			Normal			EntireVerse
 LUK	8	15	Jesus			Normal			StartOfVerse
-LUK	8	16	Jesus			Implicit			EntireVerse
-LUK	8	17	Jesus			Implicit			EntireVerse
+LUK	8	16	Jesus			Normal			EntireVerse
+LUK	8	17	Jesus			Normal			EntireVerse
 LUK	8	18	Jesus			Normal			StartOfVerse
 LUK	8	20	crowd		someone	Dialogue		MAT 12.47;MRK 3.32;LUK 8.20	Unspecified
 LUK	8	21	Jesus			Dialogue			ContainedWithinVerse
@@ -17938,8 +17934,8 @@ LUK	8	54	Jesus	giving orders		Dialogue			EndOfVerse
 LUK	8	55	Jesus			Indirect		MRK 5.43; LUK 8.55	
 LUK	8	56	Jesus	warning		Indirect		MRK 5.43; LUK 8.56	
 LUK	9	3	Jesus	instructing		Dialogue			Unspecified
-LUK	9	4	Jesus	instructing		Implicit			EntireVerse
-LUK	9	5	Jesus	instructing		Implicit			EntireVerse
+LUK	9	4	Jesus	instructing		Dialogue			EntireVerse
+LUK	9	5	Jesus	instructing		Dialogue			EntireVerse
 LUK	9	7	people			Indirect			
 LUK	9	8	people, other			Indirect			
 LUK	9	8	people, still others			Indirect			
@@ -17963,20 +17959,20 @@ LUK	9	20	Peter (Simon)	declare		Dialogue			Unspecified
 LUK	9	21	Jesus	warning		Indirect			
 LUK	9	22	Jesus			Dialogue			Unspecified
 LUK	9	23	Jesus			Normal			EndOfVerse
-LUK	9	24	Jesus			Implicit			EntireVerse
-LUK	9	25	Jesus			Implicit			EntireVerse
-LUK	9	26	Jesus			Implicit			EntireVerse
+LUK	9	24	Jesus			Normal			EntireVerse
+LUK	9	25	Jesus			Normal			EntireVerse
+LUK	9	26	Jesus			Normal			EntireVerse
 LUK	9	27	Jesus			Normal			StartOfVerse
 LUK	9	33	Peter (Simon)	afraid		Dialogue			Unspecified
 LUK	9	35	God		voice from cloud (God)	Normal			EndOfVerse
 LUK	9	38	father of demon-possessed boy	distraught	man in crowd (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EndOfVerse
-LUK	9	39	father of demon-possessed boy	distraught	man in crowd (father of demon-possessed boy)	Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
-LUK	9	40	father of demon-possessed boy	distraught	man in crowd (father of demon-possessed boy)	Implicit		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
+LUK	9	39	father of demon-possessed boy	distraught	man in crowd (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
+LUK	9	40	father of demon-possessed boy	distraught	man in crowd (father of demon-possessed boy)	Dialogue		MAT 17.15-16;MRK 9.17-18,22;LUK 9.38-40	EntireVerse
 LUK	9	41	Jesus	exasperated		Dialogue			Unspecified
 LUK	9	41	Jesus	giving orders		Dialogue			Unspecified
 LUK	9	42	Jesus	rebuking		Indirect			
 LUK	9	43	everyone who witnessed healing of boy	praising		Indirect			
-LUK	9	44	Jesus			Implicit			EntireVerse
+LUK	9	44	Jesus			Dialogue			EntireVerse
 LUK	9	46	disciples	arguing		Indirect		MAT 18.1;MRK 9.34;LUK 9.46	
 LUK	9	48	Jesus			Dialogue			Unspecified
 LUK	9	49	John		John (disciple whom Jesus loved)	Dialogue			Unspecified
@@ -18005,7 +18001,7 @@ LUK	10	7	Jesus			Normal			Unspecified
 LUK	10	8	Jesus			Normal			Unspecified
 LUK	10	9	Jesus			Normal			Unspecified
 LUK	10	10	Jesus			Normal			Unspecified
-LUK	10	11	Jesus			Implicit			EntireVerse
+LUK	10	11	Jesus			Normal			EntireVerse
 LUK	10	12	Jesus			Normal			Unspecified
 LUK	10	13	Jesus	rebuking		Normal			Unspecified
 LUK	10	14	Jesus	rebuking		Normal			Unspecified
@@ -18013,10 +18009,10 @@ LUK	10	15	Jesus	rebuking		Normal			Unspecified
 LUK	10	16	Jesus			Normal			Unspecified
 LUK	10	17	seventy-two	excited		Dialogue			EndOfVerse
 LUK	10	18	Jesus			Dialogue			Unspecified
-LUK	10	19	Jesus			Implicit			EntireVerse
+LUK	10	19	Jesus			Normal			EntireVerse
 LUK	10	20	Jesus			Normal			Unspecified
 LUK	10	21	Jesus			Normal			Unspecified
-LUK	10	22	Jesus			Implicit			EntireVerse
+LUK	10	22	Jesus			Normal			EntireVerse
 LUK	10	23	Jesus			Normal			EndOfVerse
 LUK	10	24	Jesus			Normal			StartOfVerse
 LUK	10	25	expert in religious law	testing		Dialogue	Good Priest		Unspecified
@@ -18037,19 +18033,19 @@ LUK	10	38	Martha			Rare
 LUK	10	38	Needs Review			Potential			
 LUK	10	40	Martha			Dialogue			EndOfVerse
 LUK	10	41	Jesus	compassionately		Dialogue			Unspecified
-LUK	10	42	Jesus	compassionately		Implicit			EntireVerse
+LUK	10	42	Jesus	compassionately		Normal			EntireVerse
 LUK	11	1	disciples		disciples, one of His	Dialogue			EndOfVerse
 LUK	11	2	Jesus	instructing		Dialogue			EndOfVerse
-LUK	11	3	Jesus	instructing		Implicit			EntireVerse
+LUK	11	3	Jesus	instructing		Normal			EntireVerse
 LUK	11	4	Jesus	instructing		Normal			Unspecified
 LUK	11	5	Jesus			Dialogue			Unspecified
-LUK	11	6	Jesus			Implicit			EntireVerse
+LUK	11	6	Jesus			Normal			EntireVerse
 LUK	11	7	Jesus			Normal			Unspecified
-LUK	11	8	Jesus			Implicit			EntireVerse
-LUK	11	9	Jesus			Implicit			EntireVerse
-LUK	11	10	Jesus			Implicit			EntireVerse
-LUK	11	11	Jesus			Implicit			EntireVerse
-LUK	11	12	Jesus			Implicit			EntireVerse
+LUK	11	8	Jesus			Normal			EntireVerse
+LUK	11	9	Jesus			Normal			EntireVerse
+LUK	11	10	Jesus			Normal			EntireVerse
+LUK	11	11	Jesus			Normal			EntireVerse
+LUK	11	12	Jesus			Normal			EntireVerse
 LUK	11	13	Jesus			Normal			StartOfVerse
 LUK	11	14	Jesus			Rare			
 LUK	11	14	formerly mute demon-possessed man			Rare			
@@ -18065,51 +18061,51 @@ LUK	11	21	Jesus			Normal			Unspecified
 LUK	11	22	Jesus			Normal			Unspecified
 LUK	11	23	Jesus			Normal			Unspecified
 LUK	11	24	Jesus			Normal			Unspecified
-LUK	11	25	Jesus			Implicit			EntireVerse
+LUK	11	25	Jesus			Normal			EntireVerse
 LUK	11	26	Jesus			Normal			Unspecified
 LUK	11	27	woman in crowd	praising		Dialogue			EndOfVerse
 LUK	11	28	Jesus			Dialogue			Unspecified
 LUK	11	29	Jesus			Normal			EndOfVerse
-LUK	11	30	Jesus			Implicit			EntireVerse
-LUK	11	31	Jesus			Implicit			EntireVerse
+LUK	11	30	Jesus			Normal			EntireVerse
+LUK	11	31	Jesus			Normal			EntireVerse
 LUK	11	32	Jesus			Normal			StartOfVerse
-LUK	11	33	Jesus			Implicit			EntireVerse
-LUK	11	34	Jesus			Implicit			EntireVerse
-LUK	11	35	Jesus			Implicit			EntireVerse
+LUK	11	33	Jesus			Normal			EntireVerse
+LUK	11	34	Jesus			Normal			EntireVerse
+LUK	11	35	Jesus			Normal			EntireVerse
 LUK	11	36	Jesus			Normal			StartOfVerse
 LUK	11	37	Pharisees, other		Pharisee	Indirect			
 LUK	11	38	Pharisees, other		Pharisee	Rare			
 LUK	11	38	Needs Review			Potential			
 LUK	11	39	Jesus			Dialogue			Unspecified
-LUK	11	40	Jesus			Implicit			EntireVerse
-LUK	11	41	Jesus			Implicit			EntireVerse
-LUK	11	42	Jesus	rebuking		Implicit			EntireVerse
-LUK	11	43	Jesus	rebuking		Implicit			EntireVerse
-LUK	11	44	Jesus	rebuking		Implicit			EntireVerse
+LUK	11	40	Jesus			Normal			EntireVerse
+LUK	11	41	Jesus			Normal			EntireVerse
+LUK	11	42	Jesus	rebuking		Normal			EntireVerse
+LUK	11	43	Jesus	rebuking		Normal			EntireVerse
+LUK	11	44	Jesus	rebuking		Normal			EntireVerse
 LUK	11	45	experts in religious law, one of the	insulted		Dialogue			EndOfVerse
 LUK	11	46	Jesus	rebuking		Dialogue			Unspecified
 LUK	11	47	Jesus	rebuking		Dialogue			Unspecified
 LUK	11	48	Jesus	rebuking		Dialogue			Unspecified
 LUK	11	49	Jesus	rebuking		Dialogue			Unspecified
-LUK	11	50	Jesus	rebuking		Implicit			EntireVerse
-LUK	11	51	Jesus	rebuking		Implicit			EntireVerse
-LUK	11	52	Jesus	rebuking		Implicit			EntireVerse
+LUK	11	50	Jesus	rebuking		Dialogue			EntireVerse
+LUK	11	51	Jesus	rebuking		Dialogue			EntireVerse
+LUK	11	52	Jesus	rebuking		Dialogue			EntireVerse
 LUK	11	53	Jesus			Rare			
 LUK	11	53	scribes/Pharisees			Rare			
 LUK	11	53	Needs Review			Potential			
 LUK	11	54	scribes/Pharisees			Rare			
 LUK	11	54	Needs Review			Potential			
 LUK	12	1	Jesus			Normal			EndOfVerse
-LUK	12	2	Jesus			Implicit			EntireVerse
+LUK	12	2	Jesus			Normal			EntireVerse
 LUK	12	3	Jesus			Normal			Unspecified
-LUK	12	4	Jesus			Implicit			EntireVerse
-LUK	12	5	Jesus			Implicit			EntireVerse
-LUK	12	6	Jesus			Implicit			EntireVerse
+LUK	12	4	Jesus			Normal			EntireVerse
+LUK	12	5	Jesus			Normal			EntireVerse
+LUK	12	6	Jesus			Normal			EntireVerse
 LUK	12	7	Jesus			Normal			Unspecified
-LUK	12	8	Jesus			Implicit			EntireVerse
-LUK	12	9	Jesus			Implicit			EntireVerse
-LUK	12	10	Jesus			Implicit			EntireVerse
-LUK	12	11	Jesus			Implicit			EntireVerse
+LUK	12	8	Jesus			Normal			EntireVerse
+LUK	12	9	Jesus			Normal			EntireVerse
+LUK	12	10	Jesus			Normal			EntireVerse
+LUK	12	11	Jesus			Normal			EntireVerse
 LUK	12	12	Jesus			Normal			StartOfVerse
 LUK	12	13	someone in crowd			Dialogue			EndOfVerse
 LUK	12	14	Jesus	questioning		Dialogue			Unspecified
@@ -18117,51 +18113,51 @@ LUK	12	15	Jesus	warning		Dialogue			Unspecified
 LUK	12	16	Jesus			Normal			Unspecified
 LUK	12	17	Jesus			Normal			Unspecified
 LUK	12	18	Jesus			Normal			Unspecified
-LUK	12	19	Jesus			Implicit			EntireVerse
+LUK	12	19	Jesus			Normal			EntireVerse
 LUK	12	20	Jesus			Normal			Unspecified
 LUK	12	21	Jesus			Normal			StartOfVerse
 LUK	12	22	Jesus			Normal			EndOfVerse
-LUK	12	23	Jesus			Implicit			EntireVerse
-LUK	12	24	Jesus			Implicit			EntireVerse
-LUK	12	25	Jesus			Implicit			EntireVerse
-LUK	12	26	Jesus			Implicit			EntireVerse
-LUK	12	27	Jesus			Implicit			EntireVerse
-LUK	12	28	Jesus			Implicit			EntireVerse
-LUK	12	29	Jesus			Implicit			EntireVerse
-LUK	12	30	Jesus			Implicit			EntireVerse
+LUK	12	23	Jesus			Normal			EntireVerse
+LUK	12	24	Jesus			Normal			EntireVerse
+LUK	12	25	Jesus			Normal			EntireVerse
+LUK	12	26	Jesus			Normal			EntireVerse
+LUK	12	27	Jesus			Normal			EntireVerse
+LUK	12	28	Jesus			Normal			EntireVerse
+LUK	12	29	Jesus			Normal			EntireVerse
+LUK	12	30	Jesus			Normal			EntireVerse
 LUK	12	31	Jesus			Normal			Unspecified
-LUK	12	32	Jesus			Implicit			EntireVerse
-LUK	12	33	Jesus			Implicit			EntireVerse
+LUK	12	32	Jesus			Normal			EntireVerse
+LUK	12	33	Jesus			Normal			EntireVerse
 LUK	12	34	Jesus			Normal			StartOfVerse
-LUK	12	35	Jesus			Implicit			EntireVerse
-LUK	12	36	Jesus			Implicit			EntireVerse
-LUK	12	37	Jesus			Implicit			EntireVerse
-LUK	12	38	Jesus			Implicit			EntireVerse
-LUK	12	39	Jesus			Implicit			EntireVerse
-LUK	12	40	Jesus			Implicit			EntireVerse
+LUK	12	35	Jesus			Normal			EntireVerse
+LUK	12	36	Jesus			Normal			EntireVerse
+LUK	12	37	Jesus			Normal			EntireVerse
+LUK	12	38	Jesus			Normal			EntireVerse
+LUK	12	39	Jesus			Normal			EntireVerse
+LUK	12	40	Jesus			Normal			EntireVerse
 LUK	12	41	Peter (Simon)			Dialogue			Unspecified
 LUK	12	42	Jesus			Normal			EndOfVerse
-LUK	12	43	Jesus			Implicit			EntireVerse
-LUK	12	44	Jesus			Implicit			EntireVerse
-LUK	12	45	Jesus			Implicit			EntireVerse
-LUK	12	46	Jesus			Implicit			EntireVerse
-LUK	12	47	Jesus			Implicit			EntireVerse
+LUK	12	43	Jesus			Normal			EntireVerse
+LUK	12	44	Jesus			Normal			EntireVerse
+LUK	12	45	Jesus			Normal			EntireVerse
+LUK	12	46	Jesus			Normal			EntireVerse
+LUK	12	47	Jesus			Normal			EntireVerse
 LUK	12	48	Jesus			Normal			StartOfVerse
-LUK	12	49	Jesus			Implicit			EntireVerse
-LUK	12	50	Jesus			Implicit			EntireVerse
-LUK	12	51	Jesus			Implicit			EntireVerse
-LUK	12	52	Jesus			Implicit			EntireVerse
+LUK	12	49	Jesus			Normal			EntireVerse
+LUK	12	50	Jesus			Normal			EntireVerse
+LUK	12	51	Jesus			Normal			EntireVerse
+LUK	12	52	Jesus			Normal			EntireVerse
 LUK	12	53	Jesus			Normal			StartOfVerse
 LUK	12	54	Jesus			Normal			Unspecified
 LUK	12	55	Jesus			Normal			Unspecified
 LUK	12	56	Jesus			Normal			Unspecified
-LUK	12	57	Jesus			Implicit			EntireVerse
-LUK	12	58	Jesus			Implicit			EntireVerse
-LUK	12	59	Jesus			Implicit			EntireVerse
+LUK	12	57	Jesus			Normal			EntireVerse
+LUK	12	58	Jesus			Normal			EntireVerse
+LUK	12	59	Jesus			Normal			EntireVerse
 LUK	13	1	people, some			Indirect			
 LUK	13	2	Jesus			Normal			EndOfVerse
-LUK	13	3	Jesus			Implicit			EntireVerse
-LUK	13	4	Jesus			Implicit			EntireVerse
+LUK	13	3	Jesus			Normal			EntireVerse
+LUK	13	4	Jesus			Normal			EntireVerse
 LUK	13	5	Jesus			Normal			Unspecified
 LUK	13	6	Jesus			Normal			Unspecified
 LUK	13	7	Jesus			Normal			Unspecified
@@ -18171,9 +18167,9 @@ LUK	13	12	Jesus			Dialogue			EndOfVerse
 LUK	13	13	woman who could not straighten up			Indirect			
 LUK	13	14	synagogue ruler	angry		Dialogue			EndOfVerse
 LUK	13	15	Jesus			Dialogue			Unspecified
-LUK	13	16	Jesus			Implicit			EntireVerse
+LUK	13	16	Jesus			Normal			EntireVerse
 LUK	13	18	Jesus			Normal			Unspecified
-LUK	13	19	Jesus			Implicit			EntireVerse
+LUK	13	19	Jesus			Normal			EntireVerse
 LUK	13	20	Jesus			Normal			EndOfVerse
 LUK	13	21	Jesus			Normal			StartOfVerse
 LUK	13	23	someone	questioning		Dialogue			Unspecified
@@ -18181,14 +18177,14 @@ LUK	13	24	Jesus			Dialogue			Unspecified
 LUK	13	25	Jesus			Normal			Unspecified
 LUK	13	26	Jesus			Normal			Unspecified
 LUK	13	27	Jesus			Normal			Unspecified
-LUK	13	28	Jesus			Implicit			EntireVerse
-LUK	13	29	Jesus			Implicit			EntireVerse
+LUK	13	28	Jesus			Normal			EntireVerse
+LUK	13	29	Jesus			Normal			EntireVerse
 LUK	13	30	Jesus			Normal			StartOfVerse
 LUK	13	31	Pharisee (expert in religious law)	warning		Dialogue	Good Priest		EndOfVerse
 LUK	13	32	Jesus			Dialogue			EndOfVerse
 LUK	13	33	Jesus			Normal			Unspecified
-LUK	13	34	Jesus			Implicit			EntireVerse
-LUK	13	35	Jesus			Implicit			EntireVerse
+LUK	13	34	Jesus			Normal			EntireVerse
+LUK	13	35	Jesus			Normal			EntireVerse
 LUK	14	3	Jesus	questioning		Dialogue			EndOfVerse
 LUK	14	4	Jesus			Indirect			
 LUK	14	5	Jesus	questioning		Dialogue			EndOfVerse
@@ -18197,7 +18193,7 @@ LUK	14	9	Jesus			Normal			Unspecified
 LUK	14	10	Jesus			Normal			Unspecified
 LUK	14	11	Jesus			Normal			Unspecified
 LUK	14	12	Jesus			Dialogue			EndOfVerse
-LUK	14	13	Jesus			Implicit			EntireVerse
+LUK	14	13	Jesus			Normal			EntireVerse
 LUK	14	14	Jesus			Normal			Unspecified
 LUK	14	15	one at table of Pharisee (expert in religious law)			Dialogue			EndOfVerse
 LUK	14	16	Jesus			Dialogue			Unspecified
@@ -18214,11 +18210,11 @@ LUK	14	27	Jesus			Normal			Unspecified
 LUK	14	28	Jesus			Normal			Unspecified
 LUK	14	29	Jesus			Normal			Unspecified
 LUK	14	30	Jesus			Normal			Unspecified
-LUK	14	31	Jesus			Implicit			EntireVerse
-LUK	14	32	Jesus			Implicit			EntireVerse
+LUK	14	31	Jesus			Normal			EntireVerse
+LUK	14	32	Jesus			Normal			EntireVerse
 LUK	14	33	Jesus			Normal			Unspecified
-LUK	14	34	Jesus			Implicit			EntireVerse
-LUK	14	35	Jesus			Implicit			EntireVerse
+LUK	14	34	Jesus			Normal			EntireVerse
+LUK	14	35	Jesus			Normal			EntireVerse
 LUK	15	1	narrator-LUK			Quotation			Unspecified
 LUK	15	2	Pharisees/teachers of religious law	complaining		Normal			EndOfVerse
 LUK	15	4	Jesus			Normal			Unspecified
@@ -18235,33 +18231,33 @@ LUK	15	14	Jesus			Normal			Unspecified
 LUK	15	15	Jesus			Normal			Unspecified
 LUK	15	16	Jesus			Normal			Unspecified
 LUK	15	17	Jesus			Normal			Unspecified
-LUK	15	18	Jesus			Implicit			EntireVerse
-LUK	15	19	Jesus			Implicit			EntireVerse
+LUK	15	18	Jesus			Normal			EntireVerse
+LUK	15	19	Jesus			Normal			EntireVerse
 LUK	15	20	Jesus			Normal			Unspecified
 LUK	15	21	Jesus			Normal			Unspecified
 LUK	15	22	Jesus			Normal			Unspecified
-LUK	15	23	Jesus			Implicit			EntireVerse
+LUK	15	23	Jesus			Normal			EntireVerse
 LUK	15	24	Jesus			Normal			Unspecified
 LUK	15	25	Jesus			Normal			Unspecified
 LUK	15	26	Jesus			Normal			Unspecified
 LUK	15	27	Jesus			Normal			Unspecified
 LUK	15	28	Jesus			Normal			Unspecified
 LUK	15	29	Jesus			Normal			Unspecified
-LUK	15	30	Jesus			Implicit			EntireVerse
+LUK	15	30	Jesus			Normal			EntireVerse
 LUK	15	31	Jesus			Normal			Unspecified
-LUK	15	32	Jesus			Implicit			EntireVerse
+LUK	15	32	Jesus			Normal			EntireVerse
 LUK	16	1	Jesus			Normal			Unspecified
 LUK	16	2	Jesus			Normal			Unspecified
 LUK	16	3	Jesus			Normal			Unspecified
-LUK	16	4	Jesus			Implicit			EntireVerse
+LUK	16	4	Jesus			Normal			EntireVerse
 LUK	16	5	Jesus			Normal			Unspecified
 LUK	16	6	Jesus			Normal			Unspecified
 LUK	16	7	Jesus			Normal			Unspecified
-LUK	16	8	Jesus			Implicit			EntireVerse
-LUK	16	9	Jesus			Implicit			EntireVerse
-LUK	16	10	Jesus			Implicit			EntireVerse
-LUK	16	11	Jesus			Implicit			EntireVerse
-LUK	16	12	Jesus			Implicit			EntireVerse
+LUK	16	8	Jesus			Normal			EntireVerse
+LUK	16	9	Jesus			Normal			EntireVerse
+LUK	16	10	Jesus			Normal			EntireVerse
+LUK	16	11	Jesus			Normal			EntireVerse
+LUK	16	12	Jesus			Normal			EntireVerse
 LUK	16	13	Jesus			Normal			Unspecified
 LUK	16	15	Jesus			Normal			Unspecified
 LUK	16	16	Jesus			Normal			Unspecified
@@ -18274,9 +18270,9 @@ LUK	16	22	Jesus			Normal			Unspecified
 LUK	16	23	Jesus			Normal			Unspecified
 LUK	16	24	Jesus			Normal			Unspecified
 LUK	16	25	Jesus			Normal			Unspecified
-LUK	16	26	Jesus			Implicit			EntireVerse
+LUK	16	26	Jesus			Normal			EntireVerse
 LUK	16	27	Jesus			Normal			Unspecified
-LUK	16	28	Jesus			Implicit			EntireVerse
+LUK	16	28	Jesus			Normal			EntireVerse
 LUK	16	29	Jesus			Normal			Unspecified
 LUK	16	30	Jesus			Normal			Unspecified
 LUK	16	31	Jesus			Normal			Unspecified
@@ -18295,25 +18291,25 @@ LUK	17	14	Jesus			Dialogue			ContainedWithinVerse
 LUK	17	15	leper, thankful Samaritan			Indirect			
 LUK	17	16	leper, thankful Samaritan			Indirect			
 LUK	17	17	Jesus			Dialogue			Unspecified
-LUK	17	18	Jesus			Implicit			EntireVerse
+LUK	17	18	Jesus			Normal			EntireVerse
 LUK	17	19	Jesus	giving orders		Dialogue			Unspecified
 LUK	17	20	Jesus			Dialogue			EndOfVerse
 LUK	17	20	Pharisees	questioning		Dialogue			Unspecified
-LUK	17	21	Jesus			Implicit			EntireVerse
+LUK	17	21	Jesus			Normal			EntireVerse
 LUK	17	22	Jesus			Dialogue			Unspecified
 LUK	17	23	Jesus			Normal			Unspecified
-LUK	17	24	Jesus			Implicit			EntireVerse
-LUK	17	25	Jesus			Implicit			EntireVerse
-LUK	17	26	Jesus			Implicit			EntireVerse
-LUK	17	27	Jesus			Implicit			EntireVerse
-LUK	17	28	Jesus			Implicit			EntireVerse
-LUK	17	29	Jesus			Implicit			EntireVerse
-LUK	17	30	Jesus			Implicit			EntireVerse
-LUK	17	31	Jesus			Implicit			EntireVerse
-LUK	17	32	Jesus			Implicit			EntireVerse
-LUK	17	33	Jesus			Implicit			EntireVerse
-LUK	17	34	Jesus			Implicit			EntireVerse
-LUK	17	35	Jesus			Implicit			EntireVerse
+LUK	17	24	Jesus			Normal			EntireVerse
+LUK	17	25	Jesus			Normal			EntireVerse
+LUK	17	26	Jesus			Normal			EntireVerse
+LUK	17	27	Jesus			Normal			EntireVerse
+LUK	17	28	Jesus			Normal			EntireVerse
+LUK	17	29	Jesus			Normal			EntireVerse
+LUK	17	30	Jesus			Normal			EntireVerse
+LUK	17	31	Jesus			Normal			EntireVerse
+LUK	17	32	Jesus			Normal			EntireVerse
+LUK	17	33	Jesus			Normal			EntireVerse
+LUK	17	34	Jesus			Normal			EntireVerse
+LUK	17	35	Jesus			Normal			EntireVerse
 LUK	17	36	Jesus			Potential			
 LUK	17	37	disciples	puzzled		Dialogue			Unspecified
 LUK	17	37	Jesus			Dialogue			Unspecified
@@ -18321,15 +18317,15 @@ LUK	18	1	Jesus			Indirect
 LUK	18	2	Jesus			Normal			Unspecified
 LUK	18	3	Jesus			Normal			Unspecified
 LUK	18	4	Jesus			Normal			Unspecified
-LUK	18	5	Jesus			Implicit			EntireVerse
+LUK	18	5	Jesus			Normal			EntireVerse
 LUK	18	6	Jesus			Normal			EndOfVerse
-LUK	18	7	Jesus			Implicit			EntireVerse
+LUK	18	7	Jesus			Normal			EntireVerse
 LUK	18	8	Jesus			Normal			StartOfVerse
 LUK	18	9	people, self-righteous			Rare			
 LUK	18	9	Needs Review			Potential			
 LUK	18	10	Jesus			Normal			Unspecified
 LUK	18	11	Jesus			Normal			Unspecified
-LUK	18	12	Jesus			Implicit			EntireVerse
+LUK	18	12	Jesus			Normal			EntireVerse
 LUK	18	13	Jesus			Normal			Unspecified
 LUK	18	14	Jesus			Normal			Unspecified
 LUK	18	15	disciples	rebuking		Indirect		MAT 19.13;MRK 10.13;LUK 18.15	
@@ -18337,19 +18333,19 @@ LUK	18	16	Jesus			Normal			EndOfVerse
 LUK	18	17	Jesus			Normal			StartOfVerse
 LUK	18	18	rich young ruler	respectful	ruler	Dialogue		MAT 19.16;MRK 10.17;LUK 18.18	EndOfVerse
 LUK	18	19	Jesus			Dialogue			Unspecified
-LUK	18	20	Jesus			Implicit			EntireVerse
+LUK	18	20	Jesus			Normal			EntireVerse
 LUK	18	21	rich young ruler	upset	ruler	Dialogue		MAT 19.20;MRK 10.20;LUK 18.21	Unspecified
 LUK	18	22	Jesus			Dialogue			EndOfVerse
 LUK	18	24	Jesus			Dialogue			EndOfVerse
-LUK	18	25	Jesus			Implicit			EntireVerse
+LUK	18	25	Jesus			Normal			EntireVerse
 LUK	18	26	disciples	shocked	those who heard	Dialogue		MAT 19.25;MRK 10.26;LUK 18.26	EndOfVerse
 LUK	18	27	Jesus			Dialogue			Unspecified
 LUK	18	28	Peter (Simon)	perplexed		Dialogue			Unspecified
 LUK	18	29	Jesus			Dialogue			Unspecified
 LUK	18	30	Jesus			Normal			StartOfVerse
 LUK	18	31	Jesus			Normal			EndOfVerse
-LUK	18	32	Jesus			Implicit			EntireVerse
-LUK	18	33	Jesus			Implicit			EntireVerse
+LUK	18	32	Jesus			Normal			EntireVerse
+LUK	18	33	Jesus			Normal			EntireVerse
 LUK	18	35	Bartimaeus (a blind man)	begging		Indirect		MRK 10.46;LUK 18.35	
 LUK	18	36	Bartimaeus (a blind man)			Indirect			
 LUK	18	37	crowd at Jericho			Dialogue		MAT 20.30;MRK 10.47;LUK 18.37	Unspecified
@@ -18380,29 +18376,29 @@ LUK	19	17	Jesus			Normal			Unspecified
 LUK	19	18	Jesus			Normal			Unspecified
 LUK	19	19	Jesus			Normal			Unspecified
 LUK	19	20	Jesus			Normal			Unspecified
-LUK	19	21	Jesus			Implicit			EntireVerse
+LUK	19	21	Jesus			Normal			EntireVerse
 LUK	19	22	Jesus			Normal			Unspecified
-LUK	19	23	Jesus			Implicit			EntireVerse
+LUK	19	23	Jesus			Normal			EntireVerse
 LUK	19	24	Jesus			Normal			Unspecified
 LUK	19	25	Jesus			Normal			Unspecified
 LUK	19	26	Jesus			Normal			Unspecified
 LUK	19	27	Jesus			Normal			StartOfVerse
 LUK	19	30	Jesus			Normal			Unspecified
-LUK	19	31	Jesus			Implicit			EntireVerse
+LUK	19	31	Jesus			Normal			EntireVerse
 LUK	19	33	owners of colt	suspicious		Dialogue		MRK 11.5;LUK 19.33	EndOfVerse
 LUK	19	34	disciples		disciples, two of His	Dialogue			Unspecified
 LUK	19	38	crowd preparing for Passover Feast	praising	whole crowd of disciples	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	Unspecified
 LUK	19	39	Pharisees	demanding		Dialogue			EndOfVerse
 LUK	19	40	Jesus			Dialogue			Unspecified
 LUK	19	42	Jesus			Normal			EndOfVerse
-LUK	19	43	Jesus			Implicit			EntireVerse
+LUK	19	43	Jesus			Normal			EntireVerse
 LUK	19	44	Jesus			Normal			Unspecified
 LUK	19	46	Jesus			Dialogue			Unspecified
 LUK	19	47	chief priests/scribes/leaders			Rare			
 LUK	19	47	Needs Review			Potential			
 LUK	20	2	chief priests/teachers of religious law/elders	challenging		Dialogue		MAT 21.23;MRK 11.28;LUK 20.2	Unspecified
 LUK	20	3	Jesus			Dialogue			Unspecified
-LUK	20	4	Jesus			Implicit			EntireVerse
+LUK	20	4	Jesus			Dialogue			EntireVerse
 LUK	20	5	chief priests/teachers of religious law/elders	to themselves		Normal		MAT 21.25;MRK 11.31;LUK 20.5	Unspecified
 LUK	20	6	chief priests/teachers of religious law/elders	to themselves		Normal		MAT 21.26;MRK 11.32;LUK 20.6	Unspecified
 LUK	20	7	chief priests/teachers of religious law/elders			Dialogue		MAT 21.27;MRK 11.33;LUK 20.7	Unspecified
@@ -18421,7 +18417,7 @@ LUK	20	18	Jesus			Normal			Unspecified
 LUK	20	19	chief priests/scribes			Rare			
 LUK	20	19	Needs Review			Potential			
 LUK	20	21	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Dialogue		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	Unspecified
-LUK	20	22	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Implicit		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
+LUK	20	22	spies (from Pharisees and Herodians)		spies (from the teachers of the law and chief priests)	Normal		MAT 22.16-17;MRK 12.14-15;LUK 20.21-22	EntireVerse
 LUK	20	23	Jesus			Indirect			
 LUK	20	24	Jesus			Dialogue			Unspecified
 # The Message has the spies' reply in verse 25 instead of verse 24.								
@@ -18431,23 +18427,23 @@ LUK	20	26	spies (from Pharisees and Herodians)		spies (from the teachers of the 
 LUK	20	26	Needs Review			Potential			
 LUK	20	27	Sadducees			Hypothetical			Unspecified
 LUK	20	28	Sadducees			Dialogue			Unspecified
-LUK	20	29	Sadducees			Implicit			EntireVerse
-LUK	20	30	Sadducees			Implicit			EntireVerse
-LUK	20	31	Sadducees			Implicit			EntireVerse
-LUK	20	32	Sadducees			Implicit			EntireVerse
-LUK	20	33	Sadducees			Implicit			EntireVerse
+LUK	20	29	Sadducees			Normal			EntireVerse
+LUK	20	30	Sadducees			Normal			EntireVerse
+LUK	20	31	Sadducees			Normal			EntireVerse
+LUK	20	32	Sadducees			Normal			EntireVerse
+LUK	20	33	Sadducees			Normal			EntireVerse
 LUK	20	34	Jesus			Dialogue			Unspecified
 LUK	20	35	Jesus			Normal			Unspecified
 LUK	20	36	Jesus			Normal			Unspecified
 LUK	20	37	Jesus			Normal			Unspecified
-LUK	20	38	Jesus			Implicit			EntireVerse
+LUK	20	38	Jesus			Normal			EntireVerse
 LUK	20	39	teachers of religious law	complimenting		Dialogue	Good Priest		EndOfVerse
 LUK	20	41	Jesus			Dialogue			EndOfVerse
-LUK	20	42	Jesus			Implicit			EntireVerse
-LUK	20	43	Jesus			Implicit			EntireVerse
+LUK	20	42	Jesus			Normal			EntireVerse
+LUK	20	43	Jesus			Normal			EntireVerse
 LUK	20	44	Jesus			Normal			Unspecified
-LUK	20	46	Jesus	warning		Implicit			EntireVerse
-LUK	20	47	Jesus	warning		Implicit			EntireVerse
+LUK	20	46	Jesus	warning		Normal			EntireVerse
+LUK	20	47	Jesus	warning		Normal			EntireVerse
 LUK	21	3	Jesus			Dialogue			Unspecified
 LUK	21	4	Jesus			Normal			StartOfVerse
 LUK	21	5	disciples, some			Indirect			
@@ -18456,32 +18452,32 @@ LUK	21	7	Peter (Simon)/James, the disciple/John/Andrew		some of his disciples	Di
 LUK	21	8	Jesus			Normal			Unspecified
 LUK	21	9	Jesus			Normal			Unspecified
 LUK	21	10	Jesus			Normal			Unspecified
-LUK	21	11	Jesus			Implicit			EntireVerse
-LUK	21	12	Jesus			Implicit			EntireVerse
-LUK	21	13	Jesus			Implicit			EntireVerse
-LUK	21	14	Jesus			Implicit			EntireVerse
-LUK	21	15	Jesus			Implicit			EntireVerse
-LUK	21	16	Jesus			Implicit			EntireVerse
-LUK	21	17	Jesus			Implicit			EntireVerse
-LUK	21	18	Jesus			Implicit			EntireVerse
+LUK	21	11	Jesus			Normal			EntireVerse
+LUK	21	12	Jesus			Normal			EntireVerse
+LUK	21	13	Jesus			Normal			EntireVerse
+LUK	21	14	Jesus			Normal			EntireVerse
+LUK	21	15	Jesus			Normal			EntireVerse
+LUK	21	16	Jesus			Normal			EntireVerse
+LUK	21	17	Jesus			Normal			EntireVerse
+LUK	21	18	Jesus			Normal			EntireVerse
 LUK	21	19	Jesus			Normal			Unspecified
-LUK	21	20	Jesus			Implicit			EntireVerse
-LUK	21	21	Jesus			Implicit			EntireVerse
-LUK	21	22	Jesus			Implicit			EntireVerse
-LUK	21	23	Jesus			Implicit			EntireVerse
+LUK	21	20	Jesus			Normal			EntireVerse
+LUK	21	21	Jesus			Normal			EntireVerse
+LUK	21	22	Jesus			Normal			EntireVerse
+LUK	21	23	Jesus			Normal			EntireVerse
 LUK	21	24	Jesus			Normal			Unspecified
-LUK	21	25	Jesus			Implicit			EntireVerse
-LUK	21	26	Jesus			Implicit			EntireVerse
-LUK	21	27	Jesus			Implicit			EntireVerse
+LUK	21	25	Jesus			Normal			EntireVerse
+LUK	21	26	Jesus			Normal			EntireVerse
+LUK	21	27	Jesus			Normal			EntireVerse
 LUK	21	28	Jesus			Normal			Unspecified
 LUK	21	29	Jesus			Normal			EndOfVerse
-LUK	21	30	Jesus			Implicit			EntireVerse
-LUK	21	31	Jesus			Implicit			EntireVerse
-LUK	21	32	Jesus			Implicit			EntireVerse
+LUK	21	30	Jesus			Normal			EntireVerse
+LUK	21	31	Jesus			Normal			EntireVerse
+LUK	21	32	Jesus			Normal			EntireVerse
 LUK	21	33	Jesus			Normal			Unspecified
-LUK	21	34	Jesus			Implicit			EntireVerse
-LUK	21	35	Jesus			Implicit			EntireVerse
-LUK	21	36	Jesus			Implicit			EntireVerse
+LUK	21	34	Jesus			Normal			EntireVerse
+LUK	21	35	Jesus			Normal			EntireVerse
+LUK	21	36	Jesus			Normal			EntireVerse
 LUK	22	4	Judas Iscariot			Indirect			
 LUK	22	5	chief priests/officers of temple guard			Indirect			
 LUK	22	6	Judas Iscariot			Rare			
@@ -18489,32 +18485,32 @@ LUK	22	6	Needs Review			Potential
 LUK	22	8	Jesus	giving orders		Dialogue			EndOfVerse
 LUK	22	9	Peter (Simon)/John			Dialogue	John	MAT 26.17;MRK 14.12;LUK 22.9	Unspecified
 LUK	22	10	Jesus			Dialogue			Unspecified
-LUK	22	11	Jesus			Implicit			EntireVerse
-LUK	22	12	Jesus			Implicit			EntireVerse
+LUK	22	11	Jesus			Normal			EntireVerse
+LUK	22	12	Jesus			Normal			EntireVerse
 LUK	22	15	Jesus			Dialogue			EndOfVerse
-LUK	22	16	Jesus			Implicit			EntireVerse
+LUK	22	16	Jesus			Normal			EntireVerse
 LUK	22	17	Jesus			Dialogue			EndOfVerse
-LUK	22	18	Jesus			Implicit			EntireVerse
+LUK	22	18	Jesus			Normal			EntireVerse
 LUK	22	19	Jesus			Dialogue			EndOfVerse
 LUK	22	20	Jesus			Dialogue			EndOfVerse
-LUK	22	21	Jesus			Implicit			EntireVerse
-LUK	22	22	Jesus			Implicit			EntireVerse
+LUK	22	21	Jesus			Normal			EntireVerse
+LUK	22	22	Jesus			Normal			EntireVerse
 LUK	22	23	disciples			Indirect		MAT 26.22;MRK 14.19;LUK 22.23	
 LUK	22	24	disciples			Indirect			
 LUK	22	25	Jesus			Normal			EndOfVerse
-LUK	22	26	Jesus			Implicit			EntireVerse
-LUK	22	27	Jesus			Implicit			EntireVerse
-LUK	22	28	Jesus			Implicit			EntireVerse
-LUK	22	29	Jesus			Implicit			EntireVerse
+LUK	22	26	Jesus			Normal			EntireVerse
+LUK	22	27	Jesus			Normal			EntireVerse
+LUK	22	28	Jesus			Normal			EntireVerse
+LUK	22	29	Jesus			Normal			EntireVerse
 LUK	22	30	Jesus			Normal			Unspecified
 LUK	22	31	Jesus			Normal			Unspecified
-LUK	22	32	Jesus			Implicit			EntireVerse
+LUK	22	32	Jesus			Normal			EntireVerse
 LUK	22	33	Peter (Simon)	passionate		Dialogue			Unspecified
 LUK	22	34	Jesus			Dialogue			Unspecified
 LUK	22	35	disciples			Dialogue			Unspecified
 LUK	22	35	Jesus			Dialogue			Unspecified
 LUK	22	36	Jesus			Dialogue			Unspecified
-LUK	22	37	Jesus			Implicit			EntireVerse
+LUK	22	37	Jesus			Normal			EntireVerse
 LUK	22	38	disciples	declare		Dialogue			Unspecified
 LUK	22	38	Jesus			Dialogue			Unspecified
 LUK	22	40	Jesus			Normal			EndOfVerse
@@ -18538,8 +18534,8 @@ LUK	22	61	narrator-LUK			Quotation			Unspecified
 LUK	22	64	guards at high priests' house	mocking		Dialogue			EndOfVerse
 LUK	22	67	council of elders/chief priests/teachers of religious law	demanding		Dialogue			Unspecified
 LUK	22	67	Jesus			Dialogue			EndOfVerse
-LUK	22	68	Jesus			Implicit			EntireVerse
-LUK	22	69	Jesus			Implicit			EntireVerse
+LUK	22	68	Jesus			Normal			EntireVerse
+LUK	22	69	Jesus			Normal			EntireVerse
 LUK	22	70	council of elders/chief priests/teachers of religious law	demanding		Dialogue			Unspecified
 LUK	22	70	Jesus			Dialogue			Unspecified
 LUK	22	71	council of elders/chief priests/teachers of religious law	furious		Dialogue			Unspecified
@@ -18561,7 +18557,7 @@ LUK	23	11	Herod Antipas (the tetrarch)/soldiers, Roman			Rare
 LUK	23	11	Needs Review			Potential			
 LUK	23	13	Pilate			Potential			
 LUK	23	14	Pilate	to crowd		Dialogue			EndOfVerse
-LUK	23	15	Pilate	to crowd		Implicit			EntireVerse
+LUK	23	15	Pilate	to crowd		Normal			EntireVerse
 LUK	23	16	Pilate	to crowd		Normal			Unspecified
 LUK	23	18	crowd	shouting	whole crowd	Dialogue			EndOfVerse
 LUK	23	20	Pilate			Indirect			
@@ -18574,7 +18570,7 @@ LUK	23	26	soldiers, Roman			Indirect
 LUK	23	28	Jesus			Dialogue			Unspecified
 LUK	23	29	Jesus			Normal			Unspecified
 LUK	23	30	Jesus			Normal			Unspecified
-LUK	23	31	Jesus			Implicit			EntireVerse
+LUK	23	31	Jesus			Normal			EntireVerse
 LUK	23	33	narrator-LUK			Quotation			Unspecified
 LUK	23	34	Jesus			Normal			Unspecified
 LUK	23	35	chief priests/teachers of religious law/elders	sneering	rulers	Dialogue		MAT 27.42;MRK 15.31-32;LUK 23.35	Unspecified
@@ -18583,7 +18579,7 @@ LUK	23	38	narrator-LUK			Quotation			Unspecified
 LUK	23	38	sign on the cross			Quotation	narrator-LUK		Unspecified
 LUK	23	39	criminal on cross, insulting	insulting		Dialogue		MAT 27.44;LUK 23.39	EndOfVerse
 LUK	23	40	criminal on cross, repentant	rebuking		Dialogue			EndOfVerse
-LUK	23	41	criminal on cross, repentant	rebuking		Implicit			EntireVerse
+LUK	23	41	criminal on cross, repentant	rebuking		Normal			EntireVerse
 LUK	23	42	criminal on cross, repentant	repentant		Dialogue			EndOfVerse
 LUK	23	43	Jesus			Dialogue			Unspecified
 LUK	23	46	Jesus			Dialogue			ContainedWithinVerse
@@ -18606,13 +18602,13 @@ LUK	24	17	Jesus	questioning		Dialogue			Unspecified
 LUK	24	18	Cleopas			Dialogue			EndOfVerse
 LUK	24	19	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Dialogue	Cleopas		EndOfVerse
 LUK	24	19	Jesus			Dialogue			Unspecified
-LUK	24	20	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Implicit	Cleopas		EntireVerse
-LUK	24	21	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Implicit	Cleopas		EntireVerse
-LUK	24	22	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Implicit	Cleopas		EntireVerse
-LUK	24	23	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Implicit	Cleopas		EntireVerse
-LUK	24	24	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Implicit	Cleopas		EntireVerse
+LUK	24	20	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Normal	Cleopas		EntireVerse
+LUK	24	21	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Normal	Cleopas		EntireVerse
+LUK	24	22	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Normal	Cleopas		EntireVerse
+LUK	24	23	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Normal	Cleopas		EntireVerse
+LUK	24	24	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Normal	Cleopas		EntireVerse
 LUK	24	25	Jesus			Dialogue			Unspecified
-LUK	24	26	Jesus			Implicit			EntireVerse
+LUK	24	26	Jesus			Normal			EntireVerse
 LUK	24	29	Cleopas/Cleopas' companion (on road to Emmaus)	urging	Cleopas and his companion (on road to Emmaus)	Dialogue	Cleopas		Unspecified
 LUK	24	29	Jesus			Indirect			
 LUK	24	32	Cleopas/Cleopas' companion (on road to Emmaus)		Cleopas and his companion (on road to Emmaus)	Dialogue	Cleopas' companion (on road to Emmaus)		EndOfVerse
@@ -18622,12 +18618,12 @@ LUK	24	36	Jesus			Dialogue			Unspecified
 LUK	24	37	disciples		the eleven (disciples)	Rare			
 LUK	24	37	Needs Review			Potential			
 LUK	24	38	Jesus			Dialogue			Unspecified
-LUK	24	39	Jesus			Implicit			EntireVerse
+LUK	24	39	Jesus			Normal			EntireVerse
 LUK	24	41	Jesus	questioning		Dialogue			EndOfVerse
 LUK	24	44	Jesus			Dialogue			Unspecified
 LUK	24	46	Jesus			Dialogue			Unspecified
-LUK	24	47	Jesus			Implicit			EntireVerse
-LUK	24	48	Jesus			Implicit			EntireVerse
+LUK	24	47	Jesus			Normal			EntireVerse
+LUK	24	48	Jesus			Normal			EntireVerse
 LUK	24	49	Jesus			Normal			StartOfVerse
 LUK	24	50	Jesus			Indirect			
 JHN	1	15	John the Baptist			Normal			EndOfVerse
@@ -18639,7 +18635,7 @@ JHN	1	22	priests/Levites			Dialogue			Unspecified
 JHN	1	23	John the Baptist			Dialogue			Unspecified
 JHN	1	25	priests/Levites		messengers sent from Pharisees (the Jews)	Dialogue			EndOfVerse
 JHN	1	26	John the Baptist			Dialogue			Unspecified
-JHN	1	27	John the Baptist			Implicit			EntireVerse
+JHN	1	27	John the Baptist			Normal			EntireVerse
 JHN	1	29	John the Baptist			Normal			Unspecified
 JHN	1	30	John the Baptist			Normal			Unspecified
 JHN	1	31	John the Baptist			Normal			Unspecified
@@ -18689,13 +18685,13 @@ JHN	3	2	Nicodemus			Dialogue			Unspecified
 JHN	3	3	Jesus			Dialogue			Unspecified
 JHN	3	4	Nicodemus			Dialogue			Unspecified
 JHN	3	5	Jesus			Dialogue			Unspecified
-JHN	3	6	Jesus			Implicit			EntireVerse
-JHN	3	7	Jesus			Implicit			EntireVerse
-JHN	3	8	Jesus			Implicit			EntireVerse
+JHN	3	6	Jesus			Normal			EntireVerse
+JHN	3	7	Jesus			Normal			EntireVerse
+JHN	3	8	Jesus			Normal			EntireVerse
 JHN	3	9	Nicodemus			Dialogue			Unspecified
 JHN	3	10	Jesus			Normal			Unspecified
-JHN	3	11	Jesus			Implicit			EntireVerse
-JHN	3	12	Jesus			Implicit			EntireVerse
+JHN	3	11	Jesus			Normal			EntireVerse
+JHN	3	12	Jesus			Normal			EntireVerse
 JHN	3	13	Jesus			Normal			Unspecified
 JHN	3	14	Jesus			Potential			
 JHN	3	15	Jesus			Potential			
@@ -18707,9 +18703,9 @@ JHN	3	20	Jesus			Potential
 JHN	3	21	Jesus			Potential			
 JHN	3	26	disciples of John the Baptist/a Jew	concerned		Dialogue			EndOfVerse
 JHN	3	27	John the Baptist			Dialogue			Unspecified
-JHN	3	28	John the Baptist			Implicit			EntireVerse
-JHN	3	29	John the Baptist			Implicit			EntireVerse
-JHN	3	30	John the Baptist			Implicit			EntireVerse
+JHN	3	28	John the Baptist			Normal			EntireVerse
+JHN	3	29	John the Baptist			Normal			EntireVerse
+JHN	3	30	John the Baptist			Normal			EntireVerse
 JHN	3	31	John the Baptist			Potential			
 JHN	3	32	John the Baptist			Potential			
 JHN	3	33	John the Baptist			Potential			
@@ -18721,26 +18717,26 @@ JHN	4	7	Jesus	requesting		Dialogue			EndOfVerse
 JHN	4	9	woman, Samaritan			Dialogue			Unspecified
 JHN	4	10	Jesus			Dialogue			Unspecified
 JHN	4	11	woman, Samaritan			Dialogue			Unspecified
-JHN	4	12	woman, Samaritan			Implicit			EntireVerse
+JHN	4	12	woman, Samaritan			Normal			EntireVerse
 JHN	4	13	Jesus			Dialogue			Unspecified
-JHN	4	14	Jesus			Implicit			EntireVerse
+JHN	4	14	Jesus			Normal			EntireVerse
 JHN	4	15	woman, Samaritan			Dialogue			Unspecified
 JHN	4	16	Jesus			Dialogue			Unspecified
 JHN	4	17	Jesus			Dialogue			Unspecified
 JHN	4	17	woman, Samaritan			Dialogue			Unspecified
 JHN	4	18	Jesus			Normal			Unspecified
 JHN	4	19	woman, Samaritan			Dialogue			Unspecified
-JHN	4	20	woman, Samaritan			Implicit			EntireVerse
+JHN	4	20	woman, Samaritan			Normal			EntireVerse
 JHN	4	21	Jesus			Dialogue			Unspecified
-JHN	4	22	Jesus			Implicit			EntireVerse
-JHN	4	23	Jesus			Implicit			EntireVerse
-JHN	4	24	Jesus			Implicit			EntireVerse
+JHN	4	22	Jesus			Normal			EntireVerse
+JHN	4	23	Jesus			Normal			EntireVerse
+JHN	4	24	Jesus			Normal			EntireVerse
 JHN	4	25	woman, Samaritan			Dialogue			Unspecified
 JHN	4	25	interruption-JHN			Interruption			
 JHN	4	25	Needs Review			Potential			
 JHN	4	26	Jesus			Dialogue			Unspecified
 JHN	4	27	narrator-JHN			Quotation			Unspecified
-JHN	4	29	woman, Samaritan			Implicit			EntireVerse
+JHN	4	29	woman, Samaritan			Dialogue			EntireVerse
 JHN	4	31	disciples			Dialogue			EndOfVerse
 JHN	4	32	Jesus			Dialogue			Unspecified
 JHN	4	33	disciples	puzzled		Normal			Unspecified
@@ -18781,37 +18777,37 @@ JHN	5	18	Jesus			Rare
 JHN	5	18	narrator-JHN			Rare			
 JHN	5	18	Needs Review			Potential			
 JHN	5	19	Jesus			Normal			EndOfVerse
-JHN	5	20	Jesus			Implicit			EntireVerse
-JHN	5	21	Jesus			Implicit			EntireVerse
-JHN	5	22	Jesus			Implicit			EntireVerse
-JHN	5	23	Jesus			Implicit			EntireVerse
-JHN	5	24	Jesus			Implicit			EntireVerse
-JHN	5	25	Jesus			Implicit			EntireVerse
-JHN	5	26	Jesus			Implicit			EntireVerse
-JHN	5	27	Jesus			Implicit			EntireVerse
-JHN	5	28	Jesus			Implicit			EntireVerse
+JHN	5	20	Jesus			Normal			EntireVerse
+JHN	5	21	Jesus			Normal			EntireVerse
+JHN	5	22	Jesus			Normal			EntireVerse
+JHN	5	23	Jesus			Normal			EntireVerse
+JHN	5	24	Jesus			Normal			EntireVerse
+JHN	5	25	Jesus			Normal			EntireVerse
+JHN	5	26	Jesus			Normal			EntireVerse
+JHN	5	27	Jesus			Normal			EntireVerse
+JHN	5	28	Jesus			Normal			EntireVerse
 JHN	5	29	Jesus			Normal			Unspecified
 JHN	5	30	Jesus			Normal			Unspecified
-JHN	5	31	Jesus			Implicit			EntireVerse
-JHN	5	32	Jesus			Implicit			EntireVerse
-JHN	5	33	Jesus			Implicit			EntireVerse
-JHN	5	34	Jesus			Implicit			EntireVerse
-JHN	5	35	Jesus			Implicit			EntireVerse
-JHN	5	36	Jesus			Implicit			EntireVerse
-JHN	5	37	Jesus			Implicit			EntireVerse
-JHN	5	38	Jesus			Implicit			EntireVerse
-JHN	5	39	Jesus			Implicit			EntireVerse
-JHN	5	40	Jesus			Implicit			EntireVerse
-JHN	5	41	Jesus			Implicit			EntireVerse
-JHN	5	42	Jesus			Implicit			EntireVerse
-JHN	5	43	Jesus			Implicit			EntireVerse
-JHN	5	44	Jesus			Implicit			EntireVerse
-JHN	5	45	Jesus			Implicit			EntireVerse
-JHN	5	46	Jesus			Implicit			EntireVerse
-JHN	5	47	Jesus			Implicit			EntireVerse
+JHN	5	31	Jesus			Normal			EntireVerse
+JHN	5	32	Jesus			Normal			EntireVerse
+JHN	5	33	Jesus			Normal			EntireVerse
+JHN	5	34	Jesus			Normal			EntireVerse
+JHN	5	35	Jesus			Normal			EntireVerse
+JHN	5	36	Jesus			Normal			EntireVerse
+JHN	5	37	Jesus			Normal			EntireVerse
+JHN	5	38	Jesus			Normal			EntireVerse
+JHN	5	39	Jesus			Normal			EntireVerse
+JHN	5	40	Jesus			Normal			EntireVerse
+JHN	5	41	Jesus			Normal			EntireVerse
+JHN	5	42	Jesus			Normal			EntireVerse
+JHN	5	43	Jesus			Normal			EntireVerse
+JHN	5	44	Jesus			Normal			EntireVerse
+JHN	5	45	Jesus			Normal			EntireVerse
+JHN	5	46	Jesus			Normal			EntireVerse
+JHN	5	47	Jesus			Normal			EntireVerse
 JHN	6	5	Jesus			Dialogue			EndOfVerse
 JHN	6	7	Philip the apostle		Philip	Dialogue		MRK 6.37;JHN 6.7	Unspecified
-JHN	6	9	Andrew		Andrew, Simon Peter's brother	Implicit		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9	EntireVerse
+JHN	6	9	Andrew		Andrew, Simon Peter's brother	Dialogue		MAT 14.17;MRK 6.38;LUK 9.13;JHN 6.9	EntireVerse
 JHN	6	10	Jesus			Dialogue			Unspecified
 JHN	6	11	Jesus			Indirect			
 JHN	6	12	Jesus			Dialogue			Unspecified
@@ -18825,13 +18821,13 @@ JHN	6	24	crowd			Rare
 JHN	6	24	Needs Review			Potential			
 JHN	6	25	crowd			Dialogue			Unspecified
 JHN	6	26	Jesus			Dialogue			Unspecified
-JHN	6	27	Jesus			Implicit			EntireVerse
+JHN	6	27	Jesus			Normal			EntireVerse
 JHN	6	28	people in crowd by Sea of Galilee			Dialogue			Unspecified
 JHN	6	29	Jesus			Dialogue			Unspecified
 JHN	6	30	people in crowd by Sea of Galilee	superior		Dialogue			Unspecified
-JHN	6	31	people in crowd by Sea of Galilee	superior		Implicit			EntireVerse
+JHN	6	31	people in crowd by Sea of Galilee	superior		Dialogue			EntireVerse
 JHN	6	32	Jesus			Dialogue			Unspecified
-JHN	6	33	Jesus			Implicit			EntireVerse
+JHN	6	33	Jesus			Normal			EntireVerse
 JHN	6	34	people in crowd by Sea of Galilee	polite		Dialogue			Unspecified
 JHN	6	35	Jesus			Dialogue			Unspecified
 JHN	6	36	Jesus			Implicit			
@@ -18866,38 +18862,38 @@ JHN	6	64	Jesus			Normal			StartOfVerse
 JHN	6	65	Jesus			Dialogue			Unspecified
 JHN	6	67	Jesus	questioning		Dialogue			Unspecified
 JHN	6	68	Peter (Simon)			Dialogue			Unspecified
-JHN	6	69	Peter (Simon)			Implicit			EntireVerse
+JHN	6	69	Peter (Simon)			Normal			EntireVerse
 JHN	6	70	Jesus			Dialogue			Unspecified
 JHN	7	3	Jesus' brothers	challenging		Dialogue			EndOfVerse
-JHN	7	4	Jesus' brothers	challenging		Implicit			EntireVerse
+JHN	7	4	Jesus' brothers	challenging		Dialogue			EntireVerse
 JHN	7	6	Jesus			Dialogue			EndOfVerse
-JHN	7	7	Jesus			Implicit			EntireVerse
-JHN	7	8	Jesus			Implicit			EntireVerse
+JHN	7	7	Jesus			Normal			EntireVerse
+JHN	7	8	Jesus			Normal			EntireVerse
 JHN	7	11	Jews, the			Normal			EndOfVerse
 JHN	7	12	crowd at Festival of Tabernacles in Jerusalem, some	praising Jesus		Normal			
 JHN	7	12	crowd at Festival of Tabernacles in Jerusalem, others	against Jesus		Normal			
 JHN	7	15	Jews, the			Normal			EndOfVerse
 JHN	7	16	Jesus			Dialogue			Unspecified
-JHN	7	17	Jesus			Implicit			EntireVerse
-JHN	7	18	Jesus			Implicit			EntireVerse
-JHN	7	19	Jesus			Implicit			EntireVerse
+JHN	7	17	Jesus			Normal			EntireVerse
+JHN	7	18	Jesus			Normal			EntireVerse
+JHN	7	19	Jesus			Normal			EntireVerse
 JHN	7	20	crowd at Festival of Tabernacles in Jerusalem, the	against Jesus		Dialogue			Unspecified
 JHN	7	21	Jesus			Dialogue			Unspecified
-JHN	7	22	Jesus			Implicit			EntireVerse
-JHN	7	23	Jesus			Implicit			EntireVerse
+JHN	7	22	Jesus			Normal			EntireVerse
+JHN	7	23	Jesus			Normal			EntireVerse
 JHN	7	24	Jesus			Normal			Unspecified
 JHN	7	25	people of Jerusalem, some	questioning		Normal			Unspecified
 JHN	7	26	people of Jerusalem, some	arguing		Normal			Unspecified
 JHN	7	27	people of Jerusalem, some	arguing		Normal			Unspecified
 JHN	7	28	Jesus			Dialogue			EndOfVerse
-JHN	7	29	Jesus			Implicit			EntireVerse
+JHN	7	29	Jesus			Normal			EntireVerse
 JHN	7	31	crowd at Festival of Tabernacles in Jerusalem, many in the	defending Jesus		Normal			Unspecified
 JHN	7	33	Jesus			Dialogue			Unspecified
-JHN	7	34	Jesus			Implicit			EntireVerse
+JHN	7	34	Jesus			Normal			EntireVerse
 JHN	7	35	Jews, the			Dialogue			Unspecified
 JHN	7	36	Jews, the			Dialogue			Unspecified
 JHN	7	37	Jesus			Dialogue			EndOfVerse
-JHN	7	38	Jesus			Implicit			EntireVerse
+JHN	7	38	Jesus			Normal			EntireVerse
 JHN	7	40	crowd at Festival of Tabernacles in Jerusalem, some	defending Jesus		Normal			Unspecified
 JHN	7	41	crowd at Festival of Tabernacles in Jerusalem, others			Normal			
 JHN	7	41	crowd at Festival of Tabernacles in Jerusalem, still others			Normal			
@@ -18905,12 +18901,12 @@ JHN	7	42	crowd at Festival of Tabernacles in Jerusalem, still others			Normal			
 JHN	7	45	chief priests/Pharisees			Dialogue			EndOfVerse
 JHN	7	46	temple guards	amazed		Dialogue			Unspecified
 JHN	7	47	Pharisees	angry		Dialogue			Unspecified
-JHN	7	48	Pharisees	angry		Implicit			EntireVerse
-JHN	7	49	Pharisees	angry		Implicit			EntireVerse
-JHN	7	51	Nicodemus			Implicit			EntireVerse
+JHN	7	48	Pharisees	angry		Normal			EntireVerse
+JHN	7	49	Pharisees	angry		Normal			EntireVerse
+JHN	7	51	Nicodemus			Dialogue			EntireVerse
 JHN	7	52	Pharisees	angry		Dialogue			Unspecified
 JHN	8	4	teachers of religious law/Pharisees			Dialogue			EndOfVerse
-JHN	8	5	teachers of religious law/Pharisees			Implicit			EntireVerse
+JHN	8	5	teachers of religious law/Pharisees			Normal			EntireVerse
 JHN	8	7	Jesus			Dialogue			EndOfVerse
 JHN	8	10	Jesus	questioning		Dialogue			EndOfVerse
 JHN	8	11	Jesus			Dialogue			Unspecified
@@ -18918,55 +18914,55 @@ JHN	8	11	woman, caught in adultery			Dialogue			Unspecified
 JHN	8	12	Jesus			Dialogue			EndOfVerse
 JHN	8	13	Pharisees			Dialogue			Unspecified
 JHN	8	14	Jesus			Dialogue			Unspecified
-JHN	8	15	Jesus			Implicit			EntireVerse
-JHN	8	16	Jesus			Implicit			EntireVerse
-JHN	8	17	Jesus			Implicit			EntireVerse
-JHN	8	18	Jesus			Implicit			EntireVerse
+JHN	8	15	Jesus			Normal			EntireVerse
+JHN	8	16	Jesus			Normal			EntireVerse
+JHN	8	17	Jesus			Normal			EntireVerse
+JHN	8	18	Jesus			Normal			EntireVerse
 JHN	8	19	Jesus			Dialogue			Unspecified
 JHN	8	19	Pharisees			Dialogue			Unspecified
 JHN	8	21	Jesus			Dialogue			EndOfVerse
 JHN	8	22	Jews, the			Normal			Unspecified
 JHN	8	23	Jesus			Dialogue			Unspecified
-JHN	8	24	Jesus			Implicit			EntireVerse
+JHN	8	24	Jesus			Normal			EntireVerse
 JHN	8	25	Jesus			Dialogue			Unspecified
 JHN	8	25	Jews, the	impatient		Dialogue			Unspecified
-JHN	8	26	Jesus			Implicit			EntireVerse
+JHN	8	26	Jesus			Normal			EntireVerse
 JHN	8	28	Jesus			Dialogue			EndOfVerse
-JHN	8	29	Jesus			Implicit			EntireVerse
+JHN	8	29	Jesus			Normal			EntireVerse
 JHN	8	31	Jesus			Dialogue			EndOfVerse
-JHN	8	32	Jesus			Implicit			EntireVerse
+JHN	8	32	Jesus			Normal			EntireVerse
 JHN	8	33	Jews who had believed Jesus	superior		Dialogue			Unspecified
 JHN	8	34	Jesus			Dialogue			Unspecified
-JHN	8	35	Jesus			Implicit			EntireVerse
-JHN	8	36	Jesus			Implicit			EntireVerse
-JHN	8	37	Jesus			Implicit			EntireVerse
+JHN	8	35	Jesus			Normal			EntireVerse
+JHN	8	36	Jesus			Normal			EntireVerse
+JHN	8	37	Jesus			Normal			EntireVerse
 JHN	8	38	Jesus			Normal			Unspecified
 JHN	8	39	Jesus			Dialogue			EndOfVerse
 JHN	8	39	Jews who had believed Jesus			Dialogue			Unspecified
-JHN	8	40	Jesus			Implicit			EntireVerse
+JHN	8	40	Jesus			Normal			EntireVerse
 JHN	8	41	Jesus			Normal			
 JHN	8	41	Jews who had believed Jesus			Dialogue			Unspecified
 JHN	8	42	Jesus			Dialogue			Unspecified
-JHN	8	43	Jesus			Implicit			EntireVerse
-JHN	8	44	Jesus			Implicit			EntireVerse
-JHN	8	45	Jesus			Implicit			EntireVerse
-JHN	8	46	Jesus			Implicit			EntireVerse
+JHN	8	43	Jesus			Normal			EntireVerse
+JHN	8	44	Jesus			Normal			EntireVerse
+JHN	8	45	Jesus			Normal			EntireVerse
+JHN	8	46	Jesus			Normal			EntireVerse
 JHN	8	47	Jesus			Normal			StartOfVerse
 JHN	8	48	Jews, the	angry		Dialogue			Unspecified
 JHN	8	49	Jesus			Dialogue			Unspecified
-JHN	8	50	Jesus			Implicit			EntireVerse
-JHN	8	51	Jesus			Implicit			EntireVerse
+JHN	8	50	Jesus			Normal			EntireVerse
+JHN	8	51	Jesus			Normal			EntireVerse
 JHN	8	52	Jews, the	outraged		Dialogue			Unspecified
 JHN	8	53	Jews, the	outraged		Normal			Unspecified
 JHN	8	54	Jesus			Dialogue			Unspecified
-JHN	8	55	Jesus			Implicit			EntireVerse
-JHN	8	56	Jesus			Implicit			EntireVerse
+JHN	8	55	Jesus			Normal			EntireVerse
+JHN	8	56	Jesus			Normal			EntireVerse
 JHN	8	57	Jews, the			Dialogue			Unspecified
 JHN	8	58	Jesus			Dialogue			Unspecified
 JHN	9	2	disciples	accusing		Dialogue			EndOfVerse
 JHN	9	3	Jesus			Dialogue			Unspecified
-JHN	9	4	Jesus			Implicit			EntireVerse
-JHN	9	5	Jesus			Implicit			EntireVerse
+JHN	9	4	Jesus			Normal			EntireVerse
+JHN	9	5	Jesus			Normal			EntireVerse
 JHN	9	7	Jesus	giving orders		Dialogue			Unspecified
 JHN	9	7	narrator-JHN			Quotation			Unspecified
 JHN	9	7	interruption-JHN			Interruption			
@@ -19006,11 +19002,11 @@ JHN	9	25	cured man, blind from birth			Dialogue			Unspecified
 JHN	9	26	Jews, the			Dialogue			Unspecified
 JHN	9	27	cured man, blind from birth			Dialogue			Unspecified
 JHN	9	28	Jews, the	harsh		Dialogue			EndOfVerse
-JHN	9	29	Jews, the	harsh		Implicit			EntireVerse
+JHN	9	29	Jews, the	harsh		Normal			EntireVerse
 JHN	9	30	cured man, blind from birth			Dialogue			Unspecified
-JHN	9	31	cured man, blind from birth			Implicit			EntireVerse
-JHN	9	32	cured man, blind from birth			Implicit			EntireVerse
-JHN	9	33	cured man, blind from birth			Implicit			EntireVerse
+JHN	9	31	cured man, blind from birth			Normal			EntireVerse
+JHN	9	32	cured man, blind from birth			Normal			EntireVerse
+JHN	9	33	cured man, blind from birth			Normal			EntireVerse
 JHN	9	34	Jews, the	harsh		Dialogue			Unspecified
 JHN	9	35	Jesus	questioning		Dialogue			EndOfVerse
 JHN	9	36	cured man, blind from birth			Dialogue			Unspecified
@@ -19020,38 +19016,38 @@ JHN	9	39	Jesus			Dialogue			EndOfVerse
 JHN	9	40	Pharisees, some	challenging		Dialogue			EndOfVerse
 JHN	9	41	Jesus			Dialogue			EndOfVerse
 JHN	10	1	Jesus			Normal			Unspecified
-JHN	10	2	Jesus			Implicit			EntireVerse
-JHN	10	3	Jesus			Implicit			EntireVerse
-JHN	10	4	Jesus			Implicit			EntireVerse
-JHN	10	5	Jesus			Implicit			EntireVerse
+JHN	10	2	Jesus			Normal			EntireVerse
+JHN	10	3	Jesus			Normal			EntireVerse
+JHN	10	4	Jesus			Normal			EntireVerse
+JHN	10	5	Jesus			Normal			EntireVerse
 JHN	10	7	Jesus			Normal			EndOfVerse
-JHN	10	8	Jesus			Implicit			EntireVerse
-JHN	10	9	Jesus			Implicit			EntireVerse
-JHN	10	10	Jesus			Implicit			EntireVerse
-JHN	10	11	Jesus			Implicit			EntireVerse
-JHN	10	12	Jesus			Implicit			EntireVerse
-JHN	10	13	Jesus			Implicit			EntireVerse
-JHN	10	14	Jesus			Implicit			EntireVerse
-JHN	10	15	Jesus			Implicit			EntireVerse
-JHN	10	16	Jesus			Implicit			EntireVerse
-JHN	10	17	Jesus			Implicit			EntireVerse
-JHN	10	18	Jesus			Implicit			EntireVerse
+JHN	10	8	Jesus			Normal			EntireVerse
+JHN	10	9	Jesus			Normal			EntireVerse
+JHN	10	10	Jesus			Normal			EntireVerse
+JHN	10	11	Jesus			Normal			EntireVerse
+JHN	10	12	Jesus			Normal			EntireVerse
+JHN	10	13	Jesus			Normal			EntireVerse
+JHN	10	14	Jesus			Normal			EntireVerse
+JHN	10	15	Jesus			Normal			EntireVerse
+JHN	10	16	Jesus			Normal			EntireVerse
+JHN	10	17	Jesus			Normal			EntireVerse
+JHN	10	18	Jesus			Normal			EntireVerse
 JHN	10	20	Jews, many	contempt		Normal			EndOfVerse
 JHN	10	21	Jews, other			Normal			ContainedWithinVerse
 JHN	10	24	Jews, the			Dialogue			Unspecified
 JHN	10	25	Jesus			Dialogue			Unspecified
-JHN	10	26	Jesus			Implicit			EntireVerse
-JHN	10	27	Jesus			Implicit			EntireVerse
-JHN	10	28	Jesus			Implicit			EntireVerse
-JHN	10	29	Jesus			Implicit			EntireVerse
-JHN	10	30	Jesus			Implicit			EntireVerse
+JHN	10	26	Jesus			Normal			EntireVerse
+JHN	10	27	Jesus			Normal			EntireVerse
+JHN	10	28	Jesus			Normal			EntireVerse
+JHN	10	29	Jesus			Normal			EntireVerse
+JHN	10	30	Jesus			Normal			EntireVerse
 JHN	10	32	Jesus			Dialogue			EndOfVerse
 JHN	10	33	Jews, the			Dialogue			Unspecified
 JHN	10	34	Jesus			Dialogue			Unspecified
-JHN	10	35	Jesus			Implicit			EntireVerse
-JHN	10	36	Jesus			Implicit			EntireVerse
-JHN	10	37	Jesus			Implicit			EntireVerse
-JHN	10	38	Jesus			Implicit			EntireVerse
+JHN	10	35	Jesus			Normal			EntireVerse
+JHN	10	36	Jesus			Normal			EntireVerse
+JHN	10	37	Jesus			Normal			EntireVerse
+JHN	10	38	Jesus			Normal			EntireVerse
 JHN	10	41	people near Jordan River			Normal			Unspecified
 JHN	11	3	Mary, sister of Martha/Martha			Normal			Unspecified
 JHN	11	4	Jesus			Normal			EndOfVerse
@@ -19060,22 +19056,22 @@ JHN	11	6	Needs Review			Potential
 JHN	11	7	Jesus			Dialogue			EndOfVerse
 JHN	11	8	disciples		disciples, Jesus'	Dialogue			Unspecified
 JHN	11	9	Jesus			Dialogue			Unspecified
-JHN	11	10	Jesus			Implicit			EntireVerse
+JHN	11	10	Jesus			Normal			EntireVerse
 JHN	11	11	Jesus			Dialogue			EndOfVerse
 JHN	11	12	disciples	sad		Dialogue			Unspecified
 JHN	11	13	Jesus			Indirect			
 JHN	11	14	Jesus			Dialogue			EndOfVerse
-JHN	11	15	Jesus			Implicit			EntireVerse
+JHN	11	15	Jesus			Normal			EntireVerse
 JHN	11	16	Thomas	resigned		Dialogue			ContainedWithinVerse
 JHN	11	17	person near Lazarus' grave who informed Jesus			Indirect			
 JHN	11	20	report to Martha about Jesus			Rare			
 JHN	11	20	Needs Review			Potential			
 JHN	11	21	Martha			Dialogue			Unspecified
-JHN	11	22	Martha			Implicit			EntireVerse
+JHN	11	22	Martha			Normal			EntireVerse
 JHN	11	23	Jesus	reassuring		Dialogue			Unspecified
 JHN	11	24	Martha			Dialogue			Unspecified
 JHN	11	25	Jesus			Dialogue			EndOfVerse
-JHN	11	26	Jesus			Implicit			EntireVerse
+JHN	11	26	Jesus			Normal			EntireVerse
 JHN	11	27	Martha			Dialogue			Unspecified
 JHN	11	28	Martha			Dialogue			EndOfVerse
 JHN	11	31	Jews who had been with Mary and Martha			Indirect			
@@ -19088,19 +19084,19 @@ JHN	11	39	Jesus			Dialogue			Unspecified
 JHN	11	39	Martha			Dialogue			Unspecified
 JHN	11	40	Jesus			Dialogue			Unspecified
 JHN	11	41	Jesus	praying		Dialogue			EndOfVerse
-JHN	11	42	Jesus	praying		Implicit			EntireVerse
+JHN	11	42	Jesus	praying		Dialogue			EntireVerse
 JHN	11	43	Jesus	giving orders		Dialogue			EndOfVerse
 JHN	11	44	Jesus	giving orders		Dialogue			ContainedWithinVerse
 JHN	11	46	report about Jesus			Rare			
 JHN	11	46	Needs Review			Potential			
 JHN	11	47	chief priests/Pharisees			Dialogue			Unspecified
-JHN	11	48	chief priests/Pharisees			Implicit			EntireVerse
+JHN	11	48	chief priests/Pharisees			Dialogue			EntireVerse
 JHN	11	49	Caiaphas, the high priest	indignant		Dialogue			EndOfVerse
-JHN	11	50	Caiaphas, the high priest	indignant		Implicit			EntireVerse
+JHN	11	50	Caiaphas, the high priest	indignant		Normal			EntireVerse
 JHN	11	51	Caiaphas, the high priest			Indirect			
 JHN	11	56	Jews, the		Jews from the country, many	Normal			EndOfVerse
 JHN	11	57	chief priests/Pharisees			Indirect			
-JHN	12	5	Judas Iscariot	rebuking		Implicit		MAT 26.8-9;MRK 14.4-5;JHN 12.5	EntireVerse
+JHN	12	5	Judas Iscariot	rebuking		Dialogue		MAT 26.8-9;MRK 14.4-5;JHN 12.5	EntireVerse
 JHN	12	7	Jesus			Dialogue			Unspecified
 JHN	12	8	Jesus			Normal			Unspecified
 JHN	12	9	report about Jesus			Rare			
@@ -19110,7 +19106,7 @@ JHN	12	10	chief priests	plotting		Indirect
 JHN	12	12	report about Jesus			Rare			
 JHN	12	12	Needs Review			Potential			
 JHN	12	13	crowd preparing for Passover Feast	praising	great crowd	Dialogue		MAT 21.9;MRK 11.9-10;LUK 19.38;JHN 12.13	EndOfVerse
-JHN	12	15	scripture			Implicit	Zechariah the prophet, son of Berechiah	MAT 21:5; JHN 12:15	EntireVerse
+JHN	12	15	scripture			Quotation	Zechariah the prophet, son of Berechiah	MAT 21:5; JHN 12:15	EntireVerse
 JHN	12	17	Jews who had been with Mary and Martha		multitude that was with Jesus when he raised Lazarus	Rare			
 JHN	12	17	Needs Review			Potential			
 JHN	12	18	report about Jesus			Rare			
@@ -19119,17 +19115,17 @@ JHN	12	18	Needs Review			Potential
 JHN	12	19	teachers of religious law/Pharisees		Pharisees	Normal			ContainedWithinVerse
 JHN	12	21	Greeks	respectful		Dialogue			EndOfVerse
 JHN	12	23	Jesus			Dialogue			Unspecified
-JHN	12	24	Jesus			Implicit			EntireVerse
-JHN	12	25	Jesus			Implicit			EntireVerse
+JHN	12	24	Jesus			Normal			EntireVerse
+JHN	12	25	Jesus			Normal			EntireVerse
 JHN	12	26	Jesus			Normal			Unspecified
-JHN	12	27	Jesus			Implicit			EntireVerse
+JHN	12	27	Jesus			Normal			EntireVerse
 JHN	12	28	Jesus			Normal			
 JHN	12	28	God		voice from heaven (God)	Normal			
 JHN	12	29	crowd preparing for Passover Feast			Indirect			
 JHN	12	29	crowd preparing for Passover Feast, others			Indirect			
 JHN	12	30	Jesus			Dialogue			Unspecified
-JHN	12	31	Jesus			Implicit			EntireVerse
-JHN	12	32	Jesus			Implicit			EntireVerse
+JHN	12	31	Jesus			Normal			EntireVerse
+JHN	12	32	Jesus			Normal			EntireVerse
 JHN	12	33	Jesus			Rare			
 JHN	12	33	narrator-JHN			Rare			
 JHN	12	33	Needs Review			Potential			
@@ -19142,16 +19138,16 @@ JHN	12	38	scripture			Quotation	Isaiah		EndOfVerse
 # PG-1276: A project added in a leading "God says" (the original passage quoted from ISA 6 is God speaking) in v. 39
 JHN	12	39	scripture			Rare	Isaiah		
 JHN	12	39	Needs Review			Potential			
-JHN	12	40	scripture			Implicit	Isaiah		EntireVerse
+JHN	12	40	scripture			Quotation	Isaiah		EntireVerse
 JHN	12	42	leaders, many			Rare			
 JHN	12	42	Needs Review			Potential			
 JHN	12	44	Jesus			Normal			Unspecified
-JHN	12	45	Jesus			Implicit			EntireVerse
-JHN	12	46	Jesus			Implicit			EntireVerse
-JHN	12	47	Jesus			Implicit			EntireVerse
-JHN	12	48	Jesus			Implicit			EntireVerse
-JHN	12	49	Jesus			Implicit			EntireVerse
-JHN	12	50	Jesus			Implicit			EntireVerse
+JHN	12	45	Jesus			Normal			EntireVerse
+JHN	12	46	Jesus			Normal			EntireVerse
+JHN	12	47	Jesus			Normal			EntireVerse
+JHN	12	48	Jesus			Normal			EntireVerse
+JHN	12	49	Jesus			Normal			EntireVerse
+JHN	12	50	Jesus			Normal			EntireVerse
 JHN	13	6	Peter (Simon)			Dialogue			EndOfVerse
 JHN	13	7	Jesus			Dialogue			Unspecified
 JHN	13	8	Jesus			Dialogue			Unspecified
@@ -19167,7 +19163,7 @@ JHN	13	15	Jesus			Normal			Unspecified
 JHN	13	16	Jesus			Normal			Unspecified
 JHN	13	17	Jesus			Normal			Unspecified
 JHN	13	18	Jesus			Normal			Unspecified
-JHN	13	19	Jesus			Implicit			EntireVerse
+JHN	13	19	Jesus			Normal			EntireVerse
 JHN	13	20	Jesus			Normal			Unspecified
 JHN	13	21	Jesus			Dialogue			EndOfVerse
 JHN	13	22	disciples	perplexed		Rare			
@@ -19183,43 +19179,43 @@ JHN	13	29	disciples			Indirect
 JHN	13	31	Jesus			Dialogue			Unspecified
 JHN	13	32	Jesus			Normal			Unspecified
 JHN	13	33	Jesus			Normal			Unspecified
-JHN	13	34	Jesus			Implicit			EntireVerse
+JHN	13	34	Jesus			Normal			EntireVerse
 JHN	13	35	Jesus			Normal			Unspecified
 JHN	13	36	Jesus			Dialogue			Unspecified
 JHN	13	36	Peter (Simon)	puzzled		Dialogue			Unspecified
 JHN	13	37	Peter (Simon)	declare		Dialogue			Unspecified
 JHN	13	38	Jesus			Dialogue			Unspecified
 JHN	14	1	Jesus			Normal			Unspecified
-JHN	14	2	Jesus			Implicit			EntireVerse
-JHN	14	3	Jesus			Implicit			EntireVerse
+JHN	14	2	Jesus			Normal			EntireVerse
+JHN	14	3	Jesus			Normal			EntireVerse
 JHN	14	4	Jesus			Normal			Unspecified
 JHN	14	5	Thomas	frustrated		Dialogue			EndOfVerse
 JHN	14	6	Jesus			Dialogue			Unspecified
-JHN	14	7	Jesus			Implicit			EntireVerse
+JHN	14	7	Jesus			Normal			EntireVerse
 JHN	14	8	Philip the apostle		Philip	Dialogue			Unspecified
 JHN	14	9	Jesus			Normal			Unspecified
-JHN	14	10	Jesus			Implicit			EntireVerse
-JHN	14	11	Jesus			Implicit			EntireVerse
-JHN	14	12	Jesus			Implicit			EntireVerse
-JHN	14	13	Jesus			Implicit			EntireVerse
+JHN	14	10	Jesus			Normal			EntireVerse
+JHN	14	11	Jesus			Normal			EntireVerse
+JHN	14	12	Jesus			Normal			EntireVerse
+JHN	14	13	Jesus			Normal			EntireVerse
 JHN	14	14	Jesus			Normal			StartOfVerse
 JHN	14	15	Jesus			Normal			Unspecified
-JHN	14	16	Jesus			Implicit			EntireVerse
-JHN	14	17	Jesus			Implicit			EntireVerse
-JHN	14	18	Jesus			Implicit			EntireVerse
-JHN	14	19	Jesus			Implicit			EntireVerse
-JHN	14	20	Jesus			Implicit			EntireVerse
-JHN	14	21	Jesus			Implicit			EntireVerse
+JHN	14	16	Jesus			Normal			EntireVerse
+JHN	14	17	Jesus			Normal			EntireVerse
+JHN	14	18	Jesus			Normal			EntireVerse
+JHN	14	19	Jesus			Normal			EntireVerse
+JHN	14	20	Jesus			Normal			EntireVerse
+JHN	14	21	Jesus			Normal			EntireVerse
 JHN	14	22	Judas, apostle (not Judas Iscariot)	puzzled		Dialogue			EndOfVerse
 JHN	14	23	Jesus			Dialogue			EndOfVerse
-JHN	14	24	Jesus			Implicit			EntireVerse
-JHN	14	25	Jesus			Implicit			EntireVerse
-JHN	14	26	Jesus			Implicit			EntireVerse
-JHN	14	27	Jesus			Implicit			EntireVerse
-JHN	14	28	Jesus			Implicit			EntireVerse
-JHN	14	29	Jesus			Implicit			EntireVerse
-JHN	14	30	Jesus			Implicit			EntireVerse
-JHN	14	31	Jesus			Implicit			EntireVerse
+JHN	14	24	Jesus			Normal			EntireVerse
+JHN	14	25	Jesus			Normal			EntireVerse
+JHN	14	26	Jesus			Normal			EntireVerse
+JHN	14	27	Jesus			Normal			EntireVerse
+JHN	14	28	Jesus			Normal			EntireVerse
+JHN	14	29	Jesus			Normal			EntireVerse
+JHN	14	30	Jesus			Normal			EntireVerse
+JHN	14	31	Jesus			Normal			EntireVerse
 JHN	15	1	Jesus			Normal			Unspecified
 JHN	15	2	Jesus			Normal			Unspecified
 JHN	15	3	Jesus			Normal			Unspecified
@@ -19245,67 +19241,67 @@ JHN	15	22	Jesus			Normal			Unspecified
 JHN	15	23	Jesus			Normal			Unspecified
 JHN	15	24	Jesus			Normal			Unspecified
 JHN	15	25	Jesus			Normal			Unspecified
-JHN	15	26	Jesus			Implicit			EntireVerse
-JHN	15	27	Jesus			Implicit			EntireVerse
-JHN	16	1	Jesus			Implicit			EntireVerse
-JHN	16	2	Jesus			Implicit			EntireVerse
-JHN	16	3	Jesus			Implicit			EntireVerse
+JHN	15	26	Jesus			Normal			EntireVerse
+JHN	15	27	Jesus			Normal			EntireVerse
+JHN	16	1	Jesus			Normal			EntireVerse
+JHN	16	2	Jesus			Normal			EntireVerse
+JHN	16	3	Jesus			Normal			EntireVerse
 JHN	16	4	Jesus			Normal			Unspecified
-JHN	16	5	Jesus			Implicit			EntireVerse
-JHN	16	6	Jesus			Implicit			EntireVerse
-JHN	16	7	Jesus			Implicit			EntireVerse
-JHN	16	8	Jesus			Implicit			EntireVerse
-JHN	16	9	Jesus			Implicit			EntireVerse
-JHN	16	10	Jesus			Implicit			EntireVerse
-JHN	16	11	Jesus			Implicit			EntireVerse
-JHN	16	12	Jesus			Implicit			EntireVerse
-JHN	16	13	Jesus			Implicit			EntireVerse
-JHN	16	14	Jesus			Implicit			EntireVerse
+JHN	16	5	Jesus			Normal			EntireVerse
+JHN	16	6	Jesus			Normal			EntireVerse
+JHN	16	7	Jesus			Normal			EntireVerse
+JHN	16	8	Jesus			Normal			EntireVerse
+JHN	16	9	Jesus			Normal			EntireVerse
+JHN	16	10	Jesus			Normal			EntireVerse
+JHN	16	11	Jesus			Normal			EntireVerse
+JHN	16	12	Jesus			Normal			EntireVerse
+JHN	16	13	Jesus			Normal			EntireVerse
+JHN	16	14	Jesus			Normal			EntireVerse
 JHN	16	15	Jesus			Normal			Unspecified
 JHN	16	16	Jesus			Normal			Unspecified
 JHN	16	17	disciples	puzzled	disciples, some of his	Normal			Unspecified
 JHN	16	18	disciples	frustrated	disciples, some of his	Normal	Thomas		Unspecified
 JHN	16	19	Jesus			Dialogue			EndOfVerse
-JHN	16	20	Jesus			Implicit			EntireVerse
-JHN	16	21	Jesus			Implicit			EntireVerse
-JHN	16	22	Jesus			Implicit			EntireVerse
-JHN	16	23	Jesus			Implicit			EntireVerse
+JHN	16	20	Jesus			Normal			EntireVerse
+JHN	16	21	Jesus			Normal			EntireVerse
+JHN	16	22	Jesus			Normal			EntireVerse
+JHN	16	23	Jesus			Normal			EntireVerse
 JHN	16	24	Jesus			Normal			Unspecified
-JHN	16	25	Jesus			Implicit			EntireVerse
-JHN	16	26	Jesus			Implicit			EntireVerse
-JHN	16	27	Jesus			Implicit			EntireVerse
-JHN	16	28	Jesus			Implicit			EntireVerse
+JHN	16	25	Jesus			Normal			EntireVerse
+JHN	16	26	Jesus			Normal			EntireVerse
+JHN	16	27	Jesus			Normal			EntireVerse
+JHN	16	28	Jesus			Normal			EntireVerse
 JHN	16	29	disciples	relieved	disciples, Jesus'	Dialogue			Unspecified
-JHN	16	30	disciples	relieved	disciples, Jesus'	Implicit			EntireVerse
+JHN	16	30	disciples	relieved	disciples, Jesus'	Dialogue			EntireVerse
 JHN	16	31	Jesus			Dialogue			Unspecified
-JHN	16	32	Jesus			Implicit			EntireVerse
-JHN	16	33	Jesus			Implicit			EntireVerse
+JHN	16	32	Jesus			Normal			EntireVerse
+JHN	16	33	Jesus			Normal			EntireVerse
 JHN	17	1	Jesus	praying		Normal			EndOfVerse
-JHN	17	2	Jesus	praying		Implicit			EntireVerse
-JHN	17	3	Jesus	praying		Implicit			EntireVerse
-JHN	17	4	Jesus	praying		Implicit			EntireVerse
+JHN	17	2	Jesus	praying		Normal			EntireVerse
+JHN	17	3	Jesus	praying		Normal			EntireVerse
+JHN	17	4	Jesus	praying		Normal			EntireVerse
 JHN	17	5	Jesus	praying		Normal			Unspecified
-JHN	17	6	Jesus	praying		Implicit			EntireVerse
-JHN	17	7	Jesus	praying		Implicit			EntireVerse
-JHN	17	8	Jesus	praying		Implicit			EntireVerse
-JHN	17	9	Jesus	praying		Implicit			EntireVerse
-JHN	17	10	Jesus	praying		Implicit			EntireVerse
-JHN	17	11	Jesus	praying		Implicit			EntireVerse
-JHN	17	12	Jesus	praying		Implicit			EntireVerse
-JHN	17	13	Jesus	praying		Implicit			EntireVerse
-JHN	17	14	Jesus	praying		Implicit			EntireVerse
-JHN	17	15	Jesus	praying		Implicit			EntireVerse
-JHN	17	16	Jesus	praying		Implicit			EntireVerse
-JHN	17	17	Jesus	praying		Implicit			EntireVerse
-JHN	17	18	Jesus	praying		Implicit			EntireVerse
+JHN	17	6	Jesus	praying		Normal			EntireVerse
+JHN	17	7	Jesus	praying		Normal			EntireVerse
+JHN	17	8	Jesus	praying		Normal			EntireVerse
+JHN	17	9	Jesus	praying		Normal			EntireVerse
+JHN	17	10	Jesus	praying		Normal			EntireVerse
+JHN	17	11	Jesus	praying		Normal			EntireVerse
+JHN	17	12	Jesus	praying		Normal			EntireVerse
+JHN	17	13	Jesus	praying		Normal			EntireVerse
+JHN	17	14	Jesus	praying		Normal			EntireVerse
+JHN	17	15	Jesus	praying		Normal			EntireVerse
+JHN	17	16	Jesus	praying		Normal			EntireVerse
+JHN	17	17	Jesus	praying		Normal			EntireVerse
+JHN	17	18	Jesus	praying		Normal			EntireVerse
 JHN	17	19	Jesus	praying		Normal			Unspecified
-JHN	17	20	Jesus	praying		Implicit			EntireVerse
-JHN	17	21	Jesus	praying		Implicit			EntireVerse
-JHN	17	22	Jesus	praying		Implicit			EntireVerse
-JHN	17	23	Jesus	praying		Implicit			EntireVerse
-JHN	17	24	Jesus	praying		Implicit			EntireVerse
-JHN	17	25	Jesus	praying		Implicit			EntireVerse
-JHN	17	26	Jesus	praying		Implicit			EntireVerse
+JHN	17	20	Jesus	praying		Normal			EntireVerse
+JHN	17	21	Jesus	praying		Normal			EntireVerse
+JHN	17	22	Jesus	praying		Normal			EntireVerse
+JHN	17	23	Jesus	praying		Normal			EntireVerse
+JHN	17	24	Jesus	praying		Normal			EntireVerse
+JHN	17	25	Jesus	praying		Normal			EntireVerse
+JHN	17	26	Jesus	praying		Normal			EntireVerse
 JHN	18	4	Jesus	questioning		Dialogue			Unspecified
 JHN	18	5	Jesus			Dialogue			Unspecified
 JHN	18	5	soldiers/officials from chief priests and Pharisees	rowdy		Dialogue			Unspecified
@@ -19323,7 +19319,7 @@ JHN	18	17	servant girl at high priest's courtyard		servant girl who watched the 
 JHN	18	17	Peter (Simon)	denial		Dialogue			Unspecified
 JHN	18	19	Ananias (Annas), the high priest (father-in-law of Caiaphas)		Annas, high priest	Indirect			
 JHN	18	20	Jesus			Dialogue			Unspecified
-JHN	18	21	Jesus			Implicit			EntireVerse
+JHN	18	21	Jesus			Dialogue			EntireVerse
 JHN	18	22	officials of high priest, one of the	gruff		Dialogue			EndOfVerse
 JHN	18	23	Jesus			Dialogue			Unspecified
 JHN	18	25	people in high priest's courtyard		they (people accusing Peter)	Dialogue	second person to accuse Peter (man)	*different speakers;MAT 26.71;MRK 14.69;LUK 22.58;JHN 18.25	Unspecified
@@ -19349,7 +19345,7 @@ JHN	18	37	Jesus			Dialogue			Unspecified
 JHN	18	37	Pilate	to Jesus		Dialogue			Unspecified
 JHN	18	38	Pilate	to Jesus		Dialogue			Unspecified
 JHN	18	38	Pilate	to crowd		Dialogue			Unspecified
-JHN	18	39	Pilate	to crowd		Implicit			EntireVerse
+JHN	18	39	Pilate	to crowd		Dialogue			EntireVerse
 JHN	18	40	Jews, the			Dialogue			Unspecified
 JHN	19	1	Pilate			Rare			
 JHN	19	1	Needs Review			Potential			
@@ -19427,7 +19423,7 @@ JHN	21	17	Jesus	speaking to Peter (Simon)		Dialogue			Unspecified
 JHN	21	17	Jesus	quotation of Jesus' words (should be spoken by narrator)		Quotation	narrator-JHN		Unspecified
 JHN	21	17	narrator-JHN			Quotation			Unspecified
 JHN	21	17	Peter (Simon)	perplexed		Dialogue			Unspecified
-JHN	21	18	Jesus	speaking to Peter (Simon)		Implicit			EntireVerse
+JHN	21	18	Jesus	speaking to Peter (Simon)		Normal			EntireVerse
 JHN	21	19	Jesus			Dialogue			Unspecified
 JHN	21	20	narrator-JHN			Quotation			Unspecified
 JHN	21	20	John		John (who had asked the Lord who was going to betray Him)	Quotation	narrator-JHN		Unspecified
@@ -19441,7 +19437,7 @@ ACT	1	4	Jesus			Dialogue			EndOfVerse
 ACT	1	5	Jesus			Normal			Unspecified
 ACT	1	6	disciples		apostles	Dialogue			EndOfVerse
 ACT	1	7	Jesus			Dialogue			Unspecified
-ACT	1	8	Jesus			Implicit			EntireVerse
+ACT	1	8	Jesus			Normal			EntireVerse
 ACT	1	11	men dressed in white, two (angels)			Dialogue			Unspecified
 # "the Zealot" (or some longer description/explanation of this appellation may be in quotes)
 ACT	1	13	narrator-ACT			Quotation			Unspecified
@@ -19451,43 +19447,43 @@ ACT	1	18	Peter (Simon)			Potential
 ACT	1	19	Peter (Simon)			Potential			
 ACT	1	19	narrator-ACT			Quotation			Unspecified
 ACT	1	20	Peter (Simon)			Normal			Unspecified
-ACT	1	21	Peter (Simon)			Implicit			EntireVerse
-ACT	1	22	Peter (Simon)			Implicit			EntireVerse
+ACT	1	21	Peter (Simon)			Normal			EntireVerse
+ACT	1	22	Peter (Simon)			Normal			EntireVerse
 ACT	1	24	believers, one hundred twenty	praying		Normal			EndOfVerse
-ACT	1	25	believers, one hundred twenty	praying		Implicit			EntireVerse
+ACT	1	25	believers, one hundred twenty	praying		Normal			EntireVerse
 ACT	2	7	Jews, God-fearing from every nation	amazed		Normal			EndOfVerse
-ACT	2	8	Jews, God-fearing from every nation	amazed		Implicit			EntireVerse
-ACT	2	9	Jews, God-fearing from every nation	amazed		Implicit			EntireVerse
-ACT	2	10	Jews, God-fearing from every nation	amazed		Implicit			EntireVerse
-ACT	2	11	Jews, God-fearing from every nation	amazed		Implicit			EntireVerse
+ACT	2	8	Jews, God-fearing from every nation	amazed		Normal			EntireVerse
+ACT	2	9	Jews, God-fearing from every nation	amazed		Normal			EntireVerse
+ACT	2	10	Jews, God-fearing from every nation	amazed		Normal			EntireVerse
+ACT	2	11	Jews, God-fearing from every nation	amazed		Normal			EntireVerse
 ACT	2	12	Jews, God-fearing from every nation	amazed		Normal			EndOfVerse
 ACT	2	13	Jews, God-fearing from every nation, some	mocking		Normal			ContainedWithinVerse
 ACT	2	14	Peter (Simon)		Peter (Simon), with Eleven	Normal			EndOfVerse
-ACT	2	15	Peter (Simon)		Peter (Simon), with Eleven	Implicit			EntireVerse
-ACT	2	16	Peter (Simon)			Implicit			EntireVerse
-ACT	2	17	Peter (Simon)			Implicit			EntireVerse
-ACT	2	18	Peter (Simon)			Implicit			EntireVerse
-ACT	2	19	Peter (Simon)			Implicit			EntireVerse
-ACT	2	20	Peter (Simon)			Implicit			EntireVerse
-ACT	2	21	Peter (Simon)			Implicit			EntireVerse
-ACT	2	22	Peter (Simon)			Implicit			EntireVerse
-ACT	2	23	Peter (Simon)			Implicit			EntireVerse
-ACT	2	24	Peter (Simon)			Implicit			EntireVerse
-ACT	2	25	Peter (Simon)			Implicit			EntireVerse
-ACT	2	26	Peter (Simon)			Implicit			EntireVerse
-ACT	2	27	Peter (Simon)			Implicit			EntireVerse
-ACT	2	28	Peter (Simon)			Implicit			EntireVerse
+ACT	2	15	Peter (Simon)		Peter (Simon), with Eleven	Normal			EntireVerse
+ACT	2	16	Peter (Simon)			Normal			EntireVerse
+ACT	2	17	Peter (Simon)			Normal			EntireVerse
+ACT	2	18	Peter (Simon)			Normal			EntireVerse
+ACT	2	19	Peter (Simon)			Normal			EntireVerse
+ACT	2	20	Peter (Simon)			Normal			EntireVerse
+ACT	2	21	Peter (Simon)			Normal			EntireVerse
+ACT	2	22	Peter (Simon)			Normal			EntireVerse
+ACT	2	23	Peter (Simon)			Normal			EntireVerse
+ACT	2	24	Peter (Simon)			Normal			EntireVerse
+ACT	2	25	Peter (Simon)			Normal			EntireVerse
+ACT	2	26	Peter (Simon)			Normal			EntireVerse
+ACT	2	27	Peter (Simon)			Normal			EntireVerse
+ACT	2	28	Peter (Simon)			Normal			EntireVerse
 ACT	2	29	Peter (Simon)			Normal			Unspecified
 ACT	2	30	Peter (Simon)			Normal			Unspecified
 ACT	2	31	Peter (Simon)			Normal			Unspecified
 ACT	2	32	Peter (Simon)			Normal			Unspecified
 ACT	2	33	Peter (Simon)			Normal			Unspecified
 ACT	2	34	Peter (Simon)			Normal			Unspecified
-ACT	2	35	Peter (Simon)			Implicit			EntireVerse
-ACT	2	36	Peter (Simon)			Implicit			EntireVerse
+ACT	2	35	Peter (Simon)			Normal			EntireVerse
+ACT	2	36	Peter (Simon)			Normal			EntireVerse
 ACT	2	37	crowd in Jerusalem on Pentecost			Dialogue			EndOfVerse
 ACT	2	38	Peter (Simon)			Dialogue			Unspecified
-ACT	2	39	Peter (Simon)			Implicit			EntireVerse
+ACT	2	39	Peter (Simon)			Normal			EntireVerse
 ACT	2	40	Peter (Simon)			Dialogue			Unspecified
 ACT	2	43	everyone			Indirect			
 # "Beautiful" or "Beautiful Gate
@@ -19510,79 +19506,79 @@ ACT	3	19	Peter (Simon)			Normal			Unspecified
 ACT	3	20	Peter (Simon)			Normal			Unspecified
 ACT	3	21	Peter (Simon)			Normal			Unspecified
 ACT	3	22	Peter (Simon)			Normal			Unspecified
-ACT	3	23	Peter (Simon)			Implicit			EntireVerse
+ACT	3	23	Peter (Simon)			Normal			EntireVerse
 ACT	3	24	Peter (Simon)			Normal			Unspecified
 ACT	3	25	Peter (Simon)			Normal			Unspecified
-ACT	3	26	Peter (Simon)			Implicit			EntireVerse
+ACT	3	26	Peter (Simon)			Normal			EntireVerse
 ACT	4	1	Peter (Simon)/John			Indirect	Peter (Simon)		
 ACT	4	1	priests/captain of the temple guard/Sadducees			Indirect			
 ACT	4	2	proclamation of the resurrection			Rare			
 ACT	4	2	Needs Review			Potential			
 ACT	4	7	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Dialogue	Ananias (Annas), the high priest (father-in-law of Caiaphas)		EndOfVerse
 ACT	4	8	Peter (Simon)			Dialogue			Unspecified
-ACT	4	9	Peter (Simon)			Implicit			EntireVerse
-ACT	4	10	Peter (Simon)			Implicit			EntireVerse
-ACT	4	11	Peter (Simon)			Implicit			EntireVerse
-ACT	4	12	Peter (Simon)			Implicit			EntireVerse
+ACT	4	9	Peter (Simon)			Normal			EntireVerse
+ACT	4	10	Peter (Simon)			Normal			EntireVerse
+ACT	4	11	Peter (Simon)			Normal			EntireVerse
+ACT	4	12	Peter (Simon)			Normal			EntireVerse
 ACT	4	13	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Indirect	Ananias (Annas), the high priest (father-in-law of Caiaphas)		
 ACT	4	15	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Indirect	Ananias (Annas), the high priest (father-in-law of Caiaphas)		
 ACT	4	16	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Normal	Ananias (Annas), the high priest (father-in-law of Caiaphas)		Unspecified
-ACT	4	17	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Implicit	Ananias (Annas), the high priest (father-in-law of Caiaphas)		EntireVerse
+ACT	4	17	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Normal	Ananias (Annas), the high priest (father-in-law of Caiaphas)		EntireVerse
 ACT	4	18	Ananias (Annas), the high priest (father-in-law of Caiaphas)/Caiaphas, the high priest/John, Alexander, and other men of the high priest's family/elders/teachers of religious law/Sanhedrin		men in the Sanhedrin	Indirect	Ananias (Annas), the high priest (father-in-law of Caiaphas)		
 ACT	4	19	Peter (Simon)/John			Dialogue	Peter (Simon)		EndOfVerse
-ACT	4	20	Peter (Simon)/John			Implicit	Peter (Simon)		EntireVerse
+ACT	4	20	Peter (Simon)/John			Normal	Peter (Simon)		EntireVerse
 ACT	4	23	Peter (Simon)/John			Indirect	Peter (Simon)		
 ACT	4	24	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EndOfVerse
-ACT	4	25	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
-ACT	4	26	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
-ACT	4	27	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
-ACT	4	28	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
-ACT	4	29	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
-ACT	4	30	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Implicit			EntireVerse
+ACT	4	25	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
+ACT	4	26	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
+ACT	4	27	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
+ACT	4	28	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
+ACT	4	29	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
+ACT	4	30	apostles, elders, and whole church at Jerusalem/Peter (Simon)/John		Peter and John's own people (church in Jerusalem)	Normal			EntireVerse
 ACT	4	32	narrator-ACT			Quotation			Unspecified
 ACT	4	33	disciples		apostles	Indirect			
 # "Son of Encouragement"
 ACT	4	36	narrator-ACT			Quotation			Unspecified
 ACT	5	2	Ananias of Jerusalem			Indirect			
 ACT	5	3	Peter (Simon)	rebuking		Dialogue			Unspecified
-ACT	5	4	Peter (Simon)	rebuking		Implicit			EntireVerse
+ACT	5	4	Peter (Simon)	rebuking		Normal			EntireVerse
 ACT	5	5	Ananias of Jerusalem			Indirect			
 ACT	5	8	Peter (Simon)			Dialogue			Unspecified
 ACT	5	8	Sapphira, wife of Ananias of Jerusalem			Dialogue			Unspecified
 ACT	5	9	Peter (Simon)			Dialogue			Unspecified
-ACT	5	20	angel	commanding	angel of the Lord	Implicit			EntireVerse
+ACT	5	20	angel	commanding	angel of the Lord	Normal			EntireVerse
 ACT	5	22	Needs Review			Potential			
 ACT	5	22	officers	perplexed		Rare			
-ACT	5	23	officers	perplexed		Implicit			EntireVerse
+ACT	5	23	officers	perplexed		Normal			EntireVerse
 ACT	5	24	Ananias (Annas), the high priest (father-in-law of Caiaphas)/captain of the temple guard/chief priests			Indirect			
 ACT	5	25	person who told the guards and priests where the apostles were	excited		Normal			EndOfVerse
 ACT	5	26	captain of the temple guard/officers			Rare			
 ACT	5	26	Needs Review			Potential			
 ACT	5	28	Ananias (Annas), the high priest (father-in-law of Caiaphas)		high priest	Dialogue			Unspecified
 ACT	5	29	Peter (Simon)/disciples		Peter and the apostles	Dialogue			Unspecified
-ACT	5	30	Peter (Simon)/disciples		Peter and the apostles	Implicit			EntireVerse
-ACT	5	31	Peter (Simon)/disciples		Peter and the apostles	Implicit			EntireVerse
-ACT	5	32	Peter (Simon)/disciples		Peter and the apostles	Implicit			EntireVerse
+ACT	5	30	Peter (Simon)/disciples		Peter and the apostles	Normal			EntireVerse
+ACT	5	31	Peter (Simon)/disciples		Peter and the apostles	Normal			EntireVerse
+ACT	5	32	Peter (Simon)/disciples		Peter and the apostles	Normal			EntireVerse
 ACT	5	34	Gamaliel	ordering		Indirect			
 ACT	5	35	Gamaliel		Gamaliel, a Pharisee on Sanhedrin	Normal			EndOfVerse
-ACT	5	36	Gamaliel			Implicit			EntireVerse
-ACT	5	37	Gamaliel		Gamaliel, a Pharisee on Sanhedrin	Implicit			EntireVerse
-ACT	5	38	Gamaliel			Implicit			EntireVerse
+ACT	5	36	Gamaliel			Normal			EntireVerse
+ACT	5	37	Gamaliel		Gamaliel, a Pharisee on Sanhedrin	Normal			EntireVerse
+ACT	5	38	Gamaliel			Normal			EntireVerse
 ACT	5	39	Gamaliel			Normal			StartOfVerse
 ACT	5	40	council of elders/chief priests/teachers of religious law			Indirect			
 ACT	5	41	disciples		apostles	Indirect			
 ACT	5	42	disciples		apostles	Indirect			
 ACT	6	1	Grecian Jews			Indirect			
 ACT	6	2	disciples		the twelve (apostles)	Normal			EndOfVerse
-ACT	6	3	disciples		the twelve (apostles)	Implicit			EntireVerse
-ACT	6	4	disciples		the twelve (apostles)	Implicit			EntireVerse
+ACT	6	3	disciples		the twelve (apostles)	Normal			EntireVerse
+ACT	6	4	disciples		the twelve (apostles)	Normal			EntireVerse
 ACT	6	5	Grecian Jews		the whole multitude (of believers)	Rare			
 ACT	6	5	Needs Review			Potential			
 # "Synagogue of the Freed-men"
 ACT	6	9	narrator-ACT			Quotation			Unspecified
 ACT	6	11	Jews of Cyrene, Alexandria, Cilicia & Asia	accusing		Normal			EndOfVerse
 ACT	6	13	false witnesses			Normal			EndOfVerse
-ACT	6	14	false witnesses			Implicit			EntireVerse
+ACT	6	14	false witnesses			Normal			EntireVerse
 ACT	7	1	Ananias (Annas), the high priest (father-in-law of Caiaphas)		high priest	Normal			Unspecified
 ACT	7	2	Stephen			Normal			Unspecified
 ACT	7	3	Stephen			Normal			Unspecified
@@ -19610,13 +19606,13 @@ ACT	7	24	Stephen			Normal			Unspecified
 ACT	7	25	Stephen			Normal			Unspecified
 ACT	7	26	Stephen			Normal			Unspecified
 ACT	7	27	Stephen			Normal			Unspecified
-ACT	7	28	Stephen			Implicit			EntireVerse
+ACT	7	28	Stephen			Normal			EntireVerse
 ACT	7	29	Stephen			Normal			Unspecified
 ACT	7	30	Stephen			Normal			Unspecified
 ACT	7	31	Stephen			Normal			Unspecified
 ACT	7	32	Stephen			Normal			Unspecified
 ACT	7	33	Stephen			Normal			Unspecified
-ACT	7	34	Stephen			Implicit			EntireVerse
+ACT	7	34	Stephen			Normal			EntireVerse
 ACT	7	35	Stephen			Normal			Unspecified
 ACT	7	36	Stephen			Normal			Unspecified
 ACT	7	37	Stephen			Normal			Unspecified
@@ -19625,16 +19621,16 @@ ACT	7	39	Stephen			Normal			Unspecified
 ACT	7	40	Stephen			Normal			Unspecified
 ACT	7	41	Stephen			Normal			Unspecified
 ACT	7	42	Stephen			Normal			Unspecified
-ACT	7	43	Stephen			Implicit			EntireVerse
-ACT	7	44	Stephen			Implicit			EntireVerse
-ACT	7	45	Stephen			Implicit			EntireVerse
-ACT	7	46	Stephen			Implicit			EntireVerse
-ACT	7	47	Stephen			Implicit			EntireVerse
-ACT	7	48	Stephen			Implicit			EntireVerse
-ACT	7	49	Stephen			Implicit			EntireVerse
-ACT	7	50	Stephen			Implicit			EntireVerse
-ACT	7	51	Stephen			Implicit			EntireVerse
-ACT	7	52	Stephen			Implicit			EntireVerse
+ACT	7	43	Stephen			Normal			EntireVerse
+ACT	7	44	Stephen			Normal			EntireVerse
+ACT	7	45	Stephen			Normal			EntireVerse
+ACT	7	46	Stephen			Normal			EntireVerse
+ACT	7	47	Stephen			Normal			EntireVerse
+ACT	7	48	Stephen			Normal			EntireVerse
+ACT	7	49	Stephen			Normal			EntireVerse
+ACT	7	50	Stephen			Normal			EntireVerse
+ACT	7	51	Stephen			Normal			EntireVerse
+ACT	7	52	Stephen			Normal			EntireVerse
 ACT	7	53	Stephen			Normal			StartOfVerse
 ACT	7	56	Stephen			Dialogue			Unspecified
 ACT	7	57	Sanhedrin/chief priests/Pharisees			Indirect			
@@ -19654,9 +19650,9 @@ ACT	8	18	Simon, sorcerer			Rare
 ACT	8	18	Needs Review			Potential			
 ACT	8	19	Simon, sorcerer			Normal			EndOfVerse
 ACT	8	20	Peter (Simon)	rebuking		Dialogue			Unspecified
-ACT	8	21	Peter (Simon)	rebuking		Implicit			EntireVerse
-ACT	8	22	Peter (Simon)	rebuking		Implicit			EntireVerse
-ACT	8	23	Peter (Simon)	rebuking		Implicit			EntireVerse
+ACT	8	21	Peter (Simon)	rebuking		Normal			EntireVerse
+ACT	8	22	Peter (Simon)	rebuking		Normal			EntireVerse
+ACT	8	23	Peter (Simon)	rebuking		Normal			EntireVerse
 ACT	8	24	Simon, sorcerer			Dialogue			Unspecified
 ACT	8	26	angel		angel of the Lord	Normal			
 ACT	8	26	narrator-ACT			Interruption			
@@ -19666,7 +19662,7 @@ ACT	8	29	Holy Spirit, the			Normal			Unspecified
 ACT	8	30	Philip the evangelist		Philip	Dialogue			EndOfVerse
 ACT	8	31	Ethiopian officer of Queen Candace			Dialogue			Unspecified
 ACT	8	32	scripture			Quotation	Isaiah		EndOfVerse
-ACT	8	33	scripture			Implicit	Isaiah		EntireVerse
+ACT	8	33	scripture			Quotation	Isaiah		EntireVerse
 ACT	8	34	Ethiopian officer of Queen Candace			Dialogue			Unspecified
 ACT	8	35	Philip the evangelist		Philip	Indirect			
 ACT	8	36	Ethiopian officer of Queen Candace			Dialogue			Unspecified
@@ -19684,11 +19680,11 @@ ACT	9	6	Paul	trembled	Saul (Paul)	Potential
 ACT	9	10	Ananias of Damascus	awe		Normal			
 ACT	9	10	Jesus		Lord	Normal			
 ACT	9	11	Jesus		Lord	Normal			Unspecified
-ACT	9	12	Jesus		Lord	Implicit			EntireVerse
+ACT	9	12	Jesus		Lord	Normal			EntireVerse
 ACT	9	13	Ananias of Damascus	puzzled		Normal			EndOfVerse
-ACT	9	14	Ananias of Damascus	puzzled		Implicit			EntireVerse
+ACT	9	14	Ananias of Damascus	puzzled		Normal			EntireVerse
 ACT	9	15	Jesus		Lord	Normal			Unspecified
-ACT	9	16	Jesus		Lord	Implicit			EntireVerse
+ACT	9	16	Jesus		Lord	Normal			EntireVerse
 ACT	9	17	Ananias of Damascus	praying		Normal			Unspecified
 ACT	9	20	Paul		Saul (Paul)	Indirect			
 ACT	9	21	all who heard (in synagogues)			Normal			Unspecified
@@ -19712,8 +19708,8 @@ ACT	10	1	narrator-ACT			Quotation			Unspecified
 ACT	10	3	angel		angel of God	Normal			Unspecified
 ACT	10	4	angel		angel of God	Normal			
 ACT	10	4	Cornelius	afraid		Normal			
-ACT	10	5	angel		angel of God	Implicit			EntireVerse
-ACT	10	6	angel		angel of God	Implicit			EntireVerse
+ACT	10	5	angel		angel of God	Normal			EntireVerse
+ACT	10	6	angel		angel of God	Normal			EntireVerse
 ACT	10	8	Cornelius			Potential			
 ACT	10	13	Holy Spirit, the		voice (of the Holy Spirit)	Normal			Unspecified
 ACT	10	13	God		voice (of God)	Alternate			
@@ -19726,29 +19722,29 @@ ACT	10	17	Peter (Simon)			Indirect
 ACT	10	17	men from Cornelius			Indirect			
 ACT	10	18	men from Cornelius			Indirect			
 ACT	10	19	Holy Spirit, the		Spirit, the	Normal			EndOfVerse
-ACT	10	20	Holy Spirit, the		Spirit, the	Implicit			EntireVerse
+ACT	10	20	Holy Spirit, the		Spirit, the	Normal			EntireVerse
 ACT	10	21	Peter (Simon)			Dialogue			EndOfVerse
 ACT	10	22	men from Cornelius	respectful		Dialogue			EndOfVerse
 ACT	10	23	Peter (Simon)			Indirect			
 ACT	10	26	Peter (Simon)			Dialogue			EndOfVerse
 ACT	10	28	Peter (Simon)			Dialogue			EndOfVerse
-ACT	10	29	Peter (Simon)			Implicit			EntireVerse
+ACT	10	29	Peter (Simon)			Normal			EntireVerse
 ACT	10	30	Cornelius			Normal			Unspecified
 ACT	10	31	Cornelius			Normal			Unspecified
-ACT	10	32	Cornelius			Implicit			EntireVerse
+ACT	10	32	Cornelius			Normal			EntireVerse
 ACT	10	33	Cornelius			Normal			Unspecified
 ACT	10	34	Peter (Simon)			Dialogue			EndOfVerse
-ACT	10	35	Peter (Simon)			Implicit			EntireVerse
-ACT	10	36	Peter (Simon)			Implicit			EntireVerse
-ACT	10	37	Peter (Simon)			Implicit			EntireVerse
-ACT	10	38	Peter (Simon)			Implicit			EntireVerse
-ACT	10	39	Peter (Simon)			Implicit			EntireVerse
-ACT	10	40	Peter (Simon)			Implicit			EntireVerse
-ACT	10	41	Peter (Simon)			Implicit			EntireVerse
-ACT	10	42	Peter (Simon)			Implicit			EntireVerse
+ACT	10	35	Peter (Simon)			Normal			EntireVerse
+ACT	10	36	Peter (Simon)			Normal			EntireVerse
+ACT	10	37	Peter (Simon)			Normal			EntireVerse
+ACT	10	38	Peter (Simon)			Normal			EntireVerse
+ACT	10	39	Peter (Simon)			Normal			EntireVerse
+ACT	10	40	Peter (Simon)			Normal			EntireVerse
+ACT	10	41	Peter (Simon)			Normal			EntireVerse
+ACT	10	42	Peter (Simon)			Normal			EntireVerse
 ACT	10	43	Peter (Simon)			Normal			Unspecified
 ACT	10	45	believers who came with Peter			Indirect			
-ACT	10	47	Peter (Simon)			Implicit			EntireVerse
+ACT	10	47	Peter (Simon)			Dialogue			EntireVerse
 ACT	10	48	Peter (Simon)	giving orders		Indirect			
 ACT	10	48	Cornelius			Indirect			
 ACT	11	1	informer			Indirect			
@@ -19815,28 +19811,28 @@ ACT	13	22	Paul	preaching		Normal			Unspecified
 ACT	13	23	Paul	preaching		Normal			Unspecified
 ACT	13	24	Paul	preaching		Normal			Unspecified
 ACT	13	25	Paul	preaching		Normal			Unspecified
-ACT	13	26	Paul	preaching		Implicit			EntireVerse
-ACT	13	27	Paul	preaching		Implicit			EntireVerse
-ACT	13	28	Paul	preaching		Implicit			EntireVerse
-ACT	13	29	Paul	preaching		Implicit			EntireVerse
-ACT	13	30	Paul	preaching		Implicit			EntireVerse
-ACT	13	31	Paul	preaching		Implicit			EntireVerse
-ACT	13	32	Paul	preaching		Implicit			EntireVerse
-ACT	13	33	Paul	preaching		Implicit			EntireVerse
-ACT	13	34	Paul	preaching		Implicit			EntireVerse
+ACT	13	26	Paul	preaching		Normal			EntireVerse
+ACT	13	27	Paul	preaching		Normal			EntireVerse
+ACT	13	28	Paul	preaching		Normal			EntireVerse
+ACT	13	29	Paul	preaching		Normal			EntireVerse
+ACT	13	30	Paul	preaching		Normal			EntireVerse
+ACT	13	31	Paul	preaching		Normal			EntireVerse
+ACT	13	32	Paul	preaching		Normal			EntireVerse
+ACT	13	33	Paul	preaching		Normal			EntireVerse
+ACT	13	34	Paul	preaching		Normal			EntireVerse
 ACT	13	35	Paul	preaching		Normal			Unspecified
-ACT	13	36	Paul	preaching		Implicit			EntireVerse
-ACT	13	37	Paul	preaching		Implicit			EntireVerse
-ACT	13	38	Paul	preaching		Implicit			EntireVerse
-ACT	13	39	Paul	preaching		Implicit			EntireVerse
-ACT	13	40	Paul	preaching		Implicit			EntireVerse
-ACT	13	41	Paul	preaching		Implicit			EntireVerse
+ACT	13	36	Paul	preaching		Normal			EntireVerse
+ACT	13	37	Paul	preaching		Normal			EntireVerse
+ACT	13	38	Paul	preaching		Normal			EntireVerse
+ACT	13	39	Paul	preaching		Normal			EntireVerse
+ACT	13	40	Paul	preaching		Normal			EntireVerse
+ACT	13	41	Paul	preaching		Normal			EntireVerse
 ACT	13	42	people in Pisidian Antioch synagogue			Indirect			
 ACT	13	43	Paul/Barnabas			Indirect	Paul		
 ACT	13	45	Jewish leaders in Pisidian Antioch		the Jews	Rare			
 ACT	13	45	Needs Review			Potential			
 ACT	13	46	Paul/Barnabas	boldly		Normal	Paul		EndOfVerse
-ACT	13	47	Paul/Barnabas	boldly		Implicit	Paul		EntireVerse
+ACT	13	47	Paul/Barnabas	boldly		Normal	Paul		EntireVerse
 ACT	13	48	Gentiles			Indirect			
 ACT	13	50	Jewish leaders in Pisidian Antioch		the Jews	Rare			
 ACT	13	50	Needs Review			Potential			
@@ -19849,9 +19845,9 @@ ACT	14	12	narrator-ACT			Quotation			Unspecified
 ACT	14	12	crowd in Lystra			Potential			
 ACT	14	13	narrator-ACT			Quotation			Unspecified
 ACT	14	13	priest of Jupiter			Potential			
-ACT	14	15	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
-ACT	14	16	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
-ACT	14	17	Barnabas/Paul	preaching		Implicit	Paul		EntireVerse
+ACT	14	15	Barnabas/Paul	preaching		Dialogue	Paul		EntireVerse
+ACT	14	16	Barnabas/Paul	preaching		Normal	Paul		EntireVerse
+ACT	14	17	Barnabas/Paul	preaching		Normal	Paul		EntireVerse
 ACT	14	22	Barnabas/Paul			Normal	Paul		Unspecified
 ACT	14	23	Barnabas/Paul			Rare			
 ACT	14	23	Needs Review			Potential			
@@ -19867,20 +19863,20 @@ ACT	15	4	apostles, elders, and whole church at Jerusalem			Rare
 ACT	15	4	Needs Review			Potential			
 ACT	15	5	believers who were Pharisees			Dialogue			EndOfVerse
 ACT	15	7	Peter (Simon)			Dialogue			EndOfVerse
-ACT	15	8	Peter (Simon)			Implicit			EntireVerse
-ACT	15	9	Peter (Simon)			Implicit			EntireVerse
-ACT	15	10	Peter (Simon)			Implicit			EntireVerse
+ACT	15	8	Peter (Simon)			Normal			EntireVerse
+ACT	15	9	Peter (Simon)			Normal			EntireVerse
+ACT	15	10	Peter (Simon)			Normal			EntireVerse
 ACT	15	12	Barnabas/Paul			Rare			
 ACT	15	12	Needs Review			Potential			
-ACT	15	11	Peter (Simon)			Implicit			EntireVerse
+ACT	15	11	Peter (Simon)			Normal			EntireVerse
 ACT	15	13	James			Normal			EndOfVerse
-ACT	15	14	James			Implicit			EntireVerse
-ACT	15	15	James			Implicit			EntireVerse
-ACT	15	16	James			Implicit			EntireVerse
-ACT	15	17	James			Implicit			EntireVerse
-ACT	15	18	James			Implicit			EntireVerse
-ACT	15	19	James			Implicit			EntireVerse
-ACT	15	20	James			Implicit			EntireVerse
+ACT	15	14	James			Normal			EntireVerse
+ACT	15	15	James			Normal			EntireVerse
+ACT	15	16	James			Normal			EntireVerse
+ACT	15	17	James			Normal			EntireVerse
+ACT	15	18	James			Normal			EntireVerse
+ACT	15	19	James			Normal			EntireVerse
+ACT	15	20	James			Normal			EntireVerse
 ACT	15	21	James			Normal			StartOfVerse
 ACT	15	22	apostles, elders, and whole church at Jerusalem/James		apostles, elders, and whole church at Jerusalem	Indirect	James		
 ACT	15	23	letter from apostles and elders			Potential	James		
@@ -19910,7 +19906,7 @@ ACT	16	18	Paul	sternly		Dialogue			ContainedWithinVerse
 ACT	16	19	owners of fortune telling slave girl			Rare			
 ACT	16	19	Needs Review			Potential			
 ACT	16	20	owners of fortune telling slave girl	angry		Dialogue			EndOfVerse
-ACT	16	21	owners of fortune telling slave girl	angry		Implicit			EntireVerse
+ACT	16	21	owners of fortune telling slave girl	angry		Dialogue			EntireVerse
 ACT	16	22	authorities, Philippi	giving orders		Indirect			
 ACT	16	23	authorities, Philippi	giving orders		Indirect			
 ACT	16	27	jailer in Philippi	fearful		Indirect			
@@ -19927,7 +19923,7 @@ ACT	16	38	Needs Review			Potential
 ACT	16	39	magistrates, chief			Indirect			
 ACT	17	3	Paul			Normal			Unspecified
 ACT	17	6	mob			Normal			EndOfVerse
-ACT	17	7	mob			Implicit			EntireVerse
+ACT	17	7	mob			Normal			EntireVerse
 ACT	17	10	brothers at Thessalonica			Indirect			
 ACT	17	11	Jews of Berea			Indirect			
 ACT	17	13	report concerning Paul			Rare			
@@ -19938,7 +19934,7 @@ ACT	17	15	Paul	commanding		Indirect
 ACT	17	18	Epicurean and Stoic philosophers, other	superior		Normal			
 ACT	17	18	Epicurean and Stoic philosophers, some	superior		Normal			
 ACT	17	19	Epicurean and Stoic philosophers	curious		Dialogue			Unspecified
-ACT	17	20	Epicurean and Stoic philosophers	curious		Implicit			EntireVerse
+ACT	17	20	Epicurean and Stoic philosophers	curious		Normal			EntireVerse
 ACT	17	22	Paul			Normal			Unspecified
 ACT	17	23	Paul			Normal			Unspecified
 ACT	17	24	Paul			Normal			Unspecified
@@ -19946,19 +19942,19 @@ ACT	17	25	Paul			Normal			Unspecified
 ACT	17	26	Paul			Normal			Unspecified
 ACT	17	27	Paul			Normal			Unspecified
 ACT	17	28	Paul			Normal			Unspecified
-ACT	17	29	Paul			Implicit			EntireVerse
-ACT	17	30	Paul			Implicit			EntireVerse
-ACT	17	31	Paul			Implicit			EntireVerse
+ACT	17	29	Paul			Normal			EntireVerse
+ACT	17	30	Paul			Normal			EntireVerse
+ACT	17	31	Paul			Normal			EntireVerse
 ACT	17	32	Epicurean and Stoic philosophers, interested			Dialogue			Unspecified
 ACT	17	32	Epicurean and Stoic philosophers, sneering	sneering		Dialogue			Unspecified
 ACT	18	2	Claudius			Indirect			
 ACT	18	5	Paul			Indirect			
 ACT	18	6	Paul	rebuking		Normal			EndOfVerse
 ACT	18	9	Jesus		Jesus (in vision)	Normal			EndOfVerse
-ACT	18	10	Jesus		Jesus (in vision)	Implicit			EntireVerse
+ACT	18	10	Jesus		Jesus (in vision)	Normal			EntireVerse
 ACT	18	13	Jews, the	angry		Dialogue			Unspecified
 ACT	18	14	Gallio, proconsul of Achaia	sternly		Dialogue			EndOfVerse
-ACT	18	15	Gallio, proconsul of Achaia	sternly		Implicit			EntireVerse
+ACT	18	15	Gallio, proconsul of Achaia	sternly		Normal			EntireVerse
 ACT	18	18	Paul			Indirect			
 ACT	18	20	Paul			Indirect			
 ACT	18	21	Paul			Normal			Unspecified
@@ -19973,8 +19969,8 @@ ACT	19	13	seven sons of Sceva	over-dramatic		Normal			EndOfVerse
 ACT	19	15	evil spirit in possessed man			Normal			EndOfVerse
 ACT	19	21	Paul			Normal			EndOfVerse
 ACT	19	25	Demetrius the silversmith			Normal			EndOfVerse
-ACT	19	26	Demetrius the silversmith			Implicit			EntireVerse
-ACT	19	27	Demetrius the silversmith			Implicit			EntireVerse
+ACT	19	26	Demetrius the silversmith			Normal			EntireVerse
+ACT	19	27	Demetrius the silversmith			Normal			EntireVerse
 ACT	19	28	craftsmen and workmen	furious		Normal			EndOfVerse
 ACT	19	30	brothers at Ephesus			Rare			
 ACT	19	30	Needs Review			Potential			
@@ -19982,11 +19978,11 @@ ACT	19	31	officials, Ephesus (friends of Paul)			Indirect
 ACT	19	33	craftsmen and workmen	furious		Indirect			
 ACT	19	34	craftsmen and workmen	furious		Normal			EndOfVerse
 ACT	19	35	city clerk of Ephesus	diplomatic		Normal			EndOfVerse
-ACT	19	36	city clerk of Ephesus	diplomatic		Implicit			EntireVerse
-ACT	19	37	city clerk of Ephesus	diplomatic		Implicit			EntireVerse
-ACT	19	38	city clerk of Ephesus	diplomatic		Implicit			EntireVerse
-ACT	19	39	city clerk of Ephesus	diplomatic		Implicit			EntireVerse
-ACT	19	40	city clerk of Ephesus	diplomatic		Implicit			EntireVerse
+ACT	19	36	city clerk of Ephesus	diplomatic		Normal			EntireVerse
+ACT	19	37	city clerk of Ephesus	diplomatic		Normal			EntireVerse
+ACT	19	38	city clerk of Ephesus	diplomatic		Normal			EntireVerse
+ACT	19	39	city clerk of Ephesus	diplomatic		Normal			EntireVerse
+ACT	19	40	city clerk of Ephesus	diplomatic		Normal			EntireVerse
 ACT	19	41	city clerk of Ephesus			Indirect			
 ACT	20	1	Paul			Indirect			
 ACT	20	3	Jews, the			Indirect			
@@ -20026,11 +20022,11 @@ ACT	21	13	Paul	sad		Dialogue			Unspecified
 ACT	21	14	Paul's traveling companions, Luke and	resigned		Dialogue			EndOfVerse
 ACT	21	19	Paul			Indirect			
 ACT	21	20	James/all the elders			Normal	James		EndOfVerse
-ACT	21	21	James/all the elders			Implicit	James		EntireVerse
-ACT	21	22	James/all the elders			Implicit	James		EntireVerse
-ACT	21	23	James/all the elders			Implicit	James		EntireVerse
-ACT	21	24	James/all the elders			Implicit	James		EntireVerse
-ACT	21	25	James/all the elders			Implicit	James		EntireVerse
+ACT	21	21	James/all the elders			Normal	James		EntireVerse
+ACT	21	22	James/all the elders			Normal	James		EntireVerse
+ACT	21	23	James/all the elders			Normal	James		EntireVerse
+ACT	21	24	James/all the elders			Normal	James		EntireVerse
+ACT	21	25	James/all the elders			Normal	James		EntireVerse
 ACT	21	26	Paul			Rare			
 ACT	21	26	Needs Review			Potential			
 ACT	21	28	Jews from Asia	shouting		Normal			EndOfVerse
@@ -20040,10 +20036,10 @@ ACT	21	34	crowd	shouting		Indirect
 ACT	21	36	crowd	shouting		Normal			ContainedWithinVerse
 ACT	21	37	commander of Roman troops in Jerusalem			Dialogue			Unspecified
 ACT	21	37	Paul			Dialogue			Unspecified
-ACT	21	38	commander of Roman troops in Jerusalem			Implicit			EntireVerse
+ACT	21	38	commander of Roman troops in Jerusalem			Normal			EntireVerse
 ACT	21	39	Paul			Dialogue			Unspecified
 ACT	21	40	commander of Roman troops in Jerusalem			Indirect			
-ACT	22	1	Paul	preaching		Implicit			EntireVerse
+ACT	22	1	Paul	preaching		Normal			EntireVerse
 ACT	22	2	Paul	preaching		Indirect			
 ACT	22	3	Paul	preaching		Normal			Unspecified
 ACT	22	4	Paul	preaching		Normal			Unspecified
@@ -20057,8 +20053,8 @@ ACT	22	11	Paul	preaching		Normal			Unspecified
 ACT	22	12	Paul	preaching		Normal			Unspecified
 ACT	22	13	Paul	preaching		Normal			Unspecified
 ACT	22	14	Paul	preaching		Normal			Unspecified
-ACT	22	15	Paul	preaching		Implicit			EntireVerse
-ACT	22	16	Paul	preaching		Implicit			EntireVerse
+ACT	22	15	Paul	preaching		Normal			EntireVerse
+ACT	22	16	Paul	preaching		Normal			EntireVerse
 ACT	22	17	Paul	preaching		Normal			Unspecified
 ACT	22	18	Paul	preaching		Normal			Unspecified
 ACT	22	19	Paul	preaching		Normal			Unspecified
@@ -20087,12 +20083,12 @@ ACT	23	10	commander of Roman troops in Jerusalem	ordering		Indirect
 ACT	23	11	Jesus		Jesus (in vision)	Normal			ContainedWithinVerse
 ACT	23	12	Jews, more than forty in conspiracy	plotting		Indirect			
 ACT	23	14	Jews, more than forty in conspiracy	plotting		Dialogue			EndOfVerse
-ACT	23	15	Jews, more than forty in conspiracy	plotting		Implicit			EntireVerse
+ACT	23	15	Jews, more than forty in conspiracy	plotting		Dialogue			EntireVerse
 ACT	23	17	Paul			Dialogue			EndOfVerse
 ACT	23	18	centurion in the barracks			Dialogue			EndOfVerse
 ACT	23	19	commander of Roman troops in Jerusalem			Dialogue			EndOfVerse
 ACT	23	20	son of Paul's sister (young man)			Dialogue			Unspecified
-ACT	23	21	son of Paul's sister (young man)			Implicit			EntireVerse
+ACT	23	21	son of Paul's sister (young man)			Normal			EntireVerse
 ACT	23	22	commander of Roman troops in Jerusalem	ordering		Dialogue			ContainedWithinVerse
 ACT	23	23	commander of Roman troops in Jerusalem	ordering		Dialogue			EndOfVerse
 ACT	23	24	commander of Roman troops in Jerusalem	ordering		Indirect			
@@ -20105,12 +20101,12 @@ ACT	23	34	Paul			Indirect
 ACT	23	34	Felix, governor of Judea			Indirect			
 ACT	23	35	Felix, governor of Judea	with authority		Normal			ContainedWithinVerse
 ACT	24	2	Tertullus, lawyer			Normal			EndOfVerse
-ACT	24	3	Tertullus, lawyer			Implicit			EntireVerse
-ACT	24	4	Tertullus, lawyer			Implicit			EntireVerse
-ACT	24	5	Tertullus, lawyer	accusing		Implicit			EntireVerse
-ACT	24	6	Tertullus, lawyer	accusing		Implicit			EntireVerse
-ACT	24	7	Tertullus, lawyer	accusing		Implicit			EntireVerse
-ACT	24	8	Tertullus, lawyer	accusing		Implicit			EntireVerse
+ACT	24	3	Tertullus, lawyer			Normal			EntireVerse
+ACT	24	4	Tertullus, lawyer			Normal			EntireVerse
+ACT	24	5	Tertullus, lawyer	accusing		Normal			EntireVerse
+ACT	24	6	Tertullus, lawyer	accusing		Normal			EntireVerse
+ACT	24	7	Tertullus, lawyer	accusing		Normal			EntireVerse
+ACT	24	8	Tertullus, lawyer	accusing		Normal			EntireVerse
 ACT	24	9	Jews, the			Indirect			
 ACT	24	10	Paul			Normal			Unspecified
 ACT	24	11	Paul			Normal			Unspecified
@@ -20141,23 +20137,23 @@ ACT	25	7	chief priests/Jewish leaders		Jews from Jerusalem	Indirect
 ACT	25	8	Paul	defense to governor		Dialogue			EndOfVerse
 ACT	25	9	Festus, governor of Judea			Dialogue			EndOfVerse
 ACT	25	10	Paul			Dialogue			EndOfVerse
-ACT	25	11	Paul			Implicit			EntireVerse
+ACT	25	11	Paul			Normal			EntireVerse
 ACT	25	12	Festus, governor of Judea			Dialogue			ContainedWithinVerse
 ACT	25	14	Festus, governor of Judea			Dialogue			Unspecified
-ACT	25	15	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	16	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	17	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	18	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	19	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	20	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	21	Festus, governor of Judea			Implicit			EntireVerse
+ACT	25	15	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	16	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	17	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	18	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	19	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	20	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	21	Festus, governor of Judea			Normal			EntireVerse
 ACT	25	22	Festus, governor of Judea			Dialogue			Unspecified
 ACT	25	22	King Herod Agrippa II			Dialogue			Unspecified
 ACT	25	23	Festus, governor of Judea	giving orders		Indirect			
 ACT	25	24	Festus, governor of Judea			Dialogue			EndOfVerse
-ACT	25	25	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	26	Festus, governor of Judea			Implicit			EntireVerse
-ACT	25	27	Festus, governor of Judea			Implicit			EntireVerse
+ACT	25	25	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	26	Festus, governor of Judea			Normal			EntireVerse
+ACT	25	27	Festus, governor of Judea			Normal			EntireVerse
 ACT	26	1	King Herod Agrippa II			Dialogue			ContainedWithinVerse
 ACT	26	2	Paul			Normal			Unspecified
 ACT	26	3	Paul			Normal			Unspecified
@@ -20178,12 +20174,12 @@ ACT	26	17	Paul			Normal			Unspecified
 ACT	26	18	Paul			Normal			Unspecified
 ACT	26	19	Paul			Normal			Unspecified
 ACT	26	20	Paul			Normal			Unspecified
-ACT	26	21	Paul			Implicit			EntireVerse
-ACT	26	22	Paul			Implicit			EntireVerse
-ACT	26	23	Paul			Implicit			EntireVerse
+ACT	26	21	Paul			Normal			EntireVerse
+ACT	26	22	Paul			Normal			EntireVerse
+ACT	26	23	Paul			Normal			EntireVerse
 ACT	26	24	Festus, governor of Judea			Dialogue			Unspecified
 ACT	26	25	Paul			Dialogue			Unspecified
-ACT	26	26	Paul			Implicit			EntireVerse
+ACT	26	26	Paul			Normal			EntireVerse
 ACT	26	27	Paul			Normal			Unspecified
 ACT	26	28	King Herod Agrippa II			Dialogue			Unspecified
 ACT	26	29	Paul			Dialogue			Unspecified
@@ -20203,7 +20199,7 @@ ACT	27	21	Paul			Normal			Unspecified
 ACT	27	22	Paul			Normal			Unspecified
 ACT	27	23	Paul			Normal			Unspecified
 ACT	27	24	Paul			Normal			Unspecified
-ACT	27	25	Paul			Implicit			EntireVerse
+ACT	27	25	Paul			Normal			EntireVerse
 ACT	27	26	Paul			Normal			Unspecified
 ACT	27	27	sailors on ship to Italy (Rome)		sailors	Indirect			
 ACT	27	29	sailors on ship to Italy (Rome)		sailors	Rare			
@@ -20212,7 +20208,7 @@ ACT	27	30	sailors on ship to Italy (Rome)		sailors	Rare
 ACT	27	30	Needs Review			Potential			
 ACT	27	31	Paul	warning		Normal			EndOfVerse
 ACT	27	33	Paul	encouraging		Normal			EndOfVerse
-ACT	27	34	Paul	encouraging		Implicit			EntireVerse
+ACT	27	34	Paul	encouraging		Normal			EntireVerse
 ACT	27	39	captain of ship to Italy (Rome)/sailors on ship to Italy (Rome)		ship's crew	Indirect			
 ACT	27	42	soldiers			Indirect			
 ACT	27	43	centurion on ship with Paul			Indirect			
@@ -20225,19 +20221,19 @@ ACT	28	15	brothers at Rome			Indirect
 ACT	28	15	Paul			Indirect			
 ACT	28	16	one who allowed Paul to live by himself			Indirect			
 ACT	28	17	Paul			Dialogue			EndOfVerse
-ACT	28	18	Paul			Implicit			EntireVerse
-ACT	28	19	Paul			Implicit			EntireVerse
-ACT	28	20	Paul			Implicit			EntireVerse
+ACT	28	18	Paul			Normal			EntireVerse
+ACT	28	19	Paul			Normal			EntireVerse
+ACT	28	20	Paul			Normal			EntireVerse
 ACT	28	21	Jews, leaders of the (in Rome)		Jews, leaders of the	Dialogue			Unspecified
-ACT	28	22	Jews, leaders of the (in Rome)		Jews, leaders of the	Implicit			EntireVerse
+ACT	28	22	Jews, leaders of the (in Rome)		Jews, leaders of the	Dialogue			EntireVerse
 ACT	28	23	Paul			Indirect			
 ACT	28	24	Paul			Indirect			
 ACT	28	24	some convinced by Paul			Indirect			
 ACT	28	24	others who would not believe			Indirect			
 ACT	28	25	others who would not believe			Indirect			
 ACT	28	25	Paul			Normal			
-ACT	28	26	Paul			Implicit			EntireVerse
-ACT	28	27	Paul			Implicit			EntireVerse
+ACT	28	26	Paul			Normal			EntireVerse
+ACT	28	27	Paul			Normal			EntireVerse
 ACT	28	28	Paul			Normal			Unspecified
 ACT	28	29	Jews, the			Indirect			
 ACT	28	30	Paul			Indirect			
@@ -20297,9 +20293,9 @@ ROM	9	20	Needs Review			Rare
 ROM	9	21	narrator-ROM			Rare			
 ROM	9	21	Needs Review			Potential			
 ROM	9	25	scripture			Quotation	God		EndOfVerse
-ROM	9	26	scripture			Implicit	Hosea		EntireVerse
+ROM	9	26	scripture			Quotation	Hosea		EntireVerse
 ROM	9	27	scripture			Quotation	Isaiah		EndOfVerse
-ROM	9	28	scripture			Implicit	Isaiah		EntireVerse
+ROM	9	28	scripture			Quotation	Isaiah		EntireVerse
 ROM	9	29	scripture			Quotation	Isaiah		ContainedWithinVerse
 ROM	9	32	narrator-ROM			Quotation			Unspecified
 ROM	9	33	scripture			Quotation	God		EndOfVerse
@@ -20331,9 +20327,9 @@ ROM	11	10	scripture			Quotation	David		StartOfVerse
 ROM	11	11	narrator-ROM			Quotation			Unspecified
 ROM	11	19	you (hypothetical Gentile)	smug		Hypothetical			Unspecified
 ROM	11	26	scripture			Quotation	God		EndOfVerse
-ROM	11	27	scripture			Implicit	God		EntireVerse
-ROM	11	34	scripture			Implicit	Isaiah		EntireVerse
-ROM	11	35	scripture			Implicit	God		EntireVerse
+ROM	11	27	scripture			Quotation	God		EntireVerse
+ROM	11	34	scripture			Quotation	Isaiah		EntireVerse
+ROM	11	35	scripture			Quotation	God		EntireVerse
 ROM	12	19	scripture			Quotation	God		Unspecified
 ROM	12	20	scripture			Quotation	Solomon, king		EndOfVerse
 ROM	13	3	authorities, governing			Indirect			
@@ -20406,7 +20402,7 @@ ROM	16	22	Tertius			Implicit
 1CO	15	35	someone (hypothetical argument)			Hypothetical			Unspecified
 1CO	15	45	scripture			Quotation			Unspecified
 1CO	15	54	scripture			Quotation	Isaiah		EndOfVerse
-1CO	15	55	scripture			Implicit	Hosea		EntireVerse
+1CO	15	55	scripture			Quotation	Hosea		EntireVerse
 2CO	1	17	narrator-2CO			Quotation			Unspecified
 2CO	1	18	narrator-2CO			Quotation			Unspecified
 2CO	1	19	narrator-2CO			Quotation			Unspecified
@@ -20418,7 +20414,7 @@ ROM	16	22	Tertius			Implicit
 2CO	6	2	scripture			Quotation	God		ContainedWithinVerse
 2CO	6	16	scripture			Quotation	God		Unspecified
 2CO	6	17	scripture			Quotation	God		Unspecified
-2CO	6	18	scripture			Implicit	God		EntireVerse
+2CO	6	18	scripture			Quotation	God		EntireVerse
 2CO	8	15	scripture			Quotation			ContainedWithinVerse
 2CO	8	17	Titus			Indirect			
 2CO	9	2	Paul			Indirect			
@@ -20492,7 +20488,7 @@ EPH	4	26	scripture			Quotation	David		Unspecified
 EPH	5	14	scripture			Quotation			EndOfVerse
 EPH	5	31	scripture			Quotation			Unspecified
 EPH	6	2	scripture			Quotation	God		Unspecified
-EPH	6	3	scripture			Implicit	God		EntireVerse
+EPH	6	3	scripture			Quotation	God		EntireVerse
 PHP	2	11	everyone			Hypothetical			Unspecified
 PHP	4	2	narrator-PHP			Potential			
 PHP	4	3	narrator-PHP			Potential			
@@ -20539,22 +20535,22 @@ HEB	1	5	scripture			Quotation	God		Unspecified
 HEB	1	6	scripture			Quotation	God		Unspecified
 HEB	1	7	scripture			Quotation	God		EndOfVerse
 HEB	1	8	scripture			Quotation	God		EndOfVerse
-HEB	1	9	scripture			Implicit	God		EntireVerse
+HEB	1	9	scripture			Quotation	God		EntireVerse
 HEB	1	10	scripture			Quotation	God		EndOfVerse
-HEB	1	11	scripture			Implicit	God		EntireVerse
-HEB	1	12	scripture			Implicit	God		EntireVerse
+HEB	1	11	scripture			Quotation	God		EntireVerse
+HEB	1	12	scripture			Quotation	God		EntireVerse
 HEB	1	13	scripture			Quotation	God		EndOfVerse
 HEB	2	6	scripture			Quotation	David		EndOfVerse
-HEB	2	7	scripture			Implicit	David		EntireVerse
+HEB	2	7	scripture			Quotation	David		EntireVerse
 HEB	2	8	scripture			Quotation	David		StartOfVerse
 HEB	2	9	scripture			Quotation	David		Unspecified
 HEB	2	12	Jesus			Normal			EndOfVerse
 HEB	2	13	Jesus			Normal			Unspecified
 HEB	3	7	scripture			Quotation			EndOfVerse
-HEB	3	8	scripture			Implicit			EntireVerse
-HEB	3	9	scripture			Implicit			EntireVerse
-HEB	3	10	scripture			Implicit			EntireVerse
-HEB	3	11	scripture			Implicit			EntireVerse
+HEB	3	8	scripture			Quotation			EntireVerse
+HEB	3	9	scripture			Quotation			EntireVerse
+HEB	3	10	scripture			Quotation			EntireVerse
+HEB	3	11	scripture			Quotation			EntireVerse
 HEB	3	13	narrator-HEB			Quotation			Unspecified
 HEB	3	15	scripture			Quotation			Unspecified
 HEB	3	15	narrator-HEB			Quotation			Unspecified
@@ -20574,10 +20570,10 @@ HEB	7	17	scripture			Quotation	God		EndOfVerse
 HEB	7	21	scripture			Quotation	God		EndOfVerse
 HEB	8	5	scripture			Quotation	God		EndOfVerse
 HEB	8	8	scripture			Quotation	God		Unspecified
-HEB	8	9	scripture			Implicit	God		EntireVerse
+HEB	8	9	scripture			Quotation	God		EntireVerse
 HEB	8	10	scripture			Quotation	God		Unspecified
-HEB	8	11	scripture			Implicit	God		EntireVerse
-HEB	8	12	scripture			Implicit	God		EntireVerse
+HEB	8	11	scripture			Quotation	God		EntireVerse
+HEB	8	12	scripture			Quotation	God		EntireVerse
 HEB	8	13	narrator-HEB			Quotation			Unspecified
 HEB	9	2	narrator-HEB			Quotation			Unspecified
 HEB	9	3	narrator-HEB			Quotation			Unspecified
@@ -20587,7 +20583,7 @@ HEB	9	20	scripture			Quotation	Moses		EndOfVerse
 HEB	9	24	narrator-HEB			Quotation			Unspecified
 HEB	9	25	narrator-HEB			Quotation			Unspecified
 HEB	10	5	scripture			Quotation	Jesus		EndOfVerse
-HEB	10	6	scripture			Implicit	Jesus		EntireVerse
+HEB	10	6	scripture			Quotation	Jesus		EntireVerse
 HEB	10	7	scripture			Quotation	Jesus		Unspecified
 HEB	10	8	scripture			Quotation	Jesus		Unspecified
 HEB	10	9	scripture			Quotation	Jesus		Unspecified
@@ -20595,13 +20591,13 @@ HEB	10	16	scripture			Quotation	Holy Spirit, the		Unspecified
 HEB	10	17	scripture			Quotation	Holy Spirit, the		Unspecified
 HEB	10	30	scripture			Quotation	God		Unspecified
 HEB	10	37	scripture			Quotation	God		EndOfVerse
-HEB	10	38	scripture			Implicit	God		EntireVerse
+HEB	10	38	scripture			Quotation	God		EntireVerse
 HEB	11	5	scripture			Quotation			Unspecified
 HEB	11	18	scripture			Quotation	God		Unspecified
 HEB	11	20	narrator-HEB			Quotation			Unspecified
 HEB	11	20	Isaac			Quotation			Unspecified
 HEB	12	5	scripture			Quotation	Solomon, king		EndOfVerse
-HEB	12	6	scripture			Implicit	Solomon, king		EntireVerse
+HEB	12	6	scripture			Quotation	Solomon, king		EntireVerse
 HEB	12	13	scripture			Quotation			Unspecified
 HEB	12	19	those who heard	begging		Indirect			
 HEB	12	20	scripture			Quotation	God		Unspecified
@@ -20640,8 +20636,8 @@ JAS	5	17	Elijah	praying		Indirect
 1PE	2	22	scripture			Quotation	Isaiah		Unspecified
 1PE	3	6	narrator-1PE			Quotation			Unspecified
 1PE	3	10	scripture			Quotation	David		Unspecified
-1PE	3	11	scripture			Implicit	David		EntireVerse
-1PE	3	12	scripture			Implicit	David		EntireVerse
+1PE	3	11	scripture			Quotation	David		EntireVerse
+1PE	3	12	scripture			Quotation	David		EntireVerse
 1PE	3	14	scripture			Quotation	God		Unspecified
 1PE	4	8	narrator-1PE			Quotation			Unspecified
 1PE	4	8	scripture			Quotation	Solomon, king		Unspecified
@@ -20691,25 +20687,25 @@ REV	1	8	Needs Review			Normal
 REV	1	11	Jesus		voice like a trumpet	Normal			EndOfVerse
 REV	1	13	narrator-REV			Quotation			Unspecified
 REV	1	17	Jesus		someone like a son of man	Normal			EndOfVerse
-REV	1	18	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	1	19	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	1	20	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	1	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	2	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	3	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	4	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	5	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	6	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	1	18	Jesus		someone like a son of man	Normal			EntireVerse
+REV	1	19	Jesus		someone like a son of man	Normal			EntireVerse
+REV	1	20	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	1	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	2	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	3	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	4	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	5	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	6	Jesus		someone like a son of man	Normal			EntireVerse
 REV	2	7	Jesus		someone like a son of man	Normal			StartOfVerse
 REV	2	8	Jesus		someone like a son of man	Normal			Unspecified
-REV	2	9	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	10	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	2	9	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	10	Jesus		someone like a son of man	Normal			EntireVerse
 REV	2	11	Jesus		someone like a son of man	Normal			StartOfVerse
 REV	2	12	Jesus		someone like a son of man	Normal			Unspecified
-REV	2	13	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	14	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	15	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	16	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	2	13	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	14	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	15	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	16	Jesus		someone like a son of man	Normal			EntireVerse
 REV	2	17	Jesus		someone like a son of man	Normal			StartOfVerse
 REV	2	18	Jesus		someone like a son of man	Normal			Unspecified
 REV	2	19	Jesus		someone like a son of man	Normal			Unspecified
@@ -20718,40 +20714,40 @@ REV	2	21	Jesus		someone like a son of man	Normal			Unspecified
 REV	2	22	Jesus		someone like a son of man	Normal			Unspecified
 REV	2	23	Jesus		someone like a son of man	Normal			Unspecified
 REV	2	24	Jesus		someone like a son of man	Normal			Unspecified
-REV	2	25	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	26	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	27	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	28	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	2	29	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	1	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	2	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	3	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	4	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	5	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	2	25	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	26	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	27	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	28	Jesus		someone like a son of man	Normal			EntireVerse
+REV	2	29	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	1	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	2	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	3	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	4	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	5	Jesus		someone like a son of man	Normal			EntireVerse
 REV	3	6	Jesus		someone like a son of man	Normal			StartOfVerse
 REV	3	7	Jesus		someone like a son of man	Normal			Unspecified
-REV	3	8	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	9	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	10	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	11	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	12	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	3	8	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	9	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	10	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	11	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	12	Jesus		someone like a son of man	Normal			EntireVerse
 REV	3	13	Jesus		someone like a son of man	Normal			StartOfVerse
 REV	3	14	Jesus		someone like a son of man	Normal			Unspecified
-REV	3	15	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	16	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	17	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	18	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	19	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	20	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	21	Jesus		someone like a son of man	Implicit			EntireVerse
-REV	3	22	Jesus		someone like a son of man	Implicit			EntireVerse
+REV	3	15	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	16	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	17	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	18	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	19	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	20	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	21	Jesus		someone like a son of man	Normal			EntireVerse
+REV	3	22	Jesus		someone like a son of man	Normal			EntireVerse
 REV	4	1	Jesus		voice like a trumpet	Normal			EndOfVerse
 REV	4	8	living creature, first/living creature, second/living creature, third/living creature, fourth		four living creatures	Normal			EndOfVerse
-REV	4	11	twenty-four elders			Implicit			EntireVerse
+REV	4	11	twenty-four elders			Normal			EntireVerse
 REV	5	2	angel, powerful	loud		Normal			EndOfVerse
 REV	5	5	elders, one of the			Normal			EndOfVerse
 REV	5	9	living creature, first/living creature, second/living creature, third/living creature, fourth/twenty-four elders	singing	four living creatures/twenty-four elders	Normal			EndOfVerse
-REV	5	10	living creature, first/living creature, second/living creature, third/living creature, fourth/twenty-four elders	singing	four living creatures/twenty-four elders	Implicit			EntireVerse
+REV	5	10	living creature, first/living creature, second/living creature, third/living creature, fourth/twenty-four elders	singing	four living creatures/twenty-four elders	Normal			EntireVerse
 REV	5	12	angels, many	singing		Normal			EndOfVerse
 REV	5	13	every created thing	singing		Normal			EndOfVerse
 REV	5	14	living creature, first/living creature, second/living creature, third/living creature, fourth		four living creatures	Normal			ContainedWithinVerse
@@ -20763,7 +20759,7 @@ REV	6	7	living creature, fourth			Normal			EndOfVerse
 REV	6	10	souls of those killed for word of God			Normal			EndOfVerse
 REV	6	11	reply to the slain believers (in vision)			Indirect			
 REV	6	16	kings, princes, generals, rich, powerful, slave and free	crying		Normal			EndOfVerse
-REV	6	17	kings, princes, generals, rich, powerful, slave and free	crying		Implicit			EntireVerse
+REV	6	17	kings, princes, generals, rich, powerful, slave and free	crying		Normal			EntireVerse
 REV	7	3	angel standing in sun		angel from the rising sun with seal of living God	Normal			Unspecified
 REV	7	5	voice in heaven			Potential			
 REV	7	6	voice in heaven			Potential			
@@ -20788,16 +20784,16 @@ REV	10	8	voice from heaven (God?)		voice from heaven	Normal	God		EndOfVerse
 REV	10	9	angel standing on sea and land			Normal			EndOfVerse
 REV	10	11	angel standing on sea and land			Normal			EndOfVerse
 REV	11	1	angel or messenger (Greek variant: someone speaking to John)			Normal			EndOfVerse
-REV	11	2	angel or messenger (Greek variant: someone speaking to John)			Implicit			EntireVerse
-REV	11	3	angel or messenger (Greek variant: someone speaking to John)			Implicit			EntireVerse
+REV	11	2	angel or messenger (Greek variant: someone speaking to John)			Normal			EntireVerse
+REV	11	3	angel or messenger (Greek variant: someone speaking to John)			Normal			EntireVerse
 REV	11	12	voice from heaven (God?)		voice from heaven, loud	Normal	God		ContainedWithinVerse
 REV	11	15	voices in heaven, loud			Normal			EndOfVerse
 REV	11	17	twenty-four elders			Normal			EndOfVerse
-REV	11	18	twenty-four elders			Implicit			EntireVerse
+REV	11	18	twenty-four elders			Normal			EntireVerse
 REV	11	19	narrator-REV			Quotation			Unspecified
 REV	12	10	voice in heaven, loud			Normal			EndOfVerse
-REV	12	11	voice in heaven, loud			Implicit			EntireVerse
-REV	12	12	voice in heaven, loud			Implicit			EntireVerse
+REV	12	11	voice in heaven, loud			Normal			EntireVerse
+REV	12	12	voice in heaven, loud			Normal			EntireVerse
 REV	13	3	whole earth			Indirect			
 REV	13	4	worshipers of the beast			Normal			EndOfVerse
 REV	13	9	voice in heaven			Potential			
@@ -20809,8 +20805,8 @@ REV	13	14	beast from out of the earth			Indirect
 REV	14	7	angel flying directly overhead			Normal			EndOfVerse
 REV	14	8	angel flying directly overhead, second			Normal			EndOfVerse
 REV	14	9	angel flying directly overhead, third			Normal			EndOfVerse
-REV	14	10	angel flying directly overhead, third			Implicit			EntireVerse
-REV	14	11	angel flying directly overhead, third			Implicit			EntireVerse
+REV	14	10	angel flying directly overhead, third			Normal			EntireVerse
+REV	14	11	angel flying directly overhead, third			Normal			EntireVerse
 REV	14	12	angel flying directly overhead, third			Normal			Unspecified
 REV	14	13	voice from heaven (God?)		voice from heaven	Normal	God		
 REV	14	13	Holy Spirit, the		Spirit, the	Normal			
@@ -20818,10 +20814,10 @@ REV	14	14	narrator-REV			Quotation			Unspecified
 REV	14	15	angel, coming out of temple			Normal			EndOfVerse
 REV	14	18	angel, coming out of temple, another			Normal			EndOfVerse
 REV	15	3	conquerors of beast, image & his name	singing		Normal			EndOfVerse
-REV	15	4	conquerors of beast, image & his name	singing		Implicit			EntireVerse
+REV	15	4	conquerors of beast, image & his name	singing		Normal			EntireVerse
 REV	16	1	voice from temple		voice from temple, loud	Normal			EndOfVerse
 REV	16	5	angel over waters			Normal			EndOfVerse
-REV	16	6	angel over waters			Implicit			EntireVerse
+REV	16	6	angel over waters			Normal			EntireVerse
 REV	16	7	altar			Normal			EndOfVerse
 REV	16	15	Jesus			Normal			Unspecified
 REV	16	16	narrator-REV			Quotation			Unspecified
@@ -20829,23 +20825,23 @@ REV	16	17	God		God (voice from throne)	Normal
 REV	16	17	voice from throne		loud voice out of temple, from throne	Normal			
 REV	16	17	Needs Review			Normal			
 REV	17	1	angel (one of the seven)			Normal			EndOfVerse
-REV	17	2	angel (one of the seven)			Implicit			EntireVerse
+REV	17	2	angel (one of the seven)			Normal			EntireVerse
 REV	17	5	narrator-REV			Quotation			Unspecified
 REV	17	5	inscription on forehead of Babylon			Potential			
 REV	17	7	angel (one of the seven)			Normal			EndOfVerse
-REV	17	8	angel (one of the seven)			Implicit			EntireVerse
-REV	17	9	angel (one of the seven)			Implicit			EntireVerse
-REV	17	10	angel (one of the seven)			Implicit			EntireVerse
-REV	17	11	angel (one of the seven)			Implicit			EntireVerse
-REV	17	12	angel (one of the seven)			Implicit			EntireVerse
-REV	17	13	angel (one of the seven)			Implicit			EntireVerse
-REV	17	14	angel (one of the seven)			Implicit			EntireVerse
+REV	17	8	angel (one of the seven)			Normal			EntireVerse
+REV	17	9	angel (one of the seven)			Normal			EntireVerse
+REV	17	10	angel (one of the seven)			Normal			EntireVerse
+REV	17	11	angel (one of the seven)			Normal			EntireVerse
+REV	17	12	angel (one of the seven)			Normal			EntireVerse
+REV	17	13	angel (one of the seven)			Normal			EntireVerse
+REV	17	14	angel (one of the seven)			Normal			EntireVerse
 REV	17	15	angel (one of the seven)			Normal			Unspecified
-REV	17	16	angel (one of the seven)			Implicit			EntireVerse
-REV	17	17	angel (one of the seven)			Implicit			EntireVerse
-REV	17	18	angel (one of the seven)			Implicit			EntireVerse
+REV	17	16	angel (one of the seven)			Normal			EntireVerse
+REV	17	17	angel (one of the seven)			Normal			EntireVerse
+REV	17	18	angel (one of the seven)			Normal			EntireVerse
 REV	18	2	angel, another, coming down from heaven	shouting		Normal			EndOfVerse
-REV	18	3	angel, another, coming down from heaven	shouting		Implicit			EntireVerse
+REV	18	3	angel, another, coming down from heaven	shouting		Normal			EntireVerse
 REV	18	4	voice from heaven, another			Normal			EndOfVerse
 REV	18	5	voice from heaven, another			Implicit			
 REV	18	6	voice from heaven, another			Implicit			
@@ -20875,16 +20871,16 @@ REV	18	20	voice from heaven, another			Normal
 # ESV and ISV and FCBH says this is the most common way they see it in the vernacular.
 REV	18	20	sea captains, seafarers, sailors			Normal			
 REV	18	21	angel, powerful			Normal			EndOfVerse
-REV	18	22	angel, powerful			Implicit			EntireVerse
-REV	18	23	angel, powerful			Implicit			EntireVerse
-REV	18	24	angel, powerful			Implicit			EntireVerse
+REV	18	22	angel, powerful			Normal			EntireVerse
+REV	18	23	angel, powerful			Normal			EntireVerse
+REV	18	24	angel, powerful			Normal			EntireVerse
 REV	19	1	voice of great crowd in heaven, loud	shouting		Normal			EndOfVerse
-REV	19	2	voice of great crowd in heaven, loud	shouting		Implicit			EntireVerse
+REV	19	2	voice of great crowd in heaven, loud	shouting		Normal			EntireVerse
 REV	19	3	voice of great crowd in heaven, loud	shouting		Normal			EndOfVerse
 REV	19	4	twenty-four elders/living creature, first/living creature, second/living creature, third/living creature, fourth		twenty-four elders/four living creatures	Normal			Unspecified
 REV	19	5	voice from throne			Normal			Unspecified
 REV	19	6	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Normal			EndOfVerse
-REV	19	7	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Implicit			EntireVerse
+REV	19	7	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Normal			EntireVerse
 REV	19	8	voice of great crowd, like roar of many waters, loud thunderclaps	shouting		Potential			
 REV	19	9	angel (one of the seven)			Normal			Unspecified
 REV	19	10	angel (one of the seven)			Normal			ContainedWithinVerse
@@ -20894,18 +20890,18 @@ REV	19	13	narrator-REV			Quotation			Unspecified
 REV	19	15	scripture			Quotation			Unspecified
 REV	19	16	narrator-REV			Quotation			Unspecified
 REV	19	17	angel standing in sun			Normal			EndOfVerse
-REV	19	18	angel standing in sun			Implicit			EntireVerse
+REV	19	18	angel standing in sun			Normal			EntireVerse
 REV	21	3	voice from throne		voice from throne, loud	Normal			EndOfVerse
-REV	21	4	voice from throne		voice from throne, loud	Implicit			EntireVerse
+REV	21	4	voice from throne		voice from throne, loud	Normal			EntireVerse
 REV	21	5	God		one seated on throne (God)	Normal			Unspecified
 REV	21	6	God		one seated on throne (God)	Normal			Unspecified
-REV	21	7	God		one seated on throne (God)	Implicit			EntireVerse
+REV	21	7	God		one seated on throne (God)	Normal			EntireVerse
 REV	21	8	God		one seated on throne (God)	Normal			Unspecified
 REV	21	9	angel (one of the seven)			Normal			EndOfVerse
 REV	22	6	angel (one of the seven)			Normal			Unspecified
 # Based on the words spoken, v. 7 must be Jesus; however, since he is not introduced explicitly,
 # some translations may have the angel continue to speak, conveying a message from Jesus.
-REV	22	7	Jesus			Implicit			EntireVerse
+REV	22	7	Jesus			Normal			EntireVerse
 REV	22	7	angel (one of the seven)			Alternate			
 REV	22	7	Needs Review			Alternate			
 REV	22	9	angel (one of the seven)			Normal			Unspecified
@@ -20915,7 +20911,7 @@ REV	22	9	angel (one of the seven)			Normal			Unspecified
 REV	22	10	angel (one of the seven)			Normal			Unspecified
 REV	22	10	Jesus			Rare			
 REV	22	10	Needs Review			Rare			
-REV	22	11	angel (one of the seven)			Implicit			EntireVerse
+REV	22	11	angel (one of the seven)			Normal			EntireVerse
 REV	22	11	Jesus			Alternate			
 REV	22	11	Needs Review			Alternate			
 # Based on the words spoken, vv. 12-13 must be Jesus; however, since he is not introduced
@@ -20924,14 +20920,15 @@ REV	22	11	Needs Review			Alternate
 REV	22	12	Jesus			Normal			Unspecified
 REV	22	12	angel (one of the seven)			Rare			
 REV	22	12	Needs Review			Rare			
-REV	22	13	Jesus			Implicit			EntireVerse
+REV	22	13	Jesus			Normal			EntireVerse
 REV	22	13	angel (one of the seven)			Alternate			
 REV	22	13	Needs Review			Alternate			
 REV	22	14	Jesus			Normal			Unspecified
 REV	22	15	Jesus			Normal			Unspecified
-REV	22	16	Jesus			Implicit			EntireVerse
+REV	22	16	Jesus			Normal			EntireVerse
 REV	22	17	him who hears			Normal			
 REV	22	17	Holy Spirit, the/bride, the (referring to the Church)		Holy Spirit and the bride	Normal			
 REV	22	18	narrator-REV			Potential			
 REV	22	19	narrator-REV			Potential			
 REV	22	20	Jesus			Normal			ContainedWithinVerse
+

--- a/GlyssenCharacters/Resources/CharacterVerse.txt
+++ b/GlyssenCharacters/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	168
+Control File Version	169
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage	Quote Position
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5
 GEN	1	3	God		God (Yahweh)	Normal			ContainedWithinVerse
@@ -83,26 +83,26 @@ GEN	8	17	God		God (Yahweh)	Normal			EntireVerse
 GEN	8	21	God	said in his heart	God (Yahweh)	Normal			Unspecified
 GEN	8	22	God		God (Yahweh)	Normal			Unspecified
 GEN	9	1	God		God (Yahweh)	Normal			EndOfVerse
-GEN	9	2	God		God (Yahweh)	Implicit			
-GEN	9	3	God		God (Yahweh)	Implicit			
-GEN	9	4	God		God (Yahweh)	Implicit			
-GEN	9	5	God		God (Yahweh)	Implicit			
-GEN	9	6	God		God (Yahweh)	Implicit			
-GEN	9	7	God		God (Yahweh)	Implicit			
-GEN	9	9	God		God (Yahweh)	Implicit			
-GEN	9	10	God		God (Yahweh)	Implicit			
-GEN	9	11	God		God (Yahweh)	Implicit			
+GEN	9	2	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	3	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	4	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	5	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	6	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	7	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	9	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	10	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	11	God		God (Yahweh)	Implicit			EntireVerse
 GEN	9	12	God		God (Yahweh)	Normal			Unspecified
-GEN	9	13	God		God (Yahweh)	Implicit			
-GEN	9	14	God		God (Yahweh)	Implicit			
-GEN	9	15	God		God (Yahweh)	Implicit			
-GEN	9	16	God		God (Yahweh)	Implicit			
+GEN	9	13	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	14	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	15	God		God (Yahweh)	Implicit			EntireVerse
+GEN	9	16	God		God (Yahweh)	Implicit			EntireVerse
 GEN	9	17	God		God (Yahweh)	Normal			Unspecified
 GEN	9	22	Ham			Rare			
 GEN	9	22	Needs Review			Potential			
 GEN	9	25	Noah			Normal			EndOfVerse
 GEN	9	26	Noah			Normal			Unspecified
-GEN	9	27	Noah			Implicit			
+GEN	9	27	Noah			Implicit			EntireVerse
 GEN	10	9	saying about Nimrod			Quotation			Unspecified
 GEN	10	9	narrator-GEN			Quotation			EndOfVerse
 GEN	11	3	men of Babel			Normal			Unspecified
@@ -110,20 +110,20 @@ GEN	11	4	men of Babel			Normal			Unspecified
 GEN	11	6	God		God (Yahweh)	Normal			EndOfVerse
 GEN	11	7	God		God (Yahweh)	Normal			EntireVerse
 GEN	12	1	God		God (Yahweh)	Normal			EndOfVerse
-GEN	12	2	God		God (Yahweh)	Implicit			
-GEN	12	3	God		God (Yahweh)	Implicit			
+GEN	12	2	God		God (Yahweh)	Implicit			EntireVerse
+GEN	12	3	God		God (Yahweh)	Implicit			EntireVerse
 GEN	12	7	God		God (Yahweh)	Normal			ContainedWithinVerse
 GEN	12	11	Abraham (Abram)			Normal			EndOfVerse
-GEN	12	12	Abraham (Abram)			Implicit			
-GEN	12	13	Abraham (Abram)			Implicit			
+GEN	12	12	Abraham (Abram)			Implicit			EntireVerse
+GEN	12	13	Abraham (Abram)			Implicit			EntireVerse
 GEN	12	18	Pharaoh (1st)		Pharaoh	Normal			EndOfVerse
 GEN	12	19	Pharaoh (1st)		Pharaoh	Normal			EntireVerse
 GEN	13	8	Abraham (Abram)			Normal			EndOfVerse
 GEN	13	9	Abraham (Abram)			Normal			EntireVerse
 GEN	13	14	God		God (Yahweh)	Normal			EndOfVerse
-GEN	13	15	God		God (Yahweh)	Implicit			
-GEN	13	16	God		God (Yahweh)	Implicit			
-GEN	13	17	God		God (Yahweh)	Implicit			
+GEN	13	15	God		God (Yahweh)	Implicit			EntireVerse
+GEN	13	16	God		God (Yahweh)	Implicit			EntireVerse
+GEN	13	17	God		God (Yahweh)	Implicit			EntireVerse
 GEN	14	4	Bera, king of Sodom/Birsha, king of Gomorrah/Shinab, king of Admah/Shemeber, king of Zeboiim/king of Bela			Indirect	Bera, king of Sodom		
 GEN	14	13	one who had escaped			Rare			
 GEN	14	13	Needs Review			Potential			
@@ -132,8 +132,8 @@ GEN	14	19	Melchizedek, king of Salem (priest of God Most High)			Normal			EndOfV
 GEN	14	20	Melchizedek, king of Salem (priest of God Most High)			Normal			StartOfVerse
 GEN	14	21	Bera, king of Sodom			Normal			EndOfVerse
 GEN	14	22	Abraham (Abram)			Normal			EndOfVerse
-GEN	14	23	Abraham (Abram)			Implicit			
-GEN	14	24	Abraham (Abram)			Implicit			
+GEN	14	23	Abraham (Abram)			Implicit			EntireVerse
+GEN	14	24	Abraham (Abram)			Implicit			EntireVerse
 GEN	15	1	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 GEN	15	2	Abraham (Abram)			Normal			EndOfVerse
 GEN	15	3	Abraham (Abram)			Normal			Unspecified
@@ -143,13 +143,13 @@ GEN	15	7	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 GEN	15	8	Abraham (Abram)			Normal			EndOfVerse
 GEN	15	9	God		God (Yahweh) (in vision)	Normal			EndOfVerse
 GEN	15	13	God		God (Yahweh) (in vision)	Normal			EndOfVerse
-GEN	15	14	God		God (Yahweh) (in vision)	Implicit			
-GEN	15	15	God		God (Yahweh) (in vision)	Implicit			
-GEN	15	16	God		God (Yahweh) (in vision)	Implicit			
+GEN	15	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	15	15	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	15	16	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 GEN	15	18	God		God (Yahweh) (in vision)	Normal			EndOfVerse
-GEN	15	19	God		God (Yahweh) (in vision)	Implicit			
-GEN	15	20	God		God (Yahweh) (in vision)	Implicit			
-GEN	15	21	God		God (Yahweh) (in vision)	Implicit			
+GEN	15	19	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	15	20	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+GEN	15	21	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 GEN	16	2	Sarah (Sarai)			Normal			ContainedWithinVerse
 GEN	16	5	Sarah (Sarai)			Normal			EndOfVerse
 GEN	16	6	Abraham (Abram)			Normal			Unspecified
@@ -161,27 +161,27 @@ GEN	16	11	Yahweh's angel			Normal	Jesus		Unspecified
 GEN	16	12	Yahweh's angel			Normal	Jesus		Unspecified
 GEN	16	13	Hagar, Sarai's maid			Normal			Unspecified
 GEN	17	1	God		God (Yahweh)	Normal			EndOfVerse
-GEN	17	2	God		God (Yahweh)	Implicit			
-GEN	17	4	God		God (Yahweh)	Implicit			
-GEN	17	5	God		God (Yahweh)	Implicit			
-GEN	17	6	God		God (Yahweh)	Implicit			
-GEN	17	7	God		God (Yahweh)	Implicit			
-GEN	17	8	God		God (Yahweh)	Implicit			
+GEN	17	2	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	4	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	5	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	6	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	7	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	8	God		God (Yahweh)	Implicit			EntireVerse
 GEN	17	9	God		God (Yahweh)	Normal			Unspecified
-GEN	17	10	God		God (Yahweh)	Implicit			
-GEN	17	11	God		God (Yahweh)	Implicit			
-GEN	17	12	God		God (Yahweh)	Implicit			
-GEN	17	13	God		God (Yahweh)	Implicit			
-GEN	17	14	God		God (Yahweh)	Implicit			
+GEN	17	10	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	11	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	12	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	13	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	14	God		God (Yahweh)	Implicit			EntireVerse
 GEN	17	15	God		God (Yahweh)	Normal			Unspecified
-GEN	17	16	God		God (Yahweh)	Implicit			
+GEN	17	16	God		God (Yahweh)	Implicit			EntireVerse
 GEN	17	17	Abraham (Abram)			Normal			Unspecified
 GEN	17	18	Abraham (Abram)			Normal			EndOfVerse
 GEN	17	19	God		God (Yahweh)	Normal			Unspecified
-GEN	17	20	God		God (Yahweh)	Implicit			
-GEN	17	21	God		God (Yahweh)	Implicit			
+GEN	17	20	God		God (Yahweh)	Implicit			EntireVerse
+GEN	17	21	God		God (Yahweh)	Implicit			EntireVerse
 GEN	18	3	Abraham (Abram)			Normal			EndOfVerse
-GEN	18	4	Abraham (Abram)			Implicit			
+GEN	18	4	Abraham (Abram)			Implicit			EntireVerse
 GEN	18	5	Abraham (Abram)			Normal			
 GEN	18	5	Needs Review			Normal			
 GEN	18	5	God			Alternate			
@@ -198,10 +198,10 @@ GEN	18	14	God		God (Yahweh)	Normal			EntireVerse
 GEN	18	15	God		God (Yahweh)	Normal			
 GEN	18	15	Sarah (Sarai) (old)			Normal			
 GEN	18	17	God		God (Yahweh)	Normal			EndOfVerse
-GEN	18	18	God		God (Yahweh)	Implicit			
-GEN	18	19	God		God (Yahweh)	Implicit			
+GEN	18	18	God		God (Yahweh)	Implicit			EntireVerse
+GEN	18	19	God		God (Yahweh)	Implicit			EntireVerse
 GEN	18	20	God		God (Yahweh)	Normal			EndOfVerse
-GEN	18	21	God		God (Yahweh)	Implicit			
+GEN	18	21	God		God (Yahweh)	Implicit			EntireVerse
 GEN	18	23	Abraham (Abram)			Normal			EndOfVerse
 GEN	18	24	Abraham (Abram)			Normal			EntireVerse
 GEN	18	25	Abraham (Abram)			Normal			EntireVerse
@@ -222,20 +222,20 @@ GEN	19	2	Lot			Normal
 GEN	19	3	angels at Sodom, two			Indirect			
 GEN	19	5	men of Sodom (wicked)			Normal			EndOfVerse
 GEN	19	7	Lot			Normal			EndOfVerse
-GEN	19	8	Lot			Implicit			
+GEN	19	8	Lot			Implicit			EntireVerse
 GEN	19	9	men of Sodom (wicked)			Normal			Unspecified
 GEN	19	12	angels at Sodom, two			Normal			EndOfVerse
-GEN	19	13	angels at Sodom, two			Implicit			
+GEN	19	13	angels at Sodom, two			Implicit			EntireVerse
 GEN	19	14	Lot			Normal			ContainedWithinVerse
 GEN	19	15	angels at Sodom, two			Normal			EndOfVerse
 GEN	19	17	angels at Sodom, two			Normal			EndOfVerse
 GEN	19	18	Lot			Normal			Unspecified
-GEN	19	19	Lot			Implicit			
-GEN	19	20	Lot			Implicit			
+GEN	19	19	Lot			Implicit			EntireVerse
+GEN	19	20	Lot			Implicit			EntireVerse
 GEN	19	21	angels at Sodom, two			Normal			Unspecified
 GEN	19	22	angels at Sodom, two			Normal			StartOfVerse
 GEN	19	31	older daughter of Lot			Normal			EndOfVerse
-GEN	19	32	older daughter of Lot			Implicit			
+GEN	19	32	older daughter of Lot			Implicit			EntireVerse
 GEN	19	34	older daughter of Lot			Normal			EndOfVerse
 GEN	20	2	Abraham (Abram)			Normal			Unspecified
 GEN	20	3	God		God (Yahweh) (in vision)	Normal			EndOfVerse
@@ -321,21 +321,21 @@ GEN	24	31	Laban			Normal			Unspecified
 GEN	24	33	Abraham's chief servant			Normal			
 GEN	24	33	Laban			Normal			
 GEN	24	34	Abraham's chief servant			Normal			EndOfVerse
-GEN	24	35	Abraham's chief servant			Implicit			
-GEN	24	36	Abraham's chief servant			Implicit			
-GEN	24	37	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	38	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	39	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	40	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	41	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	42	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	43	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	44	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	45	Abraham's chief servant			Implicit			
-GEN	24	46	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	47	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	48	Abraham's chief servant			ImplicitWithPotentialSelfQuote			
-GEN	24	49	Abraham's chief servant			Implicit			
+GEN	24	35	Abraham's chief servant			Implicit			EntireVerse
+GEN	24	36	Abraham's chief servant			Implicit			EntireVerse
+GEN	24	37	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	38	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	39	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	40	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	41	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	42	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	43	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	44	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	45	Abraham's chief servant			Implicit			EntireVerse
+GEN	24	46	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	47	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	48	Abraham's chief servant			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	24	49	Abraham's chief servant			Implicit			EntireVerse
 GEN	24	50	Laban/Bethuel, Rebekah's father			Normal	Laban		EndOfVerse
 GEN	24	51	Laban/Bethuel, Rebekah's father			Normal	Laban		EntireVerse
 GEN	24	54	Abraham's chief servant			Normal			EndOfVerse
@@ -775,34 +775,34 @@ GEN	44	15	Joseph			Normal			EndOfVerse
 GEN	44	16	Judah			Normal			Unspecified
 GEN	44	17	Joseph			Normal			Unspecified
 GEN	44	18	Judah			Normal			EndOfVerse
-GEN	44	19	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	20	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	21	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	22	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	23	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	24	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	25	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	26	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	27	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	28	Judah			Implicit			
-GEN	44	29	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	30	Judah			Implicit			
-GEN	44	31	Judah			Implicit			
-GEN	44	32	Judah			ImplicitWithPotentialSelfQuote			
-GEN	44	33	Judah			Implicit			
-GEN	44	34	Judah			Implicit			
-GEN	45	1	Joseph			Implicit			
-GEN	45	3	Joseph			Implicit			
-GEN	45	4	Joseph			Implicit			
-GEN	45	5	Joseph			Implicit			
-GEN	45	6	Joseph			Implicit			
-GEN	45	7	Joseph			Implicit			
-GEN	45	8	Joseph			Implicit			
-GEN	45	9	Joseph			ImplicitWithPotentialSelfQuote			
-GEN	45	10	Joseph			ImplicitWithPotentialSelfQuote			
-GEN	45	11	Joseph			ImplicitWithPotentialSelfQuote			
-GEN	45	12	Joseph			Implicit			
-GEN	45	13	Joseph			ImplicitWithPotentialSelfQuote			
+GEN	44	19	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	20	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	21	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	22	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	23	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	24	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	25	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	26	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	27	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	28	Judah			Implicit			EntireVerse
+GEN	44	29	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	30	Judah			Implicit			EntireVerse
+GEN	44	31	Judah			Implicit			EntireVerse
+GEN	44	32	Judah			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	44	33	Judah			Implicit			EntireVerse
+GEN	44	34	Judah			Implicit			EntireVerse
+GEN	45	1	Joseph			Implicit			EntireVerse
+GEN	45	3	Joseph			Implicit			EntireVerse
+GEN	45	4	Joseph			Implicit			EntireVerse
+GEN	45	5	Joseph			Implicit			EntireVerse
+GEN	45	6	Joseph			Implicit			EntireVerse
+GEN	45	7	Joseph			Implicit			EntireVerse
+GEN	45	8	Joseph			Implicit			EntireVerse
+GEN	45	9	Joseph			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	45	10	Joseph			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	45	11	Joseph			ImplicitWithPotentialSelfQuote			EntireVerse
+GEN	45	12	Joseph			Implicit			EntireVerse
+GEN	45	13	Joseph			ImplicitWithPotentialSelfQuote			EntireVerse
 GEN	45	16	news to Pharoah's palace			Indirect			
 GEN	45	17	Pharaoh (2nd)		Pharaoh	Normal			EndOfVerse
 GEN	45	18	Pharaoh (2nd)		Pharaoh	Normal			EntireVerse
@@ -1378,242 +1378,242 @@ EXO	24	7	Israelites			Normal			EndOfVerse
 EXO	24	8	Moses			Normal			EndOfVerse
 EXO	24	12	God		God (Yahweh)	Normal			EndOfVerse
 EXO	24	14	Moses			Normal			EndOfVerse
-EXO	25	2	God		God (Yahweh)	Implicit			
-EXO	25	3	God		God (Yahweh)	Implicit			
-EXO	25	4	God		God (Yahweh)	Implicit			
-EXO	25	5	God		God (Yahweh)	Implicit			
-EXO	25	6	God		God (Yahweh)	Implicit			
-EXO	25	7	God		God (Yahweh)	Implicit			
-EXO	25	8	God		God (Yahweh)	Implicit			
-EXO	25	9	God		God (Yahweh)	Implicit			
-EXO	25	10	God		God (Yahweh)	Implicit			
-EXO	25	11	God		God (Yahweh)	Implicit			
-EXO	25	12	God		God (Yahweh)	Implicit			
-EXO	25	13	God		God (Yahweh)	Implicit			
-EXO	25	14	God		God (Yahweh)	Implicit			
-EXO	25	15	God		God (Yahweh)	Implicit			
-EXO	25	16	God		God (Yahweh)	Implicit			
-EXO	25	17	God		God (Yahweh)	Implicit			
-EXO	25	18	God		God (Yahweh)	Implicit			
-EXO	25	19	God		God (Yahweh)	Implicit			
-EXO	25	20	God		God (Yahweh)	Implicit			
-EXO	25	21	God		God (Yahweh)	Implicit			
-EXO	25	22	God		God (Yahweh)	Implicit			
-EXO	25	23	God		God (Yahweh)	Implicit			
-EXO	25	24	God		God (Yahweh)	Implicit			
-EXO	25	25	God		God (Yahweh)	Implicit			
-EXO	25	26	God		God (Yahweh)	Implicit			
-EXO	25	27	God		God (Yahweh)	Implicit			
-EXO	25	28	God		God (Yahweh)	Implicit			
-EXO	25	29	God		God (Yahweh)	Implicit			
-EXO	25	30	God		God (Yahweh)	Implicit			
-EXO	25	31	God		God (Yahweh)	Implicit			
-EXO	25	32	God		God (Yahweh)	Implicit			
-EXO	25	33	God		God (Yahweh)	Implicit			
-EXO	25	34	God		God (Yahweh)	Implicit			
-EXO	25	35	God		God (Yahweh)	Implicit			
-EXO	25	36	God		God (Yahweh)	Implicit			
-EXO	25	37	God		God (Yahweh)	Implicit			
-EXO	25	38	God		God (Yahweh)	Implicit			
-EXO	25	39	God		God (Yahweh)	Implicit			
-EXO	25	40	God		God (Yahweh)	Implicit			
-EXO	26	1	God		God (Yahweh)	Implicit			
-EXO	26	2	God		God (Yahweh)	Implicit			
-EXO	26	3	God		God (Yahweh)	Implicit			
-EXO	26	4	God		God (Yahweh)	Implicit			
-EXO	26	5	God		God (Yahweh)	Implicit			
-EXO	26	6	God		God (Yahweh)	Implicit			
-EXO	26	7	God		God (Yahweh)	Implicit			
-EXO	26	8	God		God (Yahweh)	Implicit			
-EXO	26	9	God		God (Yahweh)	Implicit			
-EXO	26	10	God		God (Yahweh)	Implicit			
-EXO	26	11	God		God (Yahweh)	Implicit			
-EXO	26	12	God		God (Yahweh)	Implicit			
-EXO	26	13	God		God (Yahweh)	Implicit			
-EXO	26	14	God		God (Yahweh)	Implicit			
-EXO	26	15	God		God (Yahweh)	Implicit			
-EXO	26	16	God		God (Yahweh)	Implicit			
-EXO	26	17	God		God (Yahweh)	Implicit			
-EXO	26	18	God		God (Yahweh)	Implicit			
-EXO	26	19	God		God (Yahweh)	Implicit			
-EXO	26	20	God		God (Yahweh)	Implicit			
-EXO	26	21	God		God (Yahweh)	Implicit			
-EXO	26	22	God		God (Yahweh)	Implicit			
-EXO	26	23	God		God (Yahweh)	Implicit			
-EXO	26	24	God		God (Yahweh)	Implicit			
-EXO	26	25	God		God (Yahweh)	Implicit			
-EXO	26	26	God		God (Yahweh)	Implicit			
-EXO	26	27	God		God (Yahweh)	Implicit			
-EXO	26	28	God		God (Yahweh)	Implicit			
-EXO	26	29	God		God (Yahweh)	Implicit			
-EXO	26	30	God		God (Yahweh)	Implicit			
-EXO	26	31	God		God (Yahweh)	Implicit			
-EXO	26	32	God		God (Yahweh)	Implicit			
-EXO	26	33	God		God (Yahweh)	Implicit			
-EXO	26	34	God		God (Yahweh)	Implicit			
-EXO	26	35	God		God (Yahweh)	Implicit			
-EXO	26	36	God		God (Yahweh)	Implicit			
-EXO	26	37	God		God (Yahweh)	Implicit			
-EXO	27	1	God		God (Yahweh)	Implicit			
-EXO	27	2	God		God (Yahweh)	Implicit			
-EXO	27	3	God		God (Yahweh)	Implicit			
-EXO	27	4	God		God (Yahweh)	Implicit			
-EXO	27	5	God		God (Yahweh)	Implicit			
-EXO	27	6	God		God (Yahweh)	Implicit			
-EXO	27	7	God		God (Yahweh)	Implicit			
-EXO	27	8	God		God (Yahweh)	Implicit			
-EXO	27	9	God		God (Yahweh)	Implicit			
-EXO	27	10	God		God (Yahweh)	Implicit			
-EXO	27	11	God		God (Yahweh)	Implicit			
-EXO	27	12	God		God (Yahweh)	Implicit			
-EXO	27	13	God		God (Yahweh)	Implicit			
-EXO	27	14	God		God (Yahweh)	Implicit			
-EXO	27	15	God		God (Yahweh)	Implicit			
-EXO	27	16	God		God (Yahweh)	Implicit			
-EXO	27	17	God		God (Yahweh)	Implicit			
-EXO	27	18	God		God (Yahweh)	Implicit			
-EXO	27	19	God		God (Yahweh)	Implicit			
-EXO	27	20	God		God (Yahweh)	Implicit			
-EXO	27	21	God		God (Yahweh)	Implicit			
-EXO	28	1	God		God (Yahweh)	Implicit			
-EXO	28	2	God		God (Yahweh)	Implicit			
-EXO	28	3	God		God (Yahweh)	Implicit			
-EXO	28	4	God		God (Yahweh)	Implicit			
-EXO	28	5	God		God (Yahweh)	Implicit			
-EXO	28	6	God		God (Yahweh)	Implicit			
-EXO	28	7	God		God (Yahweh)	Implicit			
-EXO	28	8	God		God (Yahweh)	Implicit			
-EXO	28	9	God		God (Yahweh)	Implicit			
-EXO	28	10	God		God (Yahweh)	Implicit			
-EXO	28	11	God		God (Yahweh)	Implicit			
-EXO	28	12	God		God (Yahweh)	Implicit			
-EXO	28	13	God		God (Yahweh)	Implicit			
-EXO	28	14	God		God (Yahweh)	Implicit			
-EXO	28	15	God		God (Yahweh)	Implicit			
-EXO	28	16	God		God (Yahweh)	Implicit			
-EXO	28	17	God		God (Yahweh)	Implicit			
-EXO	28	18	God		God (Yahweh)	Implicit			
-EXO	28	19	God		God (Yahweh)	Implicit			
-EXO	28	20	God		God (Yahweh)	Implicit			
-EXO	28	21	God		God (Yahweh)	Implicit			
-EXO	28	22	God		God (Yahweh)	Implicit			
-EXO	28	23	God		God (Yahweh)	Implicit			
-EXO	28	24	God		God (Yahweh)	Implicit			
-EXO	28	25	God		God (Yahweh)	Implicit			
-EXO	28	26	God		God (Yahweh)	Implicit			
-EXO	28	27	God		God (Yahweh)	Implicit			
-EXO	28	28	God		God (Yahweh)	Implicit			
-EXO	28	29	God		God (Yahweh)	Implicit			
-EXO	28	30	God		God (Yahweh)	Implicit			
-EXO	28	31	God		God (Yahweh)	Implicit			
-EXO	28	32	God		God (Yahweh)	Implicit			
-EXO	28	33	God		God (Yahweh)	Implicit			
-EXO	28	34	God		God (Yahweh)	Implicit			
-EXO	28	35	God		God (Yahweh)	Implicit			
-EXO	28	36	God		God (Yahweh)	Implicit			
-EXO	28	37	God		God (Yahweh)	Implicit			
-EXO	28	38	God		God (Yahweh)	Implicit			
-EXO	28	39	God		God (Yahweh)	Implicit			
-EXO	28	40	God		God (Yahweh)	Implicit			
-EXO	28	41	God		God (Yahweh)	Implicit			
-EXO	28	42	God		God (Yahweh)	Implicit			
-EXO	28	43	God		God (Yahweh)	Implicit			
-EXO	29	1	God		God (Yahweh)	Implicit			
-EXO	29	2	God		God (Yahweh)	Implicit			
-EXO	29	3	God		God (Yahweh)	Implicit			
-EXO	29	4	God		God (Yahweh)	Implicit			
-EXO	29	5	God		God (Yahweh)	Implicit			
-EXO	29	6	God		God (Yahweh)	Implicit			
-EXO	29	7	God		God (Yahweh)	Implicit			
-EXO	29	8	God		God (Yahweh)	Implicit			
-EXO	29	9	God		God (Yahweh)	Implicit			
-EXO	29	10	God		God (Yahweh)	Implicit			
-EXO	29	11	God		God (Yahweh)	Implicit			
-EXO	29	12	God		God (Yahweh)	Implicit			
-EXO	29	13	God		God (Yahweh)	Implicit			
-EXO	29	14	God		God (Yahweh)	Implicit			
-EXO	29	15	God		God (Yahweh)	Implicit			
-EXO	29	16	God		God (Yahweh)	Implicit			
-EXO	29	17	God		God (Yahweh)	Implicit			
-EXO	29	18	God		God (Yahweh)	Implicit			
-EXO	29	19	God		God (Yahweh)	Implicit			
-EXO	29	20	God		God (Yahweh)	Implicit			
-EXO	29	21	God		God (Yahweh)	Implicit			
-EXO	29	22	God		God (Yahweh)	Implicit			
-EXO	29	23	God		God (Yahweh)	Implicit			
-EXO	29	24	God		God (Yahweh)	Implicit			
-EXO	29	25	God		God (Yahweh)	Implicit			
-EXO	29	26	God		God (Yahweh)	Implicit			
-EXO	29	27	God		God (Yahweh)	Implicit			
-EXO	29	28	God		God (Yahweh)	Implicit			
-EXO	29	29	God		God (Yahweh)	Implicit			
-EXO	29	30	God		God (Yahweh)	Implicit			
-EXO	29	31	God		God (Yahweh)	Implicit			
-EXO	29	32	God		God (Yahweh)	Implicit			
-EXO	29	33	God		God (Yahweh)	Implicit			
-EXO	29	34	God		God (Yahweh)	Implicit			
-EXO	29	35	God		God (Yahweh)	Implicit			
-EXO	29	36	God		God (Yahweh)	Implicit			
-EXO	29	37	God		God (Yahweh)	Implicit			
-EXO	29	38	God		God (Yahweh)	Implicit			
-EXO	29	39	God		God (Yahweh)	Implicit			
-EXO	29	40	God		God (Yahweh)	Implicit			
-EXO	29	41	God		God (Yahweh)	Implicit			
-EXO	29	42	God		God (Yahweh)	Implicit			
-EXO	29	43	God		God (Yahweh)	Implicit			
-EXO	29	44	God		God (Yahweh)	Implicit			
-EXO	29	45	God		God (Yahweh)	Implicit			
-EXO	29	46	God		God (Yahweh)	Implicit			
-EXO	30	1	God		God (Yahweh)	Implicit			
-EXO	30	2	God		God (Yahweh)	Implicit			
-EXO	30	3	God		God (Yahweh)	Implicit			
-EXO	30	4	God		God (Yahweh)	Implicit			
-EXO	30	5	God		God (Yahweh)	Implicit			
-EXO	30	6	God		God (Yahweh)	Implicit			
-EXO	30	7	God		God (Yahweh)	Implicit			
-EXO	30	8	God		God (Yahweh)	Implicit			
-EXO	30	9	God		God (Yahweh)	Implicit			
-EXO	30	10	God		God (Yahweh)	Implicit			
-EXO	30	12	God		God (Yahweh)	Implicit			
-EXO	30	13	God		God (Yahweh)	Implicit			
-EXO	30	14	God		God (Yahweh)	Implicit			
-EXO	30	15	God		God (Yahweh)	Implicit			
-EXO	30	16	God		God (Yahweh)	Implicit			
-EXO	30	18	God		God (Yahweh)	Implicit			
-EXO	30	19	God		God (Yahweh)	Implicit			
-EXO	30	20	God		God (Yahweh)	Implicit			
-EXO	30	21	God		God (Yahweh)	Implicit			
-EXO	30	23	God		God (Yahweh)	Implicit			
-EXO	30	24	God		God (Yahweh)	Implicit			
-EXO	30	25	God		God (Yahweh)	Implicit			
-EXO	30	26	God		God (Yahweh)	Implicit			
-EXO	30	27	God		God (Yahweh)	Implicit			
-EXO	30	28	God		God (Yahweh)	Implicit			
-EXO	30	29	God		God (Yahweh)	Implicit			
-EXO	30	30	God		God (Yahweh)	Implicit			
-EXO	30	31	God		God (Yahweh)	Implicit			
-EXO	30	32	God		God (Yahweh)	Implicit			
-EXO	30	33	God		God (Yahweh)	Implicit			
-EXO	30	34	God		God (Yahweh)	Implicit			
-EXO	30	35	God		God (Yahweh)	Implicit			
-EXO	30	36	God		God (Yahweh)	Implicit			
-EXO	30	37	God		God (Yahweh)	Implicit			
-EXO	30	38	God		God (Yahweh)	Implicit			
-EXO	31	2	God		God (Yahweh)	Implicit			
-EXO	31	3	God		God (Yahweh)	Implicit			
-EXO	31	4	God		God (Yahweh)	Implicit			
-EXO	31	5	God		God (Yahweh)	Implicit			
-EXO	31	6	God		God (Yahweh)	Implicit			
-EXO	31	7	God		God (Yahweh)	Implicit			
-EXO	31	8	God		God (Yahweh)	Implicit			
-EXO	31	9	God		God (Yahweh)	Implicit			
-EXO	31	10	God		God (Yahweh)	Implicit			
-EXO	31	11	God		God (Yahweh)	Implicit			
-EXO	31	13	God		God (Yahweh)	Implicit			
-EXO	31	14	God		God (Yahweh)	Implicit			
-EXO	31	15	God		God (Yahweh)	Implicit			
-EXO	31	16	God		God (Yahweh)	Implicit			
-EXO	31	17	God		God (Yahweh)	Implicit			
+EXO	25	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	17	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	22	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	24	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	25	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	27	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	28	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	30	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	31	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	32	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	33	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	35	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	36	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	37	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	38	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	39	God		God (Yahweh)	Implicit			EntireVerse
+EXO	25	40	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	1	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	17	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	22	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	24	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	25	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	27	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	28	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	30	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	31	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	32	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	33	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	35	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	36	God		God (Yahweh)	Implicit			EntireVerse
+EXO	26	37	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	1	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	17	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	27	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	1	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	17	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	22	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	24	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	25	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	27	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	28	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	30	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	31	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	32	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	33	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	35	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	36	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	37	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	38	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	39	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	40	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	41	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	42	God		God (Yahweh)	Implicit			EntireVerse
+EXO	28	43	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	1	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	17	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	22	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	24	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	25	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	27	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	28	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	30	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	31	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	32	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	33	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	35	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	36	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	37	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	38	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	39	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	40	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	41	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	42	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	43	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	44	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	45	God		God (Yahweh)	Implicit			EntireVerse
+EXO	29	46	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	1	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	12	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	18	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	19	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	20	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	21	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	23	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	24	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	25	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	26	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	27	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	28	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	29	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	30	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	31	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	32	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	33	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	34	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	35	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	36	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	37	God		God (Yahweh)	Implicit			EntireVerse
+EXO	30	38	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	2	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	3	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	4	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	5	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	6	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	7	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	8	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	9	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	10	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	11	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	13	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	14	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	15	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	16	God		God (Yahweh)	Implicit			EntireVerse
+EXO	31	17	God		God (Yahweh)	Implicit			EntireVerse
 EXO	32	1	Israelites			Normal			EndOfVerse
 EXO	32	2	Aaron			Normal			EndOfVerse
 EXO	32	4	Israelites			Normal			EndOfVerse
@@ -1623,7 +1623,7 @@ EXO	32	7	God		God (Yahweh)	Normal			EndOfVerse
 # should normally be spoken by God.
 EXO	32	8	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EXO	32	9	God		God (Yahweh)	Normal			Unspecified
-EXO	32	10	God		God (Yahweh)	Implicit			
+EXO	32	10	God		God (Yahweh)	Implicit			EntireVerse
 EXO	32	11	Moses			Normal			EndOfVerse
 EXO	32	12	Moses			Normal			EntireVerse
 EXO	32	13	Moses			Normal			EntireVerse
@@ -1734,173 +1734,173 @@ EXO	40	15	God		God (Yahweh)	Normal			EntireVerse
 # it properly if explicit quotes are used in the text. The reference text will have them set
 # explicitly according to FCBH's interpretation, but the scripter can look at these places and
 # choose to assign them to narrator if that is preferable.
-LEV	1	2	God		God (Yahweh)	Implicit			
-LEV	1	3	God		God (Yahweh)	Implicit			
-LEV	1	4	God		God (Yahweh)	Implicit			
-LEV	1	5	God		God (Yahweh)	Implicit			
-LEV	1	6	God		God (Yahweh)	Implicit			
-LEV	1	7	God		God (Yahweh)	Implicit			
-LEV	1	8	God		God (Yahweh)	Implicit			
-LEV	1	9	God		God (Yahweh)	Implicit			
-LEV	1	10	God		God (Yahweh)	Implicit			
-LEV	1	11	God		God (Yahweh)	Implicit			
-LEV	1	12	God		God (Yahweh)	Implicit			
-LEV	1	13	God		God (Yahweh)	Implicit			
-LEV	1	14	God		God (Yahweh)	Implicit			
-LEV	1	15	God		God (Yahweh)	Implicit			
-LEV	1	16	God		God (Yahweh)	Implicit			
-LEV	1	17	God		God (Yahweh)	Implicit			
-LEV	2	1	God		God (Yahweh)	Implicit			
-LEV	2	2	God		God (Yahweh)	Implicit			
-LEV	2	3	God		God (Yahweh)	Implicit			
-LEV	2	4	God		God (Yahweh)	Implicit			
-LEV	2	5	God		God (Yahweh)	Implicit			
-LEV	2	6	God		God (Yahweh)	Implicit			
-LEV	2	7	God		God (Yahweh)	Implicit			
-LEV	2	8	God		God (Yahweh)	Implicit			
-LEV	2	9	God		God (Yahweh)	Implicit			
-LEV	2	10	God		God (Yahweh)	Implicit			
-LEV	2	11	God		God (Yahweh)	Implicit			
-LEV	2	12	God		God (Yahweh)	Implicit			
-LEV	2	13	God		God (Yahweh)	Implicit			
-LEV	2	14	God		God (Yahweh)	Implicit			
-LEV	2	15	God		God (Yahweh)	Implicit			
-LEV	2	16	God		God (Yahweh)	Implicit			
-LEV	3	1	God		God (Yahweh)	Implicit			
-LEV	3	2	God		God (Yahweh)	Implicit			
-LEV	3	3	God		God (Yahweh)	Implicit			
-LEV	3	4	God		God (Yahweh)	Implicit			
-LEV	3	5	God		God (Yahweh)	Implicit			
-LEV	3	6	God		God (Yahweh)	Implicit			
-LEV	3	7	God		God (Yahweh)	Implicit			
-LEV	3	8	God		God (Yahweh)	Implicit			
-LEV	3	9	God		God (Yahweh)	Implicit			
-LEV	3	10	God		God (Yahweh)	Implicit			
-LEV	3	11	God		God (Yahweh)	Implicit			
-LEV	3	12	God		God (Yahweh)	Implicit			
-LEV	3	13	God		God (Yahweh)	Implicit			
-LEV	3	14	God		God (Yahweh)	Implicit			
-LEV	3	15	God		God (Yahweh)	Implicit			
-LEV	3	16	God		God (Yahweh)	Implicit			
-LEV	3	17	God		God (Yahweh)	Implicit			
-LEV	4	2	God		God (Yahweh)	Implicit			
-LEV	4	3	God		God (Yahweh)	Implicit			
-LEV	4	4	God		God (Yahweh)	Implicit			
-LEV	4	5	God		God (Yahweh)	Implicit			
-LEV	4	6	God		God (Yahweh)	Implicit			
-LEV	4	7	God		God (Yahweh)	Implicit			
-LEV	4	8	God		God (Yahweh)	Implicit			
-LEV	4	9	God		God (Yahweh)	Implicit			
-LEV	4	10	God		God (Yahweh)	Implicit			
-LEV	4	11	God		God (Yahweh)	Implicit			
-LEV	4	12	God		God (Yahweh)	Implicit			
-LEV	4	13	God		God (Yahweh)	Implicit			
-LEV	4	14	God		God (Yahweh)	Implicit			
-LEV	4	15	God		God (Yahweh)	Implicit			
-LEV	4	16	God		God (Yahweh)	Implicit			
-LEV	4	17	God		God (Yahweh)	Implicit			
-LEV	4	18	God		God (Yahweh)	Implicit			
-LEV	4	19	God		God (Yahweh)	Implicit			
-LEV	4	20	God		God (Yahweh)	Implicit			
-LEV	4	21	God		God (Yahweh)	Implicit			
-LEV	4	22	God		God (Yahweh)	Implicit			
-LEV	4	23	God		God (Yahweh)	Implicit			
-LEV	4	24	God		God (Yahweh)	Implicit			
-LEV	4	25	God		God (Yahweh)	Implicit			
-LEV	4	26	God		God (Yahweh)	Implicit			
-LEV	4	27	God		God (Yahweh)	Implicit			
-LEV	4	28	God		God (Yahweh)	Implicit			
-LEV	4	29	God		God (Yahweh)	Implicit			
-LEV	4	30	God		God (Yahweh)	Implicit			
-LEV	4	31	God		God (Yahweh)	Implicit			
-LEV	4	32	God		God (Yahweh)	Implicit			
-LEV	4	33	God		God (Yahweh)	Implicit			
-LEV	4	34	God		God (Yahweh)	Implicit			
-LEV	4	35	God		God (Yahweh)	Implicit			
-LEV	5	1	God		God (Yahweh)	Implicit			
-LEV	5	2	God		God (Yahweh)	Implicit			
-LEV	5	3	God		God (Yahweh)	Implicit			
-LEV	5	4	God		God (Yahweh)	Implicit			
-LEV	5	5	God		God (Yahweh)	Implicit			
-LEV	5	6	God		God (Yahweh)	Implicit			
-LEV	5	7	God		God (Yahweh)	Implicit			
-LEV	5	8	God		God (Yahweh)	Implicit			
-LEV	5	9	God		God (Yahweh)	Implicit			
-LEV	5	10	God		God (Yahweh)	Implicit			
-LEV	5	11	God		God (Yahweh)	Implicit			
-LEV	5	12	God		God (Yahweh)	Implicit			
-LEV	5	13	God		God (Yahweh)	Implicit			
-LEV	5	15	God		God (Yahweh)	Implicit			
-LEV	5	16	God		God (Yahweh)	Implicit			
-LEV	5	17	God		God (Yahweh)	Implicit			
-LEV	5	18	God		God (Yahweh)	Implicit			
-LEV	5	19	God		God (Yahweh)	Implicit			
-LEV	6	2	God		God (Yahweh)	Implicit			
-LEV	6	3	God		God (Yahweh)	Implicit			
-LEV	6	4	God		God (Yahweh)	Implicit			
-LEV	6	5	God		God (Yahweh)	Implicit			
-LEV	6	6	God		God (Yahweh)	Implicit			
-LEV	6	7	God		God (Yahweh)	Implicit			
-LEV	6	9	God		God (Yahweh)	Implicit			
-LEV	6	10	God		God (Yahweh)	Implicit			
-LEV	6	11	God		God (Yahweh)	Implicit			
-LEV	6	12	God		God (Yahweh)	Implicit			
-LEV	6	13	God		God (Yahweh)	Implicit			
-LEV	6	14	God		God (Yahweh)	Implicit			
-LEV	6	15	God		God (Yahweh)	Implicit			
-LEV	6	16	God		God (Yahweh)	Implicit			
-LEV	6	17	God		God (Yahweh)	Implicit			
-LEV	6	18	God		God (Yahweh)	Implicit			
-LEV	6	20	God		God (Yahweh)	Implicit			
-LEV	6	21	God		God (Yahweh)	Implicit			
-LEV	6	22	God		God (Yahweh)	Implicit			
-LEV	6	23	God		God (Yahweh)	Implicit			
-LEV	6	25	God		God (Yahweh)	Implicit			
-LEV	6	26	God		God (Yahweh)	Implicit			
-LEV	6	27	God		God (Yahweh)	Implicit			
-LEV	6	28	God		God (Yahweh)	Implicit			
-LEV	6	29	God		God (Yahweh)	Implicit			
-LEV	6	30	God		God (Yahweh)	Implicit			
-LEV	7	1	God		God (Yahweh)	Implicit			
-LEV	7	2	God		God (Yahweh)	Implicit			
-LEV	7	3	God		God (Yahweh)	Implicit			
-LEV	7	4	God		God (Yahweh)	Implicit			
-LEV	7	5	God		God (Yahweh)	Implicit			
-LEV	7	6	God		God (Yahweh)	Implicit			
-LEV	7	7	God		God (Yahweh)	Implicit			
-LEV	7	8	God		God (Yahweh)	Implicit			
-LEV	7	9	God		God (Yahweh)	Implicit			
-LEV	7	10	God		God (Yahweh)	Implicit			
-LEV	7	11	God		God (Yahweh)	Implicit			
-LEV	7	12	God		God (Yahweh)	Implicit			
-LEV	7	13	God		God (Yahweh)	Implicit			
-LEV	7	14	God		God (Yahweh)	Implicit			
-LEV	7	15	God		God (Yahweh)	Implicit			
-LEV	7	16	God		God (Yahweh)	Implicit			
-LEV	7	17	God		God (Yahweh)	Implicit			
-LEV	7	18	God		God (Yahweh)	Implicit			
-LEV	7	19	God		God (Yahweh)	Implicit			
-LEV	7	20	God		God (Yahweh)	Implicit			
-LEV	7	21	God		God (Yahweh)	Implicit			
-LEV	7	23	God		God (Yahweh)	Implicit			
-LEV	7	24	God		God (Yahweh)	Implicit			
-LEV	7	25	God		God (Yahweh)	Implicit			
-LEV	7	26	God		God (Yahweh)	Implicit			
-LEV	7	27	God		God (Yahweh)	Implicit			
-LEV	7	29	God		God (Yahweh)	Implicit			
-LEV	7	30	God		God (Yahweh)	Implicit			
-LEV	7	31	God		God (Yahweh)	Implicit			
-LEV	7	32	God		God (Yahweh)	Implicit			
-LEV	7	33	God		God (Yahweh)	Implicit			
-LEV	7	34	God		God (Yahweh)	Implicit			
-LEV	8	2	God		God (Yahweh)	Implicit			
-LEV	8	3	God		God (Yahweh)	Implicit			
+LEV	1	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	1	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	1	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	2	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	1	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	3	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	4	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	1	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	5	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	6	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	1	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	7	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	8	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	8	3	God		God (Yahweh)	Implicit			EntireVerse
 LEV	8	5	Moses			Normal			EndOfVerse
 LEV	8	31	Moses			Normal			EndOfVerse
-LEV	8	32	Moses			Implicit			
-LEV	8	33	Moses			Implicit			
-LEV	8	34	Moses			Implicit			
-LEV	8	35	Moses			Implicit			
+LEV	8	32	Moses			Implicit			EntireVerse
+LEV	8	33	Moses			Implicit			EntireVerse
+LEV	8	34	Moses			Implicit			EntireVerse
+LEV	8	35	Moses			Implicit			EntireVerse
 LEV	9	2	Moses			Normal			Unspecified
 LEV	9	3	Moses			Normal			EntireVerse
 LEV	9	4	Moses			Normal			EntireVerse
@@ -1921,696 +1921,696 @@ LEV	10	16	Moses			Indirect
 LEV	10	17	Moses			Normal			EntireVerse
 LEV	10	18	Moses			Normal			EntireVerse
 LEV	10	19	Aaron			Normal			EndOfVerse
-LEV	11	2	God		God (Yahweh)	Implicit			
-LEV	11	3	God		God (Yahweh)	Implicit			
-LEV	11	4	God		God (Yahweh)	Implicit			
-LEV	11	5	God		God (Yahweh)	Implicit			
-LEV	11	6	God		God (Yahweh)	Implicit			
-LEV	11	7	God		God (Yahweh)	Implicit			
-LEV	11	8	God		God (Yahweh)	Implicit			
-LEV	11	9	God		God (Yahweh)	Implicit			
-LEV	11	10	God		God (Yahweh)	Implicit			
-LEV	11	11	God		God (Yahweh)	Implicit			
-LEV	11	12	God		God (Yahweh)	Implicit			
-LEV	11	13	God		God (Yahweh)	Implicit			
-LEV	11	14	God		God (Yahweh)	Implicit			
-LEV	11	15	God		God (Yahweh)	Implicit			
-LEV	11	16	God		God (Yahweh)	Implicit			
-LEV	11	17	God		God (Yahweh)	Implicit			
-LEV	11	18	God		God (Yahweh)	Implicit			
-LEV	11	19	God		God (Yahweh)	Implicit			
-LEV	11	20	God		God (Yahweh)	Implicit			
-LEV	11	21	God		God (Yahweh)	Implicit			
-LEV	11	22	God		God (Yahweh)	Implicit			
-LEV	11	23	God		God (Yahweh)	Implicit			
-LEV	11	24	God		God (Yahweh)	Implicit			
-LEV	11	25	God		God (Yahweh)	Implicit			
-LEV	11	26	God		God (Yahweh)	Implicit			
-LEV	11	27	God		God (Yahweh)	Implicit			
-LEV	11	28	God		God (Yahweh)	Implicit			
-LEV	11	29	God		God (Yahweh)	Implicit			
-LEV	11	30	God		God (Yahweh)	Implicit			
-LEV	11	31	God		God (Yahweh)	Implicit			
-LEV	11	32	God		God (Yahweh)	Implicit			
-LEV	11	33	God		God (Yahweh)	Implicit			
-LEV	11	34	God		God (Yahweh)	Implicit			
-LEV	11	35	God		God (Yahweh)	Implicit			
-LEV	11	36	God		God (Yahweh)	Implicit			
-LEV	11	37	God		God (Yahweh)	Implicit			
-LEV	11	38	God		God (Yahweh)	Implicit			
-LEV	11	39	God		God (Yahweh)	Implicit			
-LEV	11	40	God		God (Yahweh)	Implicit			
-LEV	11	41	God		God (Yahweh)	Implicit			
-LEV	11	42	God		God (Yahweh)	Implicit			
-LEV	11	43	God		God (Yahweh)	Implicit			
-LEV	11	44	God		God (Yahweh)	Implicit			
-LEV	11	45	God		God (Yahweh)	Implicit			
+LEV	11	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	44	God		God (Yahweh)	Implicit			EntireVerse
+LEV	11	45	God		God (Yahweh)	Implicit			EntireVerse
 LEV	11	46	God		God (Yahweh)	Potential			
 LEV	11	47	God		God (Yahweh)	Potential			
-LEV	12	2	God		God (Yahweh)	Implicit			
-LEV	12	3	God		God (Yahweh)	Implicit			
-LEV	12	4	God		God (Yahweh)	Implicit			
-LEV	12	5	God		God (Yahweh)	Implicit			
-LEV	12	6	God		God (Yahweh)	Implicit			
-LEV	12	7	God		God (Yahweh)	Implicit			
-LEV	12	8	God		God (Yahweh)	Implicit			
-LEV	13	2	God		God (Yahweh)	Implicit			
-LEV	13	3	God		God (Yahweh)	Implicit			
-LEV	13	4	God		God (Yahweh)	Implicit			
-LEV	13	5	God		God (Yahweh)	Implicit			
-LEV	13	6	God		God (Yahweh)	Implicit			
-LEV	13	7	God		God (Yahweh)	Implicit			
-LEV	13	8	God		God (Yahweh)	Implicit			
-LEV	13	9	God		God (Yahweh)	Implicit			
-LEV	13	10	God		God (Yahweh)	Implicit			
-LEV	13	11	God		God (Yahweh)	Implicit			
-LEV	13	12	God		God (Yahweh)	Implicit			
-LEV	13	13	God		God (Yahweh)	Implicit			
-LEV	13	14	God		God (Yahweh)	Implicit			
-LEV	13	15	God		God (Yahweh)	Implicit			
-LEV	13	16	God		God (Yahweh)	Implicit			
-LEV	13	17	God		God (Yahweh)	Implicit			
-LEV	13	18	God		God (Yahweh)	Implicit			
-LEV	13	19	God		God (Yahweh)	Implicit			
-LEV	13	20	God		God (Yahweh)	Implicit			
-LEV	13	21	God		God (Yahweh)	Implicit			
-LEV	13	22	God		God (Yahweh)	Implicit			
-LEV	13	23	God		God (Yahweh)	Implicit			
-LEV	13	24	God		God (Yahweh)	Implicit			
-LEV	13	25	God		God (Yahweh)	Implicit			
-LEV	13	26	God		God (Yahweh)	Implicit			
-LEV	13	27	God		God (Yahweh)	Implicit			
-LEV	13	28	God		God (Yahweh)	Implicit			
-LEV	13	29	God		God (Yahweh)	Implicit			
-LEV	13	30	God		God (Yahweh)	Implicit			
-LEV	13	31	God		God (Yahweh)	Implicit			
-LEV	13	32	God		God (Yahweh)	Implicit			
-LEV	13	33	God		God (Yahweh)	Implicit			
-LEV	13	34	God		God (Yahweh)	Implicit			
-LEV	13	35	God		God (Yahweh)	Implicit			
-LEV	13	36	God		God (Yahweh)	Implicit			
-LEV	13	37	God		God (Yahweh)	Implicit			
-LEV	13	38	God		God (Yahweh)	Implicit			
-LEV	13	39	God		God (Yahweh)	Implicit			
-LEV	13	40	God		God (Yahweh)	Implicit			
-LEV	13	41	God		God (Yahweh)	Implicit			
-LEV	13	42	God		God (Yahweh)	Implicit			
-LEV	13	43	God		God (Yahweh)	Implicit			
-LEV	13	44	God		God (Yahweh)	Implicit			
-LEV	13	45	God		God (Yahweh)	Implicit			
-LEV	13	46	God		God (Yahweh)	Implicit			
-LEV	13	47	God		God (Yahweh)	Implicit			
-LEV	13	48	God		God (Yahweh)	Implicit			
-LEV	13	49	God		God (Yahweh)	Implicit			
-LEV	13	50	God		God (Yahweh)	Implicit			
-LEV	13	51	God		God (Yahweh)	Implicit			
-LEV	13	52	God		God (Yahweh)	Implicit			
-LEV	13	53	God		God (Yahweh)	Implicit			
-LEV	13	54	God		God (Yahweh)	Implicit			
-LEV	13	55	God		God (Yahweh)	Implicit			
-LEV	13	56	God		God (Yahweh)	Implicit			
-LEV	13	57	God		God (Yahweh)	Implicit			
-LEV	13	58	God		God (Yahweh)	Implicit			
+LEV	12	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	12	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	44	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	45	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	46	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	47	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	48	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	49	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	50	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	51	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	52	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	53	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	54	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	55	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	56	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	57	God		God (Yahweh)	Implicit			EntireVerse
+LEV	13	58	God		God (Yahweh)	Implicit			EntireVerse
 LEV	13	59	God		God (Yahweh)	Potential			
-LEV	14	2	God		God (Yahweh)	Implicit			
-LEV	14	3	God		God (Yahweh)	Implicit			
-LEV	14	4	God		God (Yahweh)	Implicit			
-LEV	14	5	God		God (Yahweh)	Implicit			
-LEV	14	6	God		God (Yahweh)	Implicit			
-LEV	14	7	God		God (Yahweh)	Implicit			
-LEV	14	8	God		God (Yahweh)	Implicit			
-LEV	14	9	God		God (Yahweh)	Implicit			
-LEV	14	10	God		God (Yahweh)	Implicit			
-LEV	14	11	God		God (Yahweh)	Implicit			
-LEV	14	12	God		God (Yahweh)	Implicit			
-LEV	14	13	God		God (Yahweh)	Implicit			
-LEV	14	14	God		God (Yahweh)	Implicit			
-LEV	14	15	God		God (Yahweh)	Implicit			
-LEV	14	16	God		God (Yahweh)	Implicit			
-LEV	14	17	God		God (Yahweh)	Implicit			
-LEV	14	18	God		God (Yahweh)	Implicit			
-LEV	14	19	God		God (Yahweh)	Implicit			
-LEV	14	20	God		God (Yahweh)	Implicit			
-LEV	14	21	God		God (Yahweh)	Implicit			
-LEV	14	22	God		God (Yahweh)	Implicit			
-LEV	14	23	God		God (Yahweh)	Implicit			
-LEV	14	24	God		God (Yahweh)	Implicit			
-LEV	14	25	God		God (Yahweh)	Implicit			
-LEV	14	26	God		God (Yahweh)	Implicit			
-LEV	14	27	God		God (Yahweh)	Implicit			
-LEV	14	28	God		God (Yahweh)	Implicit			
-LEV	14	29	God		God (Yahweh)	Implicit			
-LEV	14	30	God		God (Yahweh)	Implicit			
+LEV	14	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	30	God		God (Yahweh)	Implicit			EntireVerse
 LEV	14	31	God		God (Yahweh)	Potential			
 LEV	14	32	God		God (Yahweh)	Potential			
-LEV	14	34	God		God (Yahweh)	Implicit			
-LEV	14	35	God		God (Yahweh)	Implicit			
-LEV	14	36	God		God (Yahweh)	Implicit			
-LEV	14	37	God		God (Yahweh)	Implicit			
-LEV	14	38	God		God (Yahweh)	Implicit			
-LEV	14	39	God		God (Yahweh)	Implicit			
-LEV	14	40	God		God (Yahweh)	Implicit			
-LEV	14	41	God		God (Yahweh)	Implicit			
-LEV	14	42	God		God (Yahweh)	Implicit			
-LEV	14	43	God		God (Yahweh)	Implicit			
-LEV	14	44	God		God (Yahweh)	Implicit			
-LEV	14	45	God		God (Yahweh)	Implicit			
-LEV	14	46	God		God (Yahweh)	Implicit			
-LEV	14	47	God		God (Yahweh)	Implicit			
-LEV	14	48	God		God (Yahweh)	Implicit			
-LEV	14	49	God		God (Yahweh)	Implicit			
-LEV	14	50	God		God (Yahweh)	Implicit			
-LEV	14	51	God		God (Yahweh)	Implicit			
-LEV	14	52	God		God (Yahweh)	Implicit			
-LEV	14	53	God		God (Yahweh)	Implicit			
+LEV	14	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	44	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	45	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	46	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	47	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	48	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	49	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	50	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	51	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	52	God		God (Yahweh)	Implicit			EntireVerse
+LEV	14	53	God		God (Yahweh)	Implicit			EntireVerse
 LEV	14	54	God		God (Yahweh)	Potential			
 LEV	14	55	God		God (Yahweh)	Potential			
 LEV	14	56	God		God (Yahweh)	Potential			
 LEV	14	57	God		God (Yahweh)	Potential			
-LEV	15	2	God		God (Yahweh)	Implicit			
-LEV	15	3	God		God (Yahweh)	Implicit			
-LEV	15	4	God		God (Yahweh)	Implicit			
-LEV	15	5	God		God (Yahweh)	Implicit			
-LEV	15	6	God		God (Yahweh)	Implicit			
-LEV	15	7	God		God (Yahweh)	Implicit			
-LEV	15	8	God		God (Yahweh)	Implicit			
-LEV	15	9	God		God (Yahweh)	Implicit			
-LEV	15	10	God		God (Yahweh)	Implicit			
-LEV	15	11	God		God (Yahweh)	Implicit			
-LEV	15	12	God		God (Yahweh)	Implicit			
-LEV	15	13	God		God (Yahweh)	Implicit			
-LEV	15	14	God		God (Yahweh)	Implicit			
-LEV	15	15	God		God (Yahweh)	Implicit			
-LEV	15	16	God		God (Yahweh)	Implicit			
-LEV	15	17	God		God (Yahweh)	Implicit			
-LEV	15	18	God		God (Yahweh)	Implicit			
-LEV	15	19	God		God (Yahweh)	Implicit			
-LEV	15	20	God		God (Yahweh)	Implicit			
-LEV	15	21	God		God (Yahweh)	Implicit			
-LEV	15	22	God		God (Yahweh)	Implicit			
-LEV	15	23	God		God (Yahweh)	Implicit			
-LEV	15	24	God		God (Yahweh)	Implicit			
-LEV	15	25	God		God (Yahweh)	Implicit			
-LEV	15	26	God		God (Yahweh)	Implicit			
-LEV	15	27	God		God (Yahweh)	Implicit			
-LEV	15	28	God		God (Yahweh)	Implicit			
-LEV	15	29	God		God (Yahweh)	Implicit			
-LEV	15	30	God		God (Yahweh)	Implicit			
-LEV	15	31	God		God (Yahweh)	Implicit			
+LEV	15	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	15	31	God		God (Yahweh)	Implicit			EntireVerse
 LEV	15	32	God		God (Yahweh)	Potential			
 LEV	15	33	God		God (Yahweh)	Potential			
 LEV	16	2	God		God (Yahweh)	Normal			Unspecified
-LEV	16	3	God		God (Yahweh)	Implicit			
-LEV	16	4	God		God (Yahweh)	Implicit			
-LEV	16	5	God		God (Yahweh)	Implicit			
-LEV	16	6	God		God (Yahweh)	Implicit			
-LEV	16	7	God		God (Yahweh)	Implicit			
-LEV	16	8	God		God (Yahweh)	Implicit			
-LEV	16	9	God		God (Yahweh)	Implicit			
-LEV	16	10	God		God (Yahweh)	Implicit			
-LEV	16	11	God		God (Yahweh)	Implicit			
-LEV	16	12	God		God (Yahweh)	Implicit			
-LEV	16	13	God		God (Yahweh)	Implicit			
-LEV	16	14	God		God (Yahweh)	Implicit			
-LEV	16	15	God		God (Yahweh)	Implicit			
-LEV	16	16	God		God (Yahweh)	Implicit			
-LEV	16	17	God		God (Yahweh)	Implicit			
-LEV	16	18	God		God (Yahweh)	Implicit			
-LEV	16	19	God		God (Yahweh)	Implicit			
-LEV	16	20	God		God (Yahweh)	Implicit			
-LEV	16	21	God		God (Yahweh)	Implicit			
-LEV	16	22	God		God (Yahweh)	Implicit			
-LEV	16	23	God		God (Yahweh)	Implicit			
-LEV	16	24	God		God (Yahweh)	Implicit			
-LEV	16	25	God		God (Yahweh)	Implicit			
-LEV	16	26	God		God (Yahweh)	Implicit			
-LEV	16	27	God		God (Yahweh)	Implicit			
-LEV	16	28	God		God (Yahweh)	Implicit			
-LEV	16	29	God		God (Yahweh)	Implicit			
-LEV	16	30	God		God (Yahweh)	Implicit			
-LEV	16	31	God		God (Yahweh)	Implicit			
-LEV	16	32	God		God (Yahweh)	Implicit			
-LEV	16	33	God		God (Yahweh)	Implicit			
+LEV	16	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	16	33	God		God (Yahweh)	Implicit			EntireVerse
 LEV	16	34	God		God (Yahweh)	Normal			Unspecified
-LEV	17	2	God		God (Yahweh)	Implicit			
-LEV	17	3	God		God (Yahweh)	Implicit			
-LEV	17	4	God		God (Yahweh)	Implicit			
-LEV	17	5	God		God (Yahweh)	Implicit			
-LEV	17	6	God		God (Yahweh)	Implicit			
-LEV	17	7	God		God (Yahweh)	Implicit			
-LEV	17	8	God		God (Yahweh)	Implicit			
-LEV	17	9	God		God (Yahweh)	Implicit			
-LEV	17	10	God		God (Yahweh)	Implicit			
-LEV	17	11	God		God (Yahweh)	Implicit			
-LEV	17	12	God		God (Yahweh)	Implicit			
-LEV	17	13	God		God (Yahweh)	Implicit			
-LEV	17	14	God		God (Yahweh)	Implicit			
-LEV	17	15	God		God (Yahweh)	Implicit			
-LEV	17	16	God		God (Yahweh)	Implicit			
-LEV	18	2	God		God (Yahweh)	Implicit			
-LEV	18	3	God		God (Yahweh)	Implicit			
-LEV	18	4	God		God (Yahweh)	Implicit			
-LEV	18	5	God		God (Yahweh)	Implicit			
-LEV	18	6	God		God (Yahweh)	Implicit			
-LEV	18	7	God		God (Yahweh)	Implicit			
-LEV	18	8	God		God (Yahweh)	Implicit			
-LEV	18	9	God		God (Yahweh)	Implicit			
-LEV	18	10	God		God (Yahweh)	Implicit			
-LEV	18	11	God		God (Yahweh)	Implicit			
-LEV	18	12	God		God (Yahweh)	Implicit			
-LEV	18	13	God		God (Yahweh)	Implicit			
-LEV	18	14	God		God (Yahweh)	Implicit			
-LEV	18	15	God		God (Yahweh)	Implicit			
-LEV	18	16	God		God (Yahweh)	Implicit			
-LEV	18	17	God		God (Yahweh)	Implicit			
-LEV	18	18	God		God (Yahweh)	Implicit			
-LEV	18	19	God		God (Yahweh)	Implicit			
-LEV	18	20	God		God (Yahweh)	Implicit			
-LEV	18	21	God		God (Yahweh)	Implicit			
-LEV	18	22	God		God (Yahweh)	Implicit			
-LEV	18	23	God		God (Yahweh)	Implicit			
-LEV	18	24	God		God (Yahweh)	Implicit			
-LEV	18	25	God		God (Yahweh)	Implicit			
-LEV	18	26	God		God (Yahweh)	Implicit			
-LEV	18	27	God		God (Yahweh)	Implicit			
-LEV	18	28	God		God (Yahweh)	Implicit			
-LEV	18	29	God		God (Yahweh)	Implicit			
-LEV	18	30	God		God (Yahweh)	Implicit			
-LEV	19	2	God		God (Yahweh)	Implicit			
-LEV	19	3	God		God (Yahweh)	Implicit			
-LEV	19	4	God		God (Yahweh)	Implicit			
-LEV	19	5	God		God (Yahweh)	Implicit			
-LEV	19	6	God		God (Yahweh)	Implicit			
-LEV	19	7	God		God (Yahweh)	Implicit			
-LEV	19	8	God		God (Yahweh)	Implicit			
-LEV	19	9	God		God (Yahweh)	Implicit			
-LEV	19	10	God		God (Yahweh)	Implicit			
-LEV	19	11	God		God (Yahweh)	Implicit			
-LEV	19	12	God		God (Yahweh)	Implicit			
-LEV	19	13	God		God (Yahweh)	Implicit			
-LEV	19	14	God		God (Yahweh)	Implicit			
-LEV	19	15	God		God (Yahweh)	Implicit			
-LEV	19	16	God		God (Yahweh)	Implicit			
-LEV	19	17	God		God (Yahweh)	Implicit			
-LEV	19	18	God		God (Yahweh)	Implicit			
-LEV	19	19	God		God (Yahweh)	Implicit			
-LEV	19	20	God		God (Yahweh)	Implicit			
-LEV	19	21	God		God (Yahweh)	Implicit			
-LEV	19	22	God		God (Yahweh)	Implicit			
-LEV	19	23	God		God (Yahweh)	Implicit			
-LEV	19	24	God		God (Yahweh)	Implicit			
-LEV	19	25	God		God (Yahweh)	Implicit			
-LEV	19	26	God		God (Yahweh)	Implicit			
-LEV	19	27	God		God (Yahweh)	Implicit			
-LEV	19	28	God		God (Yahweh)	Implicit			
-LEV	19	29	God		God (Yahweh)	Implicit			
-LEV	19	30	God		God (Yahweh)	Implicit			
-LEV	19	31	God		God (Yahweh)	Implicit			
-LEV	19	32	God		God (Yahweh)	Implicit			
-LEV	19	33	God		God (Yahweh)	Implicit			
-LEV	19	34	God		God (Yahweh)	Implicit			
-LEV	19	35	God		God (Yahweh)	Implicit			
-LEV	19	36	God		God (Yahweh)	Implicit			
-LEV	19	37	God		God (Yahweh)	Implicit			
-LEV	20	2	God		God (Yahweh)	Implicit			
-LEV	20	3	God		God (Yahweh)	Implicit			
-LEV	20	4	God		God (Yahweh)	Implicit			
-LEV	20	5	God		God (Yahweh)	Implicit			
-LEV	20	6	God		God (Yahweh)	Implicit			
-LEV	20	7	God		God (Yahweh)	Implicit			
-LEV	20	8	God		God (Yahweh)	Implicit			
-LEV	20	9	God		God (Yahweh)	Implicit			
-LEV	20	10	God		God (Yahweh)	Implicit			
-LEV	20	11	God		God (Yahweh)	Implicit			
-LEV	20	12	God		God (Yahweh)	Implicit			
-LEV	20	13	God		God (Yahweh)	Implicit			
-LEV	20	14	God		God (Yahweh)	Implicit			
-LEV	20	15	God		God (Yahweh)	Implicit			
-LEV	20	16	God		God (Yahweh)	Implicit			
-LEV	20	17	God		God (Yahweh)	Implicit			
-LEV	20	18	God		God (Yahweh)	Implicit			
-LEV	20	19	God		God (Yahweh)	Implicit			
-LEV	20	20	God		God (Yahweh)	Implicit			
-LEV	20	21	God		God (Yahweh)	Implicit			
-LEV	20	22	God		God (Yahweh)	Implicit			
-LEV	20	23	God		God (Yahweh)	Implicit			
-LEV	20	24	God		God (Yahweh)	Implicit			
-LEV	20	25	God		God (Yahweh)	Implicit			
-LEV	20	26	God		God (Yahweh)	Implicit			
-LEV	20	27	God		God (Yahweh)	Implicit			
+LEV	17	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	17	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	18	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	19	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	20	27	God		God (Yahweh)	Implicit			EntireVerse
 LEV	21	1	God		God (Yahweh)	Normal			EndOfVerse
-LEV	21	2	God		God (Yahweh)	Implicit			
-LEV	21	3	God		God (Yahweh)	Implicit			
-LEV	21	4	God		God (Yahweh)	Implicit			
-LEV	21	5	God		God (Yahweh)	Implicit			
-LEV	21	6	God		God (Yahweh)	Implicit			
-LEV	21	7	God		God (Yahweh)	Implicit			
-LEV	21	8	God		God (Yahweh)	Implicit			
-LEV	21	9	God		God (Yahweh)	Implicit			
-LEV	21	10	God		God (Yahweh)	Implicit			
-LEV	21	11	God		God (Yahweh)	Implicit			
-LEV	21	12	God		God (Yahweh)	Implicit			
-LEV	21	13	God		God (Yahweh)	Implicit			
-LEV	21	14	God		God (Yahweh)	Implicit			
-LEV	21	15	God		God (Yahweh)	Implicit			
-LEV	21	17	God		God (Yahweh)	Implicit			
-LEV	21	18	God		God (Yahweh)	Implicit			
-LEV	21	19	God		God (Yahweh)	Implicit			
-LEV	21	20	God		God (Yahweh)	Implicit			
-LEV	21	21	God		God (Yahweh)	Implicit			
-LEV	21	22	God		God (Yahweh)	Implicit			
-LEV	21	23	God		God (Yahweh)	Implicit			
-LEV	22	2	God		God (Yahweh)	Implicit			
-LEV	22	3	God		God (Yahweh)	Implicit			
-LEV	22	4	God		God (Yahweh)	Implicit			
-LEV	22	5	God		God (Yahweh)	Implicit			
-LEV	22	6	God		God (Yahweh)	Implicit			
-LEV	22	7	God		God (Yahweh)	Implicit			
-LEV	22	8	God		God (Yahweh)	Implicit			
-LEV	22	9	God		God (Yahweh)	Implicit			
-LEV	22	10	God		God (Yahweh)	Implicit			
-LEV	22	11	God		God (Yahweh)	Implicit			
-LEV	22	12	God		God (Yahweh)	Implicit			
-LEV	22	13	God		God (Yahweh)	Implicit			
-LEV	22	14	God		God (Yahweh)	Implicit			
-LEV	22	15	God		God (Yahweh)	Implicit			
-LEV	22	16	God		God (Yahweh)	Implicit			
-LEV	22	18	God		God (Yahweh)	Implicit			
-LEV	22	19	God		God (Yahweh)	Implicit			
-LEV	22	20	God		God (Yahweh)	Implicit			
-LEV	22	21	God		God (Yahweh)	Implicit			
-LEV	22	22	God		God (Yahweh)	Implicit			
-LEV	22	23	God		God (Yahweh)	Implicit			
-LEV	22	24	God		God (Yahweh)	Implicit			
-LEV	22	25	God		God (Yahweh)	Implicit			
-LEV	22	27	God		God (Yahweh)	Implicit			
-LEV	22	28	God		God (Yahweh)	Implicit			
-LEV	22	29	God		God (Yahweh)	Implicit			
-LEV	22	30	God		God (Yahweh)	Implicit			
-LEV	22	31	God		God (Yahweh)	Implicit			
-LEV	22	32	God		God (Yahweh)	Implicit			
-LEV	22	33	God		God (Yahweh)	Implicit			
-LEV	23	2	God		God (Yahweh)	Implicit			
-LEV	23	3	God		God (Yahweh)	Implicit			
-LEV	23	4	God		God (Yahweh)	Implicit			
-LEV	23	5	God		God (Yahweh)	Implicit			
-LEV	23	6	God		God (Yahweh)	Implicit			
-LEV	23	7	God		God (Yahweh)	Implicit			
-LEV	23	8	God		God (Yahweh)	Implicit			
-LEV	23	10	God		God (Yahweh)	Implicit			
-LEV	23	11	God		God (Yahweh)	Implicit			
-LEV	23	12	God		God (Yahweh)	Implicit			
-LEV	23	13	God		God (Yahweh)	Implicit			
-LEV	23	14	God		God (Yahweh)	Implicit			
-LEV	23	15	God		God (Yahweh)	Implicit			
-LEV	23	16	God		God (Yahweh)	Implicit			
-LEV	23	17	God		God (Yahweh)	Implicit			
-LEV	23	18	God		God (Yahweh)	Implicit			
-LEV	23	19	God		God (Yahweh)	Implicit			
-LEV	23	20	God		God (Yahweh)	Implicit			
-LEV	23	21	God		God (Yahweh)	Implicit			
-LEV	23	22	God		God (Yahweh)	Implicit			
-LEV	23	24	God		God (Yahweh)	Implicit			
-LEV	23	25	God		God (Yahweh)	Implicit			
-LEV	23	27	God		God (Yahweh)	Implicit			
-LEV	23	28	God		God (Yahweh)	Implicit			
-LEV	23	29	God		God (Yahweh)	Implicit			
-LEV	23	30	God		God (Yahweh)	Implicit			
-LEV	23	31	God		God (Yahweh)	Implicit			
-LEV	23	32	God		God (Yahweh)	Implicit			
-LEV	23	34	God		God (Yahweh)	Implicit			
-LEV	23	35	God		God (Yahweh)	Implicit			
-LEV	23	36	God		God (Yahweh)	Implicit			
-LEV	23	37	God		God (Yahweh)	Implicit			
-LEV	23	38	God		God (Yahweh)	Implicit			
-LEV	23	39	God		God (Yahweh)	Implicit			
-LEV	23	40	God		God (Yahweh)	Implicit			
-LEV	23	41	God		God (Yahweh)	Implicit			
-LEV	23	42	God		God (Yahweh)	Implicit			
-LEV	23	43	God		God (Yahweh)	Implicit			
-LEV	24	2	God		God (Yahweh)	Implicit			
-LEV	24	3	God		God (Yahweh)	Implicit			
-LEV	24	4	God		God (Yahweh)	Implicit			
-LEV	24	5	God		God (Yahweh)	Implicit			
-LEV	24	6	God		God (Yahweh)	Implicit			
-LEV	24	7	God		God (Yahweh)	Implicit			
-LEV	24	8	God		God (Yahweh)	Implicit			
-LEV	24	9	God		God (Yahweh)	Implicit			
+LEV	21	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	21	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	22	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	23	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	9	God		God (Yahweh)	Implicit			EntireVerse
 LEV	24	11	son of Shelomith (whose father was an Egyptian)			Rare			
 LEV	24	11	Needs Review			Potential			
-LEV	24	14	God		God (Yahweh)	Implicit			
-LEV	24	15	God		God (Yahweh)	Implicit			
-LEV	24	16	God		God (Yahweh)	Implicit			
-LEV	24	17	God		God (Yahweh)	Implicit			
-LEV	24	18	God		God (Yahweh)	Implicit			
-LEV	24	19	God		God (Yahweh)	Implicit			
-LEV	24	20	God		God (Yahweh)	Implicit			
-LEV	24	21	God		God (Yahweh)	Implicit			
-LEV	24	22	God		God (Yahweh)	Implicit			
+LEV	24	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	24	22	God		God (Yahweh)	Implicit			EntireVerse
 LEV	24	23	Moses			Indirect			
 LEV	24	23	God		God (Yahweh)	Indirect			
 LEV	24	23	son of Shelomith (whose father was an Egyptian)			Quotation			Unspecified
 LEV	24	23	narrator-LEV			Quotation			Unspecified
-LEV	25	2	God		God (Yahweh)	Implicit			
-LEV	25	3	God		God (Yahweh)	Implicit			
-LEV	25	4	God		God (Yahweh)	Implicit			
-LEV	25	5	God		God (Yahweh)	Implicit			
-LEV	25	6	God		God (Yahweh)	Implicit			
-LEV	25	7	God		God (Yahweh)	Implicit			
-LEV	25	8	God		God (Yahweh)	Implicit			
-LEV	25	9	God		God (Yahweh)	Implicit			
-LEV	25	10	God		God (Yahweh)	Implicit			
-LEV	25	11	God		God (Yahweh)	Implicit			
-LEV	25	12	God		God (Yahweh)	Implicit			
-LEV	25	13	God		God (Yahweh)	Implicit			
-LEV	25	14	God		God (Yahweh)	Implicit			
-LEV	25	15	God		God (Yahweh)	Implicit			
-LEV	25	16	God		God (Yahweh)	Implicit			
-LEV	25	17	God		God (Yahweh)	Implicit			
-LEV	25	18	God		God (Yahweh)	Implicit			
-LEV	25	19	God		God (Yahweh)	Implicit			
-LEV	25	20	God		God (Yahweh)	Implicit			
-LEV	25	21	God		God (Yahweh)	Implicit			
-LEV	25	22	God		God (Yahweh)	Implicit			
-LEV	25	23	God		God (Yahweh)	Implicit			
-LEV	25	24	God		God (Yahweh)	Implicit			
-LEV	25	25	God		God (Yahweh)	Implicit			
-LEV	25	26	God		God (Yahweh)	Implicit			
-LEV	25	27	God		God (Yahweh)	Implicit			
-LEV	25	28	God		God (Yahweh)	Implicit			
-LEV	25	29	God		God (Yahweh)	Implicit			
-LEV	25	30	God		God (Yahweh)	Implicit			
-LEV	25	31	God		God (Yahweh)	Implicit			
-LEV	25	32	God		God (Yahweh)	Implicit			
-LEV	25	33	God		God (Yahweh)	Implicit			
-LEV	25	34	God		God (Yahweh)	Implicit			
-LEV	25	35	God		God (Yahweh)	Implicit			
-LEV	25	36	God		God (Yahweh)	Implicit			
-LEV	25	37	God		God (Yahweh)	Implicit			
-LEV	25	38	God		God (Yahweh)	Implicit			
-LEV	25	39	God		God (Yahweh)	Implicit			
-LEV	25	40	God		God (Yahweh)	Implicit			
-LEV	25	41	God		God (Yahweh)	Implicit			
-LEV	25	42	God		God (Yahweh)	Implicit			
-LEV	25	43	God		God (Yahweh)	Implicit			
-LEV	25	44	God		God (Yahweh)	Implicit			
-LEV	25	45	God		God (Yahweh)	Implicit			
-LEV	25	46	God		God (Yahweh)	Implicit			
-LEV	25	47	God		God (Yahweh)	Implicit			
-LEV	25	48	God		God (Yahweh)	Implicit			
-LEV	25	49	God		God (Yahweh)	Implicit			
-LEV	25	50	God		God (Yahweh)	Implicit			
-LEV	25	51	God		God (Yahweh)	Implicit			
-LEV	25	52	God		God (Yahweh)	Implicit			
-LEV	25	53	God		God (Yahweh)	Implicit			
-LEV	25	54	God		God (Yahweh)	Implicit			
-LEV	25	55	God		God (Yahweh)	Implicit			
-LEV	26	1	God		God (Yahweh)	Implicit			
-LEV	26	2	God		God (Yahweh)	Implicit			
-LEV	26	3	God		God (Yahweh)	Implicit			
-LEV	26	4	God		God (Yahweh)	Implicit			
-LEV	26	5	God		God (Yahweh)	Implicit			
-LEV	26	6	God		God (Yahweh)	Implicit			
-LEV	26	7	God		God (Yahweh)	Implicit			
-LEV	26	8	God		God (Yahweh)	Implicit			
-LEV	26	9	God		God (Yahweh)	Implicit			
-LEV	26	10	God		God (Yahweh)	Implicit			
-LEV	26	11	God		God (Yahweh)	Implicit			
-LEV	26	12	God		God (Yahweh)	Implicit			
-LEV	26	13	God		God (Yahweh)	Implicit			
-LEV	26	14	God		God (Yahweh)	Implicit			
-LEV	26	15	God		God (Yahweh)	Implicit			
-LEV	26	16	God		God (Yahweh)	Implicit			
-LEV	26	17	God		God (Yahweh)	Implicit			
-LEV	26	18	God		God (Yahweh)	Implicit			
-LEV	26	19	God		God (Yahweh)	Implicit			
-LEV	26	20	God		God (Yahweh)	Implicit			
-LEV	26	21	God		God (Yahweh)	Implicit			
-LEV	26	22	God		God (Yahweh)	Implicit			
-LEV	26	23	God		God (Yahweh)	Implicit			
-LEV	26	24	God		God (Yahweh)	Implicit			
-LEV	26	25	God		God (Yahweh)	Implicit			
-LEV	26	26	God		God (Yahweh)	Implicit			
-LEV	26	27	God		God (Yahweh)	Implicit			
-LEV	26	28	God		God (Yahweh)	Implicit			
-LEV	26	29	God		God (Yahweh)	Implicit			
-LEV	26	30	God		God (Yahweh)	Implicit			
-LEV	26	31	God		God (Yahweh)	Implicit			
-LEV	26	32	God		God (Yahweh)	Implicit			
-LEV	26	33	God		God (Yahweh)	Implicit			
-LEV	26	34	God		God (Yahweh)	Implicit			
-LEV	26	35	God		God (Yahweh)	Implicit			
-LEV	26	36	God		God (Yahweh)	Implicit			
-LEV	26	37	God		God (Yahweh)	Implicit			
-LEV	26	38	God		God (Yahweh)	Implicit			
-LEV	26	39	God		God (Yahweh)	Implicit			
-LEV	26	40	God		God (Yahweh)	Implicit			
-LEV	26	41	God		God (Yahweh)	Implicit			
-LEV	26	42	God		God (Yahweh)	Implicit			
-LEV	26	43	God		God (Yahweh)	Implicit			
-LEV	26	44	God		God (Yahweh)	Implicit			
-LEV	26	45	God		God (Yahweh)	Implicit			
-LEV	27	2	God		God (Yahweh)	Implicit			
-LEV	27	3	God		God (Yahweh)	Implicit			
-LEV	27	4	God		God (Yahweh)	Implicit			
-LEV	27	5	God		God (Yahweh)	Implicit			
-LEV	27	6	God		God (Yahweh)	Implicit			
-LEV	27	7	God		God (Yahweh)	Implicit			
-LEV	27	8	God		God (Yahweh)	Implicit			
-LEV	27	9	God		God (Yahweh)	Implicit			
-LEV	27	10	God		God (Yahweh)	Implicit			
-LEV	27	11	God		God (Yahweh)	Implicit			
-LEV	27	12	God		God (Yahweh)	Implicit			
-LEV	27	13	God		God (Yahweh)	Implicit			
-LEV	27	14	God		God (Yahweh)	Implicit			
-LEV	27	15	God		God (Yahweh)	Implicit			
-LEV	27	16	God		God (Yahweh)	Implicit			
-LEV	27	17	God		God (Yahweh)	Implicit			
-LEV	27	18	God		God (Yahweh)	Implicit			
-LEV	27	19	God		God (Yahweh)	Implicit			
-LEV	27	20	God		God (Yahweh)	Implicit			
-LEV	27	21	God		God (Yahweh)	Implicit			
-LEV	27	22	God		God (Yahweh)	Implicit			
-LEV	27	23	God		God (Yahweh)	Implicit			
-LEV	27	24	God		God (Yahweh)	Implicit			
-LEV	27	25	God		God (Yahweh)	Implicit			
-LEV	27	26	God		God (Yahweh)	Implicit			
-LEV	27	27	God		God (Yahweh)	Implicit			
-LEV	27	28	God		God (Yahweh)	Implicit			
-LEV	27	29	God		God (Yahweh)	Implicit			
-LEV	27	30	God		God (Yahweh)	Implicit			
-LEV	27	31	God		God (Yahweh)	Implicit			
-LEV	27	32	God		God (Yahweh)	Implicit			
-LEV	27	33	God		God (Yahweh)	Implicit			
-NUM	1	2	God		God (Yahweh)	Implicit			
-NUM	1	3	God		God (Yahweh)	Implicit			
-NUM	1	4	God		God (Yahweh)	Implicit			
-NUM	1	5	God		God (Yahweh)	Implicit			
-NUM	1	6	God		God (Yahweh)	Implicit			
-NUM	1	7	God		God (Yahweh)	Implicit			
-NUM	1	8	God		God (Yahweh)	Implicit			
-NUM	1	9	God		God (Yahweh)	Implicit			
-NUM	1	10	God		God (Yahweh)	Implicit			
-NUM	1	11	God		God (Yahweh)	Implicit			
-NUM	1	12	God		God (Yahweh)	Implicit			
-NUM	1	13	God		God (Yahweh)	Implicit			
-NUM	1	14	God		God (Yahweh)	Implicit			
-NUM	1	15	God		God (Yahweh)	Implicit			
+LEV	25	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	44	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	45	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	46	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	47	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	48	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	49	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	50	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	51	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	52	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	53	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	54	God		God (Yahweh)	Implicit			EntireVerse
+LEV	25	55	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	1	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	33	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	34	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	35	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	36	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	37	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	38	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	39	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	40	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	41	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	42	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	43	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	44	God		God (Yahweh)	Implicit			EntireVerse
+LEV	26	45	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	2	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	3	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	4	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	5	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	6	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	7	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	8	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	9	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	10	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	11	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	12	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	13	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	14	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	15	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	16	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	17	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	18	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	19	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	20	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	21	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	22	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	23	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	24	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	25	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	26	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	27	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	28	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	29	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	30	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	31	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	32	God		God (Yahweh)	Implicit			EntireVerse
+LEV	27	33	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	15	God		God (Yahweh)	Implicit			EntireVerse
 # The following verse is unlikely to be quoted speech by God, but some projects may include it.
 NUM	1	16	God		God (Yahweh)	Potential			
-NUM	1	49	God		God (Yahweh)	Implicit			
-NUM	1	50	God		God (Yahweh)	Implicit			
-NUM	1	51	God		God (Yahweh)	Implicit			
-NUM	1	52	God		God (Yahweh)	Implicit			
-NUM	1	53	God		God (Yahweh)	Implicit			
-NUM	2	2	God		God (Yahweh)	Implicit			
-NUM	2	3	God		God (Yahweh)	Implicit			
-NUM	2	4	God		God (Yahweh)	Implicit			
-NUM	2	5	God		God (Yahweh)	Implicit			
-NUM	2	6	God		God (Yahweh)	Implicit			
-NUM	2	7	God		God (Yahweh)	Implicit			
-NUM	2	8	God		God (Yahweh)	Implicit			
-NUM	2	9	God		God (Yahweh)	Implicit			
-NUM	2	10	God		God (Yahweh)	Implicit			
-NUM	2	11	God		God (Yahweh)	Implicit			
-NUM	2	12	God		God (Yahweh)	Implicit			
-NUM	2	13	God		God (Yahweh)	Implicit			
-NUM	2	14	God		God (Yahweh)	Implicit			
-NUM	2	15	God		God (Yahweh)	Implicit			
-NUM	2	16	God		God (Yahweh)	Implicit			
-NUM	2	17	God		God (Yahweh)	Implicit			
-NUM	2	18	God		God (Yahweh)	Implicit			
-NUM	2	19	God		God (Yahweh)	Implicit			
-NUM	2	20	God		God (Yahweh)	Implicit			
-NUM	2	21	God		God (Yahweh)	Implicit			
-NUM	2	22	God		God (Yahweh)	Implicit			
-NUM	2	23	God		God (Yahweh)	Implicit			
-NUM	2	24	God		God (Yahweh)	Implicit			
-NUM	2	25	God		God (Yahweh)	Implicit			
-NUM	2	26	God		God (Yahweh)	Implicit			
-NUM	2	27	God		God (Yahweh)	Implicit			
-NUM	2	28	God		God (Yahweh)	Implicit			
-NUM	2	29	God		God (Yahweh)	Implicit			
-NUM	2	30	God		God (Yahweh)	Implicit			
-NUM	2	31	God		God (Yahweh)	Implicit			
-NUM	3	6	God		God (Yahweh)	Implicit			
-NUM	3	7	God		God (Yahweh)	Implicit			
-NUM	3	8	God		God (Yahweh)	Implicit			
-NUM	3	9	God		God (Yahweh)	Implicit			
-NUM	3	10	God		God (Yahweh)	Implicit			
-NUM	3	12	God		God (Yahweh)	Implicit			
-NUM	3	13	God		God (Yahweh)	Implicit			
-NUM	3	15	God		God (Yahweh)	Implicit			
-NUM	3	40	God		God (Yahweh)	Implicit			
-NUM	3	41	God		God (Yahweh)	Implicit			
-NUM	3	45	God		God (Yahweh)	Implicit			
-NUM	3	46	God		God (Yahweh)	Implicit			
-NUM	3	47	God		God (Yahweh)	Implicit			
-NUM	3	48	God		God (Yahweh)	Implicit			
-NUM	4	2	God		God (Yahweh)	Implicit			
-NUM	4	3	God		God (Yahweh)	Implicit			
-NUM	4	4	God		God (Yahweh)	Implicit			
-NUM	4	5	God		God (Yahweh)	Implicit			
-NUM	4	6	God		God (Yahweh)	Implicit			
-NUM	4	7	God		God (Yahweh)	Implicit			
-NUM	4	8	God		God (Yahweh)	Implicit			
-NUM	4	9	God		God (Yahweh)	Implicit			
-NUM	4	10	God		God (Yahweh)	Implicit			
-NUM	4	11	God		God (Yahweh)	Implicit			
-NUM	4	12	God		God (Yahweh)	Implicit			
-NUM	4	13	God		God (Yahweh)	Implicit			
-NUM	4	14	God		God (Yahweh)	Implicit			
-NUM	4	15	God		God (Yahweh)	Implicit			
-NUM	4	16	God		God (Yahweh)	Implicit			
-NUM	4	18	God		God (Yahweh)	Implicit			
-NUM	4	19	God		God (Yahweh)	Implicit			
-NUM	4	20	God		God (Yahweh)	Implicit			
-NUM	4	22	God		God (Yahweh)	Implicit			
-NUM	4	23	God		God (Yahweh)	Implicit			
-NUM	4	24	God		God (Yahweh)	Implicit			
-NUM	4	25	God		God (Yahweh)	Implicit			
-NUM	4	26	God		God (Yahweh)	Implicit			
-NUM	4	27	God		God (Yahweh)	Implicit			
-NUM	4	28	God		God (Yahweh)	Implicit			
-NUM	4	29	God		God (Yahweh)	Implicit			
-NUM	4	30	God		God (Yahweh)	Implicit			
-NUM	4	31	God		God (Yahweh)	Implicit			
-NUM	4	32	God		God (Yahweh)	Implicit			
-NUM	4	33	God		God (Yahweh)	Implicit			
-NUM	5	2	God		God (Yahweh)	Implicit			
-NUM	5	3	God		God (Yahweh)	Implicit			
-NUM	5	6	God		God (Yahweh)	Implicit			
-NUM	5	7	God		God (Yahweh)	Implicit			
-NUM	5	8	God		God (Yahweh)	Implicit			
-NUM	5	9	God		God (Yahweh)	Implicit			
-NUM	5	10	God		God (Yahweh)	Implicit			
-NUM	5	12	God		God (Yahweh)	Implicit			
-NUM	5	13	God		God (Yahweh)	Implicit			
-NUM	5	14	God		God (Yahweh)	Implicit			
-NUM	5	15	God		God (Yahweh)	Implicit			
-NUM	5	16	God		God (Yahweh)	Implicit			
-NUM	5	17	God		God (Yahweh)	Implicit			
-NUM	5	18	God		God (Yahweh)	Implicit			
+NUM	1	49	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	50	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	51	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	52	God		God (Yahweh)	Implicit			EntireVerse
+NUM	1	53	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	17	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	22	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	2	31	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	40	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	41	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	45	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	46	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	47	God		God (Yahweh)	Implicit			EntireVerse
+NUM	3	48	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	22	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	31	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	32	God		God (Yahweh)	Implicit			EntireVerse
+NUM	4	33	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	17	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	18	God		God (Yahweh)	Implicit			EntireVerse
 NUM	5	19	God		God (Yahweh)	Normal			
 NUM	5	19	priest			Quotation			Unspecified
 NUM	5	20	God		God (Yahweh)	Normal			
@@ -2620,41 +2620,41 @@ NUM	5	21	priest			Quotation			Unspecified
 NUM	5	22	God		God (Yahweh)	Normal			
 NUM	5	22	priest			Quotation			Unspecified
 NUM	5	22	wife suspected of infidelity			Quotation			Unspecified
-NUM	5	23	God		God (Yahweh)	Implicit			
-NUM	5	24	God		God (Yahweh)	Implicit			
-NUM	5	25	God		God (Yahweh)	Implicit			
-NUM	5	26	God		God (Yahweh)	Implicit			
-NUM	5	27	God		God (Yahweh)	Implicit			
-NUM	5	28	God		God (Yahweh)	Implicit			
-NUM	5	29	God		God (Yahweh)	Implicit			
-NUM	5	30	God		God (Yahweh)	Implicit			
-NUM	5	31	God		God (Yahweh)	Implicit			
-NUM	6	2	God		God (Yahweh)	Implicit			
-NUM	6	3	God		God (Yahweh)	Implicit			
-NUM	6	4	God		God (Yahweh)	Implicit			
-NUM	6	5	God		God (Yahweh)	Implicit			
-NUM	6	6	God		God (Yahweh)	Implicit			
-NUM	6	7	God		God (Yahweh)	Implicit			
-NUM	6	8	God		God (Yahweh)	Implicit			
-NUM	6	9	God		God (Yahweh)	Implicit			
-NUM	6	10	God		God (Yahweh)	Implicit			
-NUM	6	11	God		God (Yahweh)	Implicit			
-NUM	6	12	God		God (Yahweh)	Implicit			
-NUM	6	13	God		God (Yahweh)	Implicit			
-NUM	6	14	God		God (Yahweh)	Implicit			
-NUM	6	15	God		God (Yahweh)	Implicit			
-NUM	6	16	God		God (Yahweh)	Implicit			
-NUM	6	17	God		God (Yahweh)	Implicit			
-NUM	6	18	God		God (Yahweh)	Implicit			
-NUM	6	19	God		God (Yahweh)	Implicit			
-NUM	6	20	God		God (Yahweh)	Implicit			
-NUM	6	21	God		God (Yahweh)	Implicit			
-NUM	6	23	God		God (Yahweh)	Implicit			
-NUM	6	24	God		God (Yahweh)	Implicit			
-NUM	6	25	God		God (Yahweh)	Implicit			
-NUM	6	26	God		God (Yahweh)	Implicit			
-NUM	6	27	God		God (Yahweh)	Implicit			
-NUM	7	5	God		God (Yahweh)	Implicit			
+NUM	5	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	5	31	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	17	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	6	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	7	5	God		God (Yahweh)	Implicit			EntireVerse
 NUM	7	11	God		God (Yahweh)	Normal			Unspecified
 NUM	8	2	God		God (Yahweh)	Normal			EntireVerse
 NUM	8	6	God		God (Yahweh)	Normal			Unspecified
@@ -2774,35 +2774,35 @@ NUM	14	40	Israelite community	mourning		Normal			EndOfVerse
 NUM	14	41	Moses			Normal			EndOfVerse
 NUM	14	42	Moses			Normal			EntireVerse
 NUM	14	43	Moses			Normal			EntireVerse
-NUM	15	2	God		God (Yahweh)	Implicit			
-NUM	15	3	God		God (Yahweh)	Implicit			
-NUM	15	4	God		God (Yahweh)	Implicit			
-NUM	15	5	God		God (Yahweh)	Implicit			
-NUM	15	6	God		God (Yahweh)	Implicit			
-NUM	15	7	God		God (Yahweh)	Implicit			
-NUM	15	8	God		God (Yahweh)	Implicit			
-NUM	15	9	God		God (Yahweh)	Implicit			
-NUM	15	10	God		God (Yahweh)	Implicit			
-NUM	15	11	God		God (Yahweh)	Implicit			
-NUM	15	12	God		God (Yahweh)	Implicit			
-NUM	15	13	God		God (Yahweh)	Implicit			
-NUM	15	14	God		God (Yahweh)	Implicit			
-NUM	15	15	God		God (Yahweh)	Implicit			
-NUM	15	16	God		God (Yahweh)	Implicit			
-NUM	15	18	God		God (Yahweh)	Implicit			
-NUM	15	19	God		God (Yahweh)	Implicit			
-NUM	15	20	God		God (Yahweh)	Implicit			
-NUM	15	21	God		God (Yahweh)	Implicit			
-NUM	15	22	God		God (Yahweh)	Implicit			
-NUM	15	23	God		God (Yahweh)	Implicit			
-NUM	15	24	God		God (Yahweh)	Implicit			
-NUM	15	25	God		God (Yahweh)	Implicit			
-NUM	15	26	God		God (Yahweh)	Implicit			
-NUM	15	27	God		God (Yahweh)	Implicit			
-NUM	15	28	God		God (Yahweh)	Implicit			
-NUM	15	29	God		God (Yahweh)	Implicit			
-NUM	15	30	God		God (Yahweh)	Implicit			
-NUM	15	31	God		God (Yahweh)	Implicit			
+NUM	15	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	22	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	15	31	God		God (Yahweh)	Implicit			EntireVerse
 NUM	15	35	God		God (Yahweh)	Normal			EndOfVerse
 NUM	15	38	God		God (Yahweh)	Normal			Unspecified
 NUM	15	39	God		God (Yahweh)	Normal			EntireVerse
@@ -3029,75 +3029,75 @@ NUM	27	18	God		God (Yahweh)	Normal			EndOfVerse
 NUM	27	19	God		God (Yahweh)	Normal			EntireVerse
 NUM	27	20	God		God (Yahweh)	Normal			EntireVerse
 NUM	27	21	God		God (Yahweh)	Normal			EntireVerse
-NUM	28	2	God		God (Yahweh)	Implicit			
-NUM	28	3	God		God (Yahweh)	Implicit			
-NUM	28	4	God		God (Yahweh)	Implicit			
-NUM	28	5	God		God (Yahweh)	Implicit			
-NUM	28	6	God		God (Yahweh)	Implicit			
-NUM	28	7	God		God (Yahweh)	Implicit			
-NUM	28	8	God		God (Yahweh)	Implicit			
-NUM	28	9	God		God (Yahweh)	Implicit			
-NUM	28	10	God		God (Yahweh)	Implicit			
-NUM	28	11	God		God (Yahweh)	Implicit			
-NUM	28	12	God		God (Yahweh)	Implicit			
-NUM	28	13	God		God (Yahweh)	Implicit			
-NUM	28	14	God		God (Yahweh)	Implicit			
-NUM	28	15	God		God (Yahweh)	Implicit			
-NUM	28	16	God		God (Yahweh)	Implicit			
-NUM	28	17	God		God (Yahweh)	Implicit			
-NUM	28	18	God		God (Yahweh)	Implicit			
-NUM	28	19	God		God (Yahweh)	Implicit			
-NUM	28	20	God		God (Yahweh)	Implicit			
-NUM	28	21	God		God (Yahweh)	Implicit			
-NUM	28	22	God		God (Yahweh)	Implicit			
-NUM	28	23	God		God (Yahweh)	Implicit			
-NUM	28	24	God		God (Yahweh)	Implicit			
-NUM	28	25	God		God (Yahweh)	Implicit			
-NUM	28	26	God		God (Yahweh)	Implicit			
-NUM	28	27	God		God (Yahweh)	Implicit			
-NUM	28	28	God		God (Yahweh)	Implicit			
-NUM	28	29	God		God (Yahweh)	Implicit			
-NUM	28	30	God		God (Yahweh)	Implicit			
-NUM	28	31	God		God (Yahweh)	Implicit			
-NUM	29	1	God		God (Yahweh)	Implicit			
-NUM	29	2	God		God (Yahweh)	Implicit			
-NUM	29	3	God		God (Yahweh)	Implicit			
-NUM	29	4	God		God (Yahweh)	Implicit			
-NUM	29	5	God		God (Yahweh)	Implicit			
-NUM	29	6	God		God (Yahweh)	Implicit			
-NUM	29	7	God		God (Yahweh)	Implicit			
-NUM	29	8	God		God (Yahweh)	Implicit			
-NUM	29	9	God		God (Yahweh)	Implicit			
-NUM	29	10	God		God (Yahweh)	Implicit			
-NUM	29	11	God		God (Yahweh)	Implicit			
-NUM	29	12	God		God (Yahweh)	Implicit			
-NUM	29	13	God		God (Yahweh)	Implicit			
-NUM	29	14	God		God (Yahweh)	Implicit			
-NUM	29	15	God		God (Yahweh)	Implicit			
-NUM	29	16	God		God (Yahweh)	Implicit			
-NUM	29	17	God		God (Yahweh)	Implicit			
-NUM	29	18	God		God (Yahweh)	Implicit			
-NUM	29	19	God		God (Yahweh)	Implicit			
-NUM	29	20	God		God (Yahweh)	Implicit			
-NUM	29	21	God		God (Yahweh)	Implicit			
-NUM	29	22	God		God (Yahweh)	Implicit			
-NUM	29	23	God		God (Yahweh)	Implicit			
-NUM	29	24	God		God (Yahweh)	Implicit			
-NUM	29	25	God		God (Yahweh)	Implicit			
-NUM	29	26	God		God (Yahweh)	Implicit			
-NUM	29	27	God		God (Yahweh)	Implicit			
-NUM	29	28	God		God (Yahweh)	Implicit			
-NUM	29	29	God		God (Yahweh)	Implicit			
-NUM	29	30	God		God (Yahweh)	Implicit			
-NUM	29	31	God		God (Yahweh)	Implicit			
-NUM	29	32	God		God (Yahweh)	Implicit			
-NUM	29	33	God		God (Yahweh)	Implicit			
-NUM	29	34	God		God (Yahweh)	Implicit			
-NUM	29	35	God		God (Yahweh)	Implicit			
-NUM	29	36	God		God (Yahweh)	Implicit			
-NUM	29	37	God		God (Yahweh)	Implicit			
-NUM	29	38	God		God (Yahweh)	Implicit			
-NUM	29	39	God		God (Yahweh)	Implicit			
+NUM	28	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	17	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	22	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	28	31	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	1	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	2	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	3	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	4	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	5	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	6	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	7	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	8	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	9	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	10	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	11	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	12	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	13	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	14	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	15	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	16	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	17	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	18	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	19	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	20	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	21	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	22	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	23	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	24	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	25	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	26	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	27	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	28	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	29	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	30	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	31	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	32	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	33	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	34	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	35	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	36	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	37	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	38	God		God (Yahweh)	Implicit			EntireVerse
+NUM	29	39	God		God (Yahweh)	Implicit			EntireVerse
 NUM	30	1	Moses			Normal			Unspecified
 NUM	30	2	Moses			Normal			Unspecified
 NUM	30	3	Moses			Normal			Unspecified
@@ -3234,793 +3234,793 @@ NUM	36	6	Moses		Moses (at LORD's command)	Normal			EntireVerse
 NUM	36	7	Moses		Moses (at LORD's command)	Normal			EntireVerse
 NUM	36	8	Moses		Moses (at LORD's command)	Normal			EntireVerse
 NUM	36	9	Moses		Moses (at LORD's command)	Normal			EntireVerse
-DEU	1	6	Moses			Implicit			
+DEU	1	6	Moses			Implicit			EntireVerse
 DEU	1	6	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	7	Moses			Implicit			
+DEU	1	7	Moses			Implicit			EntireVerse
 DEU	1	7	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	8	Moses			Implicit			
+DEU	1	8	Moses			Implicit			EntireVerse
 DEU	1	8	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	9	Moses			Implicit			
-DEU	1	10	Moses			Implicit			
-DEU	1	11	Moses			Implicit			
-DEU	1	12	Moses			Implicit			
-DEU	1	13	Moses			Implicit			
-DEU	1	14	Moses			Implicit			
-DEU	1	15	Moses			Implicit			
-DEU	1	16	Moses			Implicit			
-DEU	1	17	Moses			Implicit			
-DEU	1	18	Moses			Implicit			
-DEU	1	19	Moses			Implicit			
-DEU	1	20	Moses			Implicit			
-DEU	1	21	Moses			Implicit			
-DEU	1	22	Moses			Implicit			
-DEU	1	23	Moses			Implicit			
-DEU	1	24	Moses			Implicit			
-DEU	1	25	Moses			Implicit			
+DEU	1	9	Moses			Implicit			EntireVerse
+DEU	1	10	Moses			Implicit			EntireVerse
+DEU	1	11	Moses			Implicit			EntireVerse
+DEU	1	12	Moses			Implicit			EntireVerse
+DEU	1	13	Moses			Implicit			EntireVerse
+DEU	1	14	Moses			Implicit			EntireVerse
+DEU	1	15	Moses			Implicit			EntireVerse
+DEU	1	16	Moses			Implicit			EntireVerse
+DEU	1	17	Moses			Implicit			EntireVerse
+DEU	1	18	Moses			Implicit			EntireVerse
+DEU	1	19	Moses			Implicit			EntireVerse
+DEU	1	20	Moses			Implicit			EntireVerse
+DEU	1	21	Moses			Implicit			EntireVerse
+DEU	1	22	Moses			Implicit			EntireVerse
+DEU	1	23	Moses			Implicit			EntireVerse
+DEU	1	24	Moses			Implicit			EntireVerse
+DEU	1	25	Moses			Implicit			EntireVerse
 DEU	1	25	Joshua/Caleb		explorers, twelve	Quotation	Joshua	NUM 14.7; DEU 1.25	Unspecified
-DEU	1	26	Moses			Implicit			
-DEU	1	27	Moses			Implicit			
-DEU	1	28	Moses			Implicit			
-DEU	1	29	Moses			Implicit			
-DEU	1	30	Moses			Implicit			
-DEU	1	31	Moses			Implicit			
-DEU	1	32	Moses			Implicit			
-DEU	1	33	Moses			Implicit			
-DEU	1	34	Moses			Implicit			
-DEU	1	35	Moses			Implicit			
+DEU	1	26	Moses			Implicit			EntireVerse
+DEU	1	27	Moses			Implicit			EntireVerse
+DEU	1	28	Moses			Implicit			EntireVerse
+DEU	1	29	Moses			Implicit			EntireVerse
+DEU	1	30	Moses			Implicit			EntireVerse
+DEU	1	31	Moses			Implicit			EntireVerse
+DEU	1	32	Moses			Implicit			EntireVerse
+DEU	1	33	Moses			Implicit			EntireVerse
+DEU	1	34	Moses			Implicit			EntireVerse
+DEU	1	35	Moses			Implicit			EntireVerse
 DEU	1	35	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	36	Moses			Implicit			
+DEU	1	36	Moses			Implicit			EntireVerse
 DEU	1	36	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	37	Moses			Implicit			
+DEU	1	37	Moses			Implicit			EntireVerse
 DEU	1	37	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	38	Moses			Implicit			
+DEU	1	38	Moses			Implicit			EntireVerse
 DEU	1	38	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	39	Moses			Implicit			
+DEU	1	39	Moses			Implicit			EntireVerse
 DEU	1	39	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	40	Moses			Implicit			
+DEU	1	40	Moses			Implicit			EntireVerse
 DEU	1	40	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	41	Moses			Implicit			
+DEU	1	41	Moses			Implicit			EntireVerse
 DEU	1	41	Israel			Quotation			Unspecified
-DEU	1	42	Moses			Implicit			
+DEU	1	42	Moses			Implicit			EntireVerse
 DEU	1	42	God		God (Yahweh)	Quotation			Unspecified
-DEU	1	43	Moses			Implicit			
-DEU	1	44	Moses			Implicit			
-DEU	1	45	Moses			Implicit			
-DEU	1	46	Moses			Implicit			
-DEU	2	1	Moses			Implicit			
-DEU	2	2	Moses			Implicit			
-DEU	2	3	Moses			Implicit			
+DEU	1	43	Moses			Implicit			EntireVerse
+DEU	1	44	Moses			Implicit			EntireVerse
+DEU	1	45	Moses			Implicit			EntireVerse
+DEU	1	46	Moses			Implicit			EntireVerse
+DEU	2	1	Moses			Implicit			EntireVerse
+DEU	2	2	Moses			Implicit			EntireVerse
+DEU	2	3	Moses			Implicit			EntireVerse
 DEU	2	3	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	4	Moses			Implicit			
+DEU	2	4	Moses			Implicit			EntireVerse
 DEU	2	4	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	5	Moses			Implicit			
+DEU	2	5	Moses			Implicit			EntireVerse
 DEU	2	5	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	6	Moses			Implicit			
+DEU	2	6	Moses			Implicit			EntireVerse
 DEU	2	6	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	7	Moses			Implicit			
-DEU	2	8	Moses			Implicit			
-DEU	2	9	Moses			Implicit			
+DEU	2	7	Moses			Implicit			EntireVerse
+DEU	2	8	Moses			Implicit			EntireVerse
+DEU	2	9	Moses			Implicit			EntireVerse
 DEU	2	9	God		God (Yahweh)	Quotation			Unspecified
 DEU	2	10	Moses			Potential			
 DEU	2	11	Moses			Potential			
 DEU	2	12	Moses			Potential			
-DEU	2	13	Moses			Implicit			
+DEU	2	13	Moses			Implicit			EntireVerse
 DEU	2	13	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	14	Moses			Implicit			
-DEU	2	15	Moses			Implicit			
-DEU	2	16	Moses			Implicit			
-DEU	2	17	Moses			Implicit			
-DEU	2	18	Moses			Implicit			
+DEU	2	14	Moses			Implicit			EntireVerse
+DEU	2	15	Moses			Implicit			EntireVerse
+DEU	2	16	Moses			Implicit			EntireVerse
+DEU	2	17	Moses			Implicit			EntireVerse
+DEU	2	18	Moses			Implicit			EntireVerse
 DEU	2	18	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	19	Moses			Implicit			
+DEU	2	19	Moses			Implicit			EntireVerse
 DEU	2	19	God		God (Yahweh)	Quotation			Unspecified
 DEU	2	20	Moses			Potential			
 DEU	2	21	Moses			Potential			
 DEU	2	22	Moses			Potential			
 DEU	2	23	Moses			Potential			
-DEU	2	24	Moses			Implicit			
+DEU	2	24	Moses			Implicit			EntireVerse
 DEU	2	24	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	25	Moses			Implicit			
+DEU	2	25	Moses			Implicit			EntireVerse
 DEU	2	25	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	26	Moses			Implicit			
-DEU	2	27	Moses			Implicit			
-DEU	2	28	Moses			Implicit			
-DEU	2	29	Moses			Implicit			
-DEU	2	30	Moses			Implicit			
-DEU	2	31	Moses			Implicit			
+DEU	2	26	Moses			Implicit			EntireVerse
+DEU	2	27	Moses			Implicit			EntireVerse
+DEU	2	28	Moses			Implicit			EntireVerse
+DEU	2	29	Moses			Implicit			EntireVerse
+DEU	2	30	Moses			Implicit			EntireVerse
+DEU	2	31	Moses			Implicit			EntireVerse
 DEU	2	31	God		God (Yahweh)	Quotation			Unspecified
-DEU	2	32	Moses			Implicit			
-DEU	2	33	Moses			Implicit			
-DEU	2	34	Moses			Implicit			
-DEU	2	35	Moses			Implicit			
-DEU	2	36	Moses			Implicit			
-DEU	2	37	Moses			Implicit			
-DEU	3	1	Moses			Implicit			
+DEU	2	32	Moses			Implicit			EntireVerse
+DEU	2	33	Moses			Implicit			EntireVerse
+DEU	2	34	Moses			Implicit			EntireVerse
+DEU	2	35	Moses			Implicit			EntireVerse
+DEU	2	36	Moses			Implicit			EntireVerse
+DEU	2	37	Moses			Implicit			EntireVerse
+DEU	3	1	Moses			Implicit			EntireVerse
 DEU	3	2	God		God (Yahweh)	Quotation			Unspecified
-DEU	3	2	Moses			Implicit			
-DEU	3	3	Moses			Implicit			
-DEU	3	4	Moses			Implicit			
-DEU	3	5	Moses			Implicit			
-DEU	3	6	Moses			Implicit			
-DEU	3	7	Moses			Implicit			
-DEU	3	8	Moses			Implicit			
+DEU	3	2	Moses			Implicit			EntireVerse
+DEU	3	3	Moses			Implicit			EntireVerse
+DEU	3	4	Moses			Implicit			EntireVerse
+DEU	3	5	Moses			Implicit			EntireVerse
+DEU	3	6	Moses			Implicit			EntireVerse
+DEU	3	7	Moses			Implicit			EntireVerse
+DEU	3	8	Moses			Implicit			EntireVerse
 DEU	3	9	Moses			Potential			
-DEU	3	10	Moses			Implicit			
+DEU	3	10	Moses			Implicit			EntireVerse
 DEU	3	11	Moses			Potential			
-DEU	3	12	Moses			Implicit			
+DEU	3	12	Moses			Implicit			EntireVerse
 DEU	3	13	Moses			Normal			Unspecified
 DEU	3	14	Moses			Potential			
-DEU	3	15	Moses			Implicit			
-DEU	3	16	Moses			Implicit			
-DEU	3	17	Moses			Implicit			
-DEU	3	18	Moses			Implicit			
-DEU	3	19	Moses			Implicit			
-DEU	3	20	Moses			Implicit			
-DEU	3	21	Moses			Implicit			
-DEU	3	22	Moses			Implicit			
-DEU	3	23	Moses			Implicit			
-DEU	3	24	Moses			Implicit			
-DEU	3	25	Moses			Implicit			
-DEU	3	26	Moses			Implicit			
+DEU	3	15	Moses			Implicit			EntireVerse
+DEU	3	16	Moses			Implicit			EntireVerse
+DEU	3	17	Moses			Implicit			EntireVerse
+DEU	3	18	Moses			Implicit			EntireVerse
+DEU	3	19	Moses			Implicit			EntireVerse
+DEU	3	20	Moses			Implicit			EntireVerse
+DEU	3	21	Moses			Implicit			EntireVerse
+DEU	3	22	Moses			Implicit			EntireVerse
+DEU	3	23	Moses			Implicit			EntireVerse
+DEU	3	24	Moses			Implicit			EntireVerse
+DEU	3	25	Moses			Implicit			EntireVerse
+DEU	3	26	Moses			Implicit			EntireVerse
 DEU	3	26	God		God (Yahweh)	Quotation			Unspecified
-DEU	3	27	Moses			Implicit			
+DEU	3	27	Moses			Implicit			EntireVerse
 DEU	3	27	God		God (Yahweh)	Quotation			Unspecified
-DEU	3	28	Moses			Implicit			
+DEU	3	28	Moses			Implicit			EntireVerse
 DEU	3	28	God		God (Yahweh)	Quotation			Unspecified
-DEU	3	29	Moses			Implicit			
-DEU	4	1	Moses			Implicit			
-DEU	4	2	Moses			Implicit			
-DEU	4	3	Moses			Implicit			
-DEU	4	4	Moses			Implicit			
-DEU	4	5	Moses			Implicit			
-DEU	4	6	Moses			Implicit			
+DEU	3	29	Moses			Implicit			EntireVerse
+DEU	4	1	Moses			Implicit			EntireVerse
+DEU	4	2	Moses			Implicit			EntireVerse
+DEU	4	3	Moses			Implicit			EntireVerse
+DEU	4	4	Moses			Implicit			EntireVerse
+DEU	4	5	Moses			Implicit			EntireVerse
+DEU	4	6	Moses			Implicit			EntireVerse
 DEU	4	6	nations			Hypothetical			Unspecified
-DEU	4	7	Moses			Implicit			
-DEU	4	8	Moses			Implicit			
-DEU	4	9	Moses			Implicit			
-DEU	4	10	Moses			Implicit			
-DEU	4	11	Moses			Implicit			
-DEU	4	12	Moses			Implicit			
-DEU	4	13	Moses			Implicit			
-DEU	4	14	Moses			Implicit			
-DEU	4	15	Moses			Implicit			
-DEU	4	16	Moses			Implicit			
-DEU	4	17	Moses			Implicit			
-DEU	4	18	Moses			Implicit			
-DEU	4	19	Moses			Implicit			
-DEU	4	20	Moses			Implicit			
-DEU	4	21	Moses			Implicit			
-DEU	4	22	Moses			Implicit			
-DEU	4	23	Moses			Implicit			
-DEU	4	24	Moses			Implicit			
-DEU	4	25	Moses			Implicit			
-DEU	4	26	Moses			Implicit			
-DEU	4	27	Moses			Implicit			
-DEU	4	28	Moses			Implicit			
-DEU	4	29	Moses			Implicit			
-DEU	4	30	Moses			Implicit			
-DEU	4	31	Moses			Implicit			
-DEU	4	32	Moses			Implicit			
-DEU	4	33	Moses			Implicit			
-DEU	4	34	Moses			Implicit			
-DEU	4	35	Moses			Implicit			
-DEU	4	36	Moses			Implicit			
-DEU	4	37	Moses			Implicit			
-DEU	4	38	Moses			Implicit			
-DEU	4	39	Moses			Implicit			
-DEU	4	40	Moses			Implicit			
+DEU	4	7	Moses			Implicit			EntireVerse
+DEU	4	8	Moses			Implicit			EntireVerse
+DEU	4	9	Moses			Implicit			EntireVerse
+DEU	4	10	Moses			Implicit			EntireVerse
+DEU	4	11	Moses			Implicit			EntireVerse
+DEU	4	12	Moses			Implicit			EntireVerse
+DEU	4	13	Moses			Implicit			EntireVerse
+DEU	4	14	Moses			Implicit			EntireVerse
+DEU	4	15	Moses			Implicit			EntireVerse
+DEU	4	16	Moses			Implicit			EntireVerse
+DEU	4	17	Moses			Implicit			EntireVerse
+DEU	4	18	Moses			Implicit			EntireVerse
+DEU	4	19	Moses			Implicit			EntireVerse
+DEU	4	20	Moses			Implicit			EntireVerse
+DEU	4	21	Moses			Implicit			EntireVerse
+DEU	4	22	Moses			Implicit			EntireVerse
+DEU	4	23	Moses			Implicit			EntireVerse
+DEU	4	24	Moses			Implicit			EntireVerse
+DEU	4	25	Moses			Implicit			EntireVerse
+DEU	4	26	Moses			Implicit			EntireVerse
+DEU	4	27	Moses			Implicit			EntireVerse
+DEU	4	28	Moses			Implicit			EntireVerse
+DEU	4	29	Moses			Implicit			EntireVerse
+DEU	4	30	Moses			Implicit			EntireVerse
+DEU	4	31	Moses			Implicit			EntireVerse
+DEU	4	32	Moses			Implicit			EntireVerse
+DEU	4	33	Moses			Implicit			EntireVerse
+DEU	4	34	Moses			Implicit			EntireVerse
+DEU	4	35	Moses			Implicit			EntireVerse
+DEU	4	36	Moses			Implicit			EntireVerse
+DEU	4	37	Moses			Implicit			EntireVerse
+DEU	4	38	Moses			Implicit			EntireVerse
+DEU	4	39	Moses			Implicit			EntireVerse
+DEU	4	40	Moses			Implicit			EntireVerse
 DEU	5	1	Moses			Normal			EndOfVerse
-DEU	5	2	Moses			Implicit			
-DEU	5	3	Moses			Implicit			
-DEU	5	4	Moses			Implicit			
-DEU	5	5	Moses			Implicit			
-DEU	5	6	Moses			Implicit			
+DEU	5	2	Moses			Implicit			EntireVerse
+DEU	5	3	Moses			Implicit			EntireVerse
+DEU	5	4	Moses			Implicit			EntireVerse
+DEU	5	5	Moses			Implicit			EntireVerse
+DEU	5	6	Moses			Implicit			EntireVerse
 DEU	5	6	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	7	Moses			Implicit			
+DEU	5	7	Moses			Implicit			EntireVerse
 DEU	5	7	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	8	Moses			Implicit			
+DEU	5	8	Moses			Implicit			EntireVerse
 DEU	5	8	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	9	Moses			Implicit			
+DEU	5	9	Moses			Implicit			EntireVerse
 DEU	5	9	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	10	Moses			Implicit			
+DEU	5	10	Moses			Implicit			EntireVerse
 DEU	5	10	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	11	Moses			Implicit			
+DEU	5	11	Moses			Implicit			EntireVerse
 DEU	5	11	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	12	Moses			Implicit			
+DEU	5	12	Moses			Implicit			EntireVerse
 DEU	5	12	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	13	Moses			Implicit			
+DEU	5	13	Moses			Implicit			EntireVerse
 DEU	5	13	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	14	Moses			Implicit			
+DEU	5	14	Moses			Implicit			EntireVerse
 DEU	5	14	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	15	Moses			Implicit			
+DEU	5	15	Moses			Implicit			EntireVerse
 DEU	5	15	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	16	Moses			Implicit			
+DEU	5	16	Moses			Implicit			EntireVerse
 DEU	5	16	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	17	Moses			Implicit			
+DEU	5	17	Moses			Implicit			EntireVerse
 DEU	5	17	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	18	Moses			Implicit			
+DEU	5	18	Moses			Implicit			EntireVerse
 DEU	5	18	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	19	Moses			Implicit			
+DEU	5	19	Moses			Implicit			EntireVerse
 DEU	5	19	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	20	Moses			Implicit			
+DEU	5	20	Moses			Implicit			EntireVerse
 DEU	5	20	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	21	Moses			Implicit			
+DEU	5	21	Moses			Implicit			EntireVerse
 DEU	5	21	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	22	Moses			Implicit			
-DEU	5	23	Moses			Implicit			
-DEU	5	24	Moses			Implicit			
+DEU	5	22	Moses			Implicit			EntireVerse
+DEU	5	23	Moses			Implicit			EntireVerse
+DEU	5	24	Moses			Implicit			EntireVerse
 DEU	5	24	Israel			Quotation			Unspecified
-DEU	5	25	Moses			Implicit			
+DEU	5	25	Moses			Implicit			EntireVerse
 DEU	5	25	Israel			Quotation			Unspecified
-DEU	5	26	Moses			Implicit			
+DEU	5	26	Moses			Implicit			EntireVerse
 DEU	5	26	Israel			Quotation			Unspecified
-DEU	5	27	Moses			Implicit			
+DEU	5	27	Moses			Implicit			EntireVerse
 DEU	5	27	Israel			Quotation			Unspecified
-DEU	5	28	Moses			Implicit			
+DEU	5	28	Moses			Implicit			EntireVerse
 DEU	5	28	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	29	Moses			Implicit			
+DEU	5	29	Moses			Implicit			EntireVerse
 DEU	5	29	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	30	Moses			Implicit			
+DEU	5	30	Moses			Implicit			EntireVerse
 DEU	5	30	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	31	Moses			Implicit			
+DEU	5	31	Moses			Implicit			EntireVerse
 DEU	5	31	God		God (Yahweh)	Quotation			Unspecified
-DEU	5	32	Moses			Implicit			
-DEU	5	33	Moses			Implicit			
-DEU	6	1	Moses			Implicit			
-DEU	6	2	Moses			Implicit			
-DEU	6	3	Moses			Implicit			
-DEU	6	4	Moses			Implicit			
-DEU	6	5	Moses			Implicit			
-DEU	6	6	Moses			Implicit			
-DEU	6	7	Moses			Implicit			
-DEU	6	8	Moses			Implicit			
-DEU	6	9	Moses			Implicit			
-DEU	6	10	Moses			Implicit			
-DEU	6	11	Moses			Implicit			
-DEU	6	12	Moses			Implicit			
-DEU	6	13	Moses			Implicit			
-DEU	6	14	Moses			Implicit			
-DEU	6	15	Moses			Implicit			
-DEU	6	16	Moses			Implicit			
-DEU	6	17	Moses			Implicit			
-DEU	6	18	Moses			Implicit			
-DEU	6	19	Moses			Implicit			
-DEU	6	20	Moses			Implicit			
+DEU	5	32	Moses			Implicit			EntireVerse
+DEU	5	33	Moses			Implicit			EntireVerse
+DEU	6	1	Moses			Implicit			EntireVerse
+DEU	6	2	Moses			Implicit			EntireVerse
+DEU	6	3	Moses			Implicit			EntireVerse
+DEU	6	4	Moses			Implicit			EntireVerse
+DEU	6	5	Moses			Implicit			EntireVerse
+DEU	6	6	Moses			Implicit			EntireVerse
+DEU	6	7	Moses			Implicit			EntireVerse
+DEU	6	8	Moses			Implicit			EntireVerse
+DEU	6	9	Moses			Implicit			EntireVerse
+DEU	6	10	Moses			Implicit			EntireVerse
+DEU	6	11	Moses			Implicit			EntireVerse
+DEU	6	12	Moses			Implicit			EntireVerse
+DEU	6	13	Moses			Implicit			EntireVerse
+DEU	6	14	Moses			Implicit			EntireVerse
+DEU	6	15	Moses			Implicit			EntireVerse
+DEU	6	16	Moses			Implicit			EntireVerse
+DEU	6	17	Moses			Implicit			EntireVerse
+DEU	6	18	Moses			Implicit			EntireVerse
+DEU	6	19	Moses			Implicit			EntireVerse
+DEU	6	20	Moses			Implicit			EntireVerse
 DEU	6	20	son (child) in Israel (hypothetical)			Hypothetical			Unspecified
-DEU	6	21	Moses			Implicit			
+DEU	6	21	Moses			Implicit			EntireVerse
 DEU	6	21	Israel			Hypothetical			Unspecified
-DEU	6	22	Moses			Implicit			
+DEU	6	22	Moses			Implicit			EntireVerse
 DEU	6	22	Israel			Hypothetical			Unspecified
-DEU	6	23	Moses			Implicit			
+DEU	6	23	Moses			Implicit			EntireVerse
 DEU	6	23	Israel			Hypothetical			Unspecified
-DEU	6	24	Moses			Implicit			
+DEU	6	24	Moses			Implicit			EntireVerse
 DEU	6	24	Israel			Hypothetical			Unspecified
-DEU	6	25	Moses			Implicit			
+DEU	6	25	Moses			Implicit			EntireVerse
 DEU	6	25	Israel			Hypothetical			Unspecified
-DEU	7	1	Moses			Implicit			
-DEU	7	2	Moses			Implicit			
-DEU	7	3	Moses			Implicit			
-DEU	7	4	Moses			Implicit			
-DEU	7	5	Moses			Implicit			
-DEU	7	6	Moses			Implicit			
-DEU	7	7	Moses			Implicit			
-DEU	7	8	Moses			Implicit			
-DEU	7	9	Moses			Implicit			
-DEU	7	10	Moses			Implicit			
-DEU	7	11	Moses			Implicit			
-DEU	7	12	Moses			Implicit			
-DEU	7	13	Moses			Implicit			
-DEU	7	14	Moses			Implicit			
-DEU	7	15	Moses			Implicit			
-DEU	7	16	Moses			Implicit			
-DEU	7	17	Moses			Implicit			
+DEU	7	1	Moses			Implicit			EntireVerse
+DEU	7	2	Moses			Implicit			EntireVerse
+DEU	7	3	Moses			Implicit			EntireVerse
+DEU	7	4	Moses			Implicit			EntireVerse
+DEU	7	5	Moses			Implicit			EntireVerse
+DEU	7	6	Moses			Implicit			EntireVerse
+DEU	7	7	Moses			Implicit			EntireVerse
+DEU	7	8	Moses			Implicit			EntireVerse
+DEU	7	9	Moses			Implicit			EntireVerse
+DEU	7	10	Moses			Implicit			EntireVerse
+DEU	7	11	Moses			Implicit			EntireVerse
+DEU	7	12	Moses			Implicit			EntireVerse
+DEU	7	13	Moses			Implicit			EntireVerse
+DEU	7	14	Moses			Implicit			EntireVerse
+DEU	7	15	Moses			Implicit			EntireVerse
+DEU	7	16	Moses			Implicit			EntireVerse
+DEU	7	17	Moses			Implicit			EntireVerse
 DEU	7	17	Israel			Hypothetical			Unspecified
-DEU	7	18	Moses			Implicit			
-DEU	7	19	Moses			Implicit			
-DEU	7	20	Moses			Implicit			
-DEU	7	21	Moses			Implicit			
-DEU	7	22	Moses			Implicit			
-DEU	7	23	Moses			Implicit			
-DEU	7	24	Moses			Implicit			
-DEU	7	25	Moses			Implicit			
-DEU	7	26	Moses			Implicit			
-DEU	8	1	Moses			Implicit			
-DEU	8	2	Moses			Implicit			
-DEU	8	3	Moses			Implicit			
-DEU	8	4	Moses			Implicit			
-DEU	8	5	Moses			Implicit			
-DEU	8	6	Moses			Implicit			
-DEU	8	7	Moses			Implicit			
-DEU	8	8	Moses			Implicit			
-DEU	8	9	Moses			Implicit			
-DEU	8	10	Moses			Implicit			
-DEU	8	11	Moses			Implicit			
-DEU	8	12	Moses			Implicit			
-DEU	8	13	Moses			Implicit			
-DEU	8	14	Moses			Implicit			
-DEU	8	15	Moses			Implicit			
-DEU	8	16	Moses			Implicit			
-DEU	8	17	Moses			Implicit			
+DEU	7	18	Moses			Implicit			EntireVerse
+DEU	7	19	Moses			Implicit			EntireVerse
+DEU	7	20	Moses			Implicit			EntireVerse
+DEU	7	21	Moses			Implicit			EntireVerse
+DEU	7	22	Moses			Implicit			EntireVerse
+DEU	7	23	Moses			Implicit			EntireVerse
+DEU	7	24	Moses			Implicit			EntireVerse
+DEU	7	25	Moses			Implicit			EntireVerse
+DEU	7	26	Moses			Implicit			EntireVerse
+DEU	8	1	Moses			Implicit			EntireVerse
+DEU	8	2	Moses			Implicit			EntireVerse
+DEU	8	3	Moses			Implicit			EntireVerse
+DEU	8	4	Moses			Implicit			EntireVerse
+DEU	8	5	Moses			Implicit			EntireVerse
+DEU	8	6	Moses			Implicit			EntireVerse
+DEU	8	7	Moses			Implicit			EntireVerse
+DEU	8	8	Moses			Implicit			EntireVerse
+DEU	8	9	Moses			Implicit			EntireVerse
+DEU	8	10	Moses			Implicit			EntireVerse
+DEU	8	11	Moses			Implicit			EntireVerse
+DEU	8	12	Moses			Implicit			EntireVerse
+DEU	8	13	Moses			Implicit			EntireVerse
+DEU	8	14	Moses			Implicit			EntireVerse
+DEU	8	15	Moses			Implicit			EntireVerse
+DEU	8	16	Moses			Implicit			EntireVerse
+DEU	8	17	Moses			Implicit			EntireVerse
 DEU	8	17	Israel			Hypothetical			Unspecified
-DEU	8	18	Moses			Implicit			
-DEU	8	19	Moses			Implicit			
-DEU	8	20	Moses			Implicit			
-DEU	9	1	Moses			Implicit			
-DEU	9	2	Moses			Implicit			
+DEU	8	18	Moses			Implicit			EntireVerse
+DEU	8	19	Moses			Implicit			EntireVerse
+DEU	8	20	Moses			Implicit			EntireVerse
+DEU	9	1	Moses			Implicit			EntireVerse
+DEU	9	2	Moses			Implicit			EntireVerse
 DEU	9	2	saying about Anakites			Quotation			Unspecified
-DEU	9	3	Moses			Implicit			
-DEU	9	4	Moses			Implicit			
+DEU	9	3	Moses			Implicit			EntireVerse
+DEU	9	4	Moses			Implicit			EntireVerse
 DEU	9	4	Israel			Hypothetical			Unspecified
-DEU	9	5	Moses			Implicit			
-DEU	9	6	Moses			Implicit			
-DEU	9	7	Moses			Implicit			
-DEU	9	8	Moses			Implicit			
-DEU	9	9	Moses			Implicit			
-DEU	9	10	Moses			Implicit			
-DEU	9	11	Moses			Implicit			
-DEU	9	12	Moses			Implicit			
+DEU	9	5	Moses			Implicit			EntireVerse
+DEU	9	6	Moses			Implicit			EntireVerse
+DEU	9	7	Moses			Implicit			EntireVerse
+DEU	9	8	Moses			Implicit			EntireVerse
+DEU	9	9	Moses			Implicit			EntireVerse
+DEU	9	10	Moses			Implicit			EntireVerse
+DEU	9	11	Moses			Implicit			EntireVerse
+DEU	9	12	Moses			Implicit			EntireVerse
 DEU	9	12	God		God (Yahweh)	Quotation			Unspecified
-DEU	9	13	Moses			Implicit			
+DEU	9	13	Moses			Implicit			EntireVerse
 DEU	9	13	God		God (Yahweh)	Quotation			Unspecified
-DEU	9	14	Moses			Implicit			
+DEU	9	14	Moses			Implicit			EntireVerse
 DEU	9	14	God		God (Yahweh)	Quotation			Unspecified
-DEU	9	15	Moses			Implicit			
-DEU	9	16	Moses			Implicit			
-DEU	9	17	Moses			Implicit			
-DEU	9	18	Moses			Implicit			
-DEU	9	19	Moses			Implicit			
-DEU	9	20	Moses			Implicit			
-DEU	9	21	Moses			Implicit			
-DEU	9	22	Moses			Implicit			
-DEU	9	23	Moses			Implicit			
+DEU	9	15	Moses			Implicit			EntireVerse
+DEU	9	16	Moses			Implicit			EntireVerse
+DEU	9	17	Moses			Implicit			EntireVerse
+DEU	9	18	Moses			Implicit			EntireVerse
+DEU	9	19	Moses			Implicit			EntireVerse
+DEU	9	20	Moses			Implicit			EntireVerse
+DEU	9	21	Moses			Implicit			EntireVerse
+DEU	9	22	Moses			Implicit			EntireVerse
+DEU	9	23	Moses			Implicit			EntireVerse
 DEU	9	23	God		God (Yahweh)	Quotation			Unspecified
-DEU	9	24	Moses			Implicit			
-DEU	9	25	Moses			Implicit			
-DEU	9	26	Moses			Implicit			
-DEU	9	27	Moses			Implicit			
-DEU	9	28	Moses			Implicit			
-DEU	9	29	Moses			Implicit			
-DEU	10	1	Moses			Implicit			
-DEU	10	2	Moses			Implicit			
-DEU	10	3	Moses			Implicit			
-DEU	10	4	Moses			Implicit			
-DEU	10	5	Moses			Implicit			
-DEU	10	6	Moses			Implicit			
-DEU	10	7	Moses			Implicit			
-DEU	10	8	Moses			Implicit			
-DEU	10	9	Moses			Implicit			
-DEU	10	10	Moses			Implicit			
-DEU	10	11	Moses			Implicit			
+DEU	9	24	Moses			Implicit			EntireVerse
+DEU	9	25	Moses			Implicit			EntireVerse
+DEU	9	26	Moses			Implicit			EntireVerse
+DEU	9	27	Moses			Implicit			EntireVerse
+DEU	9	28	Moses			Implicit			EntireVerse
+DEU	9	29	Moses			Implicit			EntireVerse
+DEU	10	1	Moses			Implicit			EntireVerse
+DEU	10	2	Moses			Implicit			EntireVerse
+DEU	10	3	Moses			Implicit			EntireVerse
+DEU	10	4	Moses			Implicit			EntireVerse
+DEU	10	5	Moses			Implicit			EntireVerse
+DEU	10	6	Moses			Implicit			EntireVerse
+DEU	10	7	Moses			Implicit			EntireVerse
+DEU	10	8	Moses			Implicit			EntireVerse
+DEU	10	9	Moses			Implicit			EntireVerse
+DEU	10	10	Moses			Implicit			EntireVerse
+DEU	10	11	Moses			Implicit			EntireVerse
 DEU	10	11	God		God (Yahweh)	Quotation			Unspecified
-DEU	10	12	Moses			Implicit			
-DEU	10	13	Moses			Implicit			
-DEU	10	14	Moses			Implicit			
-DEU	10	15	Moses			Implicit			
-DEU	10	16	Moses			Implicit			
-DEU	10	17	Moses			Implicit			
-DEU	10	18	Moses			Implicit			
-DEU	10	19	Moses			Implicit			
-DEU	10	20	Moses			Implicit			
-DEU	10	21	Moses			Implicit			
-DEU	10	22	Moses			Implicit			
-DEU	11	1	Moses			Implicit			
-DEU	11	2	Moses			Implicit			
-DEU	11	3	Moses			Implicit			
-DEU	11	4	Moses			Implicit			
-DEU	11	5	Moses			Implicit			
-DEU	11	6	Moses			Implicit			
-DEU	11	7	Moses			Implicit			
-DEU	11	8	Moses			Implicit			
-DEU	11	9	Moses			Implicit			
-DEU	11	10	Moses			Implicit			
-DEU	11	11	Moses			Implicit			
-DEU	11	12	Moses			Implicit			
-DEU	11	13	Moses			Implicit			
-DEU	11	14	Moses			Implicit			
-DEU	11	15	Moses			Implicit			
-DEU	11	16	Moses			Implicit			
-DEU	11	17	Moses			Implicit			
-DEU	11	18	Moses			Implicit			
-DEU	11	19	Moses			Implicit			
-DEU	11	20	Moses			Implicit			
-DEU	11	21	Moses			Implicit			
-DEU	11	22	Moses			Implicit			
-DEU	11	23	Moses			Implicit			
-DEU	11	24	Moses			Implicit			
-DEU	11	25	Moses			Implicit			
-DEU	11	26	Moses			Implicit			
-DEU	11	27	Moses			Implicit			
-DEU	11	28	Moses			Implicit			
-DEU	11	29	Moses			Implicit			
-DEU	11	30	Moses			Implicit			
-DEU	11	31	Moses			Implicit			
-DEU	11	32	Moses			Implicit			
-DEU	12	1	Moses			Implicit			
-DEU	12	2	Moses			Implicit			
-DEU	12	3	Moses			Implicit			
-DEU	12	4	Moses			Implicit			
-DEU	12	5	Moses			Implicit			
-DEU	12	6	Moses			Implicit			
-DEU	12	7	Moses			Implicit			
-DEU	12	8	Moses			Implicit			
-DEU	12	9	Moses			Implicit			
-DEU	12	10	Moses			Implicit			
-DEU	12	11	Moses			Implicit			
-DEU	12	12	Moses			Implicit			
-DEU	12	13	Moses			Implicit			
-DEU	12	14	Moses			Implicit			
-DEU	12	15	Moses			Implicit			
-DEU	12	16	Moses			Implicit			
-DEU	12	17	Moses			Implicit			
-DEU	12	18	Moses			Implicit			
-DEU	12	19	Moses			Implicit			
-DEU	12	20	Moses			Implicit			
+DEU	10	12	Moses			Implicit			EntireVerse
+DEU	10	13	Moses			Implicit			EntireVerse
+DEU	10	14	Moses			Implicit			EntireVerse
+DEU	10	15	Moses			Implicit			EntireVerse
+DEU	10	16	Moses			Implicit			EntireVerse
+DEU	10	17	Moses			Implicit			EntireVerse
+DEU	10	18	Moses			Implicit			EntireVerse
+DEU	10	19	Moses			Implicit			EntireVerse
+DEU	10	20	Moses			Implicit			EntireVerse
+DEU	10	21	Moses			Implicit			EntireVerse
+DEU	10	22	Moses			Implicit			EntireVerse
+DEU	11	1	Moses			Implicit			EntireVerse
+DEU	11	2	Moses			Implicit			EntireVerse
+DEU	11	3	Moses			Implicit			EntireVerse
+DEU	11	4	Moses			Implicit			EntireVerse
+DEU	11	5	Moses			Implicit			EntireVerse
+DEU	11	6	Moses			Implicit			EntireVerse
+DEU	11	7	Moses			Implicit			EntireVerse
+DEU	11	8	Moses			Implicit			EntireVerse
+DEU	11	9	Moses			Implicit			EntireVerse
+DEU	11	10	Moses			Implicit			EntireVerse
+DEU	11	11	Moses			Implicit			EntireVerse
+DEU	11	12	Moses			Implicit			EntireVerse
+DEU	11	13	Moses			Implicit			EntireVerse
+DEU	11	14	Moses			Implicit			EntireVerse
+DEU	11	15	Moses			Implicit			EntireVerse
+DEU	11	16	Moses			Implicit			EntireVerse
+DEU	11	17	Moses			Implicit			EntireVerse
+DEU	11	18	Moses			Implicit			EntireVerse
+DEU	11	19	Moses			Implicit			EntireVerse
+DEU	11	20	Moses			Implicit			EntireVerse
+DEU	11	21	Moses			Implicit			EntireVerse
+DEU	11	22	Moses			Implicit			EntireVerse
+DEU	11	23	Moses			Implicit			EntireVerse
+DEU	11	24	Moses			Implicit			EntireVerse
+DEU	11	25	Moses			Implicit			EntireVerse
+DEU	11	26	Moses			Implicit			EntireVerse
+DEU	11	27	Moses			Implicit			EntireVerse
+DEU	11	28	Moses			Implicit			EntireVerse
+DEU	11	29	Moses			Implicit			EntireVerse
+DEU	11	30	Moses			Implicit			EntireVerse
+DEU	11	31	Moses			Implicit			EntireVerse
+DEU	11	32	Moses			Implicit			EntireVerse
+DEU	12	1	Moses			Implicit			EntireVerse
+DEU	12	2	Moses			Implicit			EntireVerse
+DEU	12	3	Moses			Implicit			EntireVerse
+DEU	12	4	Moses			Implicit			EntireVerse
+DEU	12	5	Moses			Implicit			EntireVerse
+DEU	12	6	Moses			Implicit			EntireVerse
+DEU	12	7	Moses			Implicit			EntireVerse
+DEU	12	8	Moses			Implicit			EntireVerse
+DEU	12	9	Moses			Implicit			EntireVerse
+DEU	12	10	Moses			Implicit			EntireVerse
+DEU	12	11	Moses			Implicit			EntireVerse
+DEU	12	12	Moses			Implicit			EntireVerse
+DEU	12	13	Moses			Implicit			EntireVerse
+DEU	12	14	Moses			Implicit			EntireVerse
+DEU	12	15	Moses			Implicit			EntireVerse
+DEU	12	16	Moses			Implicit			EntireVerse
+DEU	12	17	Moses			Implicit			EntireVerse
+DEU	12	18	Moses			Implicit			EntireVerse
+DEU	12	19	Moses			Implicit			EntireVerse
+DEU	12	20	Moses			Implicit			EntireVerse
 DEU	12	20	Israel			Hypothetical			Unspecified
-DEU	12	21	Moses			Implicit			
-DEU	12	22	Moses			Implicit			
-DEU	12	23	Moses			Implicit			
-DEU	12	24	Moses			Implicit			
-DEU	12	25	Moses			Implicit			
-DEU	12	26	Moses			Implicit			
-DEU	12	27	Moses			Implicit			
-DEU	12	28	Moses			Implicit			
-DEU	12	29	Moses			Implicit			
-DEU	12	30	Moses			Implicit			
+DEU	12	21	Moses			Implicit			EntireVerse
+DEU	12	22	Moses			Implicit			EntireVerse
+DEU	12	23	Moses			Implicit			EntireVerse
+DEU	12	24	Moses			Implicit			EntireVerse
+DEU	12	25	Moses			Implicit			EntireVerse
+DEU	12	26	Moses			Implicit			EntireVerse
+DEU	12	27	Moses			Implicit			EntireVerse
+DEU	12	28	Moses			Implicit			EntireVerse
+DEU	12	29	Moses			Implicit			EntireVerse
+DEU	12	30	Moses			Implicit			EntireVerse
 DEU	12	30	Israel			Hypothetical			Unspecified
-DEU	12	31	Moses			Implicit			
-DEU	12	32	Moses			Implicit			
-DEU	13	1	Moses			Implicit			
-DEU	13	2	Moses			Implicit			
+DEU	12	31	Moses			Implicit			EntireVerse
+DEU	12	32	Moses			Implicit			EntireVerse
+DEU	13	1	Moses			Implicit			EntireVerse
+DEU	13	2	Moses			Implicit			EntireVerse
 DEU	13	2	Israel			Hypothetical			Unspecified
-DEU	13	3	Moses			Implicit			
-DEU	13	4	Moses			Implicit			
-DEU	13	5	Moses			Implicit			
-DEU	13	6	Moses			Implicit			
+DEU	13	3	Moses			Implicit			EntireVerse
+DEU	13	4	Moses			Implicit			EntireVerse
+DEU	13	5	Moses			Implicit			EntireVerse
+DEU	13	6	Moses			Implicit			EntireVerse
 DEU	13	6	Israel			Hypothetical			Unspecified
-DEU	13	7	Moses			Implicit			
-DEU	13	8	Moses			Implicit			
-DEU	13	9	Moses			Implicit			
-DEU	13	10	Moses			Implicit			
-DEU	13	11	Moses			Implicit			
-DEU	13	12	Moses			Implicit			
-DEU	13	13	Moses			Implicit			
+DEU	13	7	Moses			Implicit			EntireVerse
+DEU	13	8	Moses			Implicit			EntireVerse
+DEU	13	9	Moses			Implicit			EntireVerse
+DEU	13	10	Moses			Implicit			EntireVerse
+DEU	13	11	Moses			Implicit			EntireVerse
+DEU	13	12	Moses			Implicit			EntireVerse
+DEU	13	13	Moses			Implicit			EntireVerse
 DEU	13	13	Israel			Hypothetical			Unspecified
-DEU	13	14	Moses			Implicit			
-DEU	13	15	Moses			Implicit			
-DEU	13	16	Moses			Implicit			
-DEU	13	17	Moses			Implicit			
-DEU	13	18	Moses			Implicit			
-DEU	14	1	Moses			Implicit			
-DEU	14	2	Moses			Implicit			
-DEU	14	3	Moses			Implicit			
-DEU	14	4	Moses			Implicit			
-DEU	14	5	Moses			Implicit			
-DEU	14	6	Moses			Implicit			
-DEU	14	7	Moses			Implicit			
-DEU	14	8	Moses			Implicit			
-DEU	14	9	Moses			Implicit			
-DEU	14	10	Moses			Implicit			
-DEU	14	11	Moses			Implicit			
-DEU	14	12	Moses			Implicit			
-DEU	14	13	Moses			Implicit			
-DEU	14	14	Moses			Implicit			
-DEU	14	15	Moses			Implicit			
-DEU	14	16	Moses			Implicit			
-DEU	14	17	Moses			Implicit			
-DEU	14	18	Moses			Implicit			
-DEU	14	19	Moses			Implicit			
-DEU	14	20	Moses			Implicit			
-DEU	14	21	Moses			Implicit			
-DEU	14	22	Moses			Implicit			
-DEU	14	23	Moses			Implicit			
-DEU	14	24	Moses			Implicit			
-DEU	14	25	Moses			Implicit			
-DEU	14	26	Moses			Implicit			
-DEU	14	27	Moses			Implicit			
-DEU	14	28	Moses			Implicit			
-DEU	14	29	Moses			Implicit			
-DEU	15	1	Moses			Implicit			
-DEU	15	2	Moses			Implicit			
-DEU	15	3	Moses			Implicit			
-DEU	15	4	Moses			Implicit			
-DEU	15	5	Moses			Implicit			
-DEU	15	6	Moses			Implicit			
-DEU	15	7	Moses			Implicit			
-DEU	15	8	Moses			Implicit			
-DEU	15	9	Moses			Implicit			
+DEU	13	14	Moses			Implicit			EntireVerse
+DEU	13	15	Moses			Implicit			EntireVerse
+DEU	13	16	Moses			Implicit			EntireVerse
+DEU	13	17	Moses			Implicit			EntireVerse
+DEU	13	18	Moses			Implicit			EntireVerse
+DEU	14	1	Moses			Implicit			EntireVerse
+DEU	14	2	Moses			Implicit			EntireVerse
+DEU	14	3	Moses			Implicit			EntireVerse
+DEU	14	4	Moses			Implicit			EntireVerse
+DEU	14	5	Moses			Implicit			EntireVerse
+DEU	14	6	Moses			Implicit			EntireVerse
+DEU	14	7	Moses			Implicit			EntireVerse
+DEU	14	8	Moses			Implicit			EntireVerse
+DEU	14	9	Moses			Implicit			EntireVerse
+DEU	14	10	Moses			Implicit			EntireVerse
+DEU	14	11	Moses			Implicit			EntireVerse
+DEU	14	12	Moses			Implicit			EntireVerse
+DEU	14	13	Moses			Implicit			EntireVerse
+DEU	14	14	Moses			Implicit			EntireVerse
+DEU	14	15	Moses			Implicit			EntireVerse
+DEU	14	16	Moses			Implicit			EntireVerse
+DEU	14	17	Moses			Implicit			EntireVerse
+DEU	14	18	Moses			Implicit			EntireVerse
+DEU	14	19	Moses			Implicit			EntireVerse
+DEU	14	20	Moses			Implicit			EntireVerse
+DEU	14	21	Moses			Implicit			EntireVerse
+DEU	14	22	Moses			Implicit			EntireVerse
+DEU	14	23	Moses			Implicit			EntireVerse
+DEU	14	24	Moses			Implicit			EntireVerse
+DEU	14	25	Moses			Implicit			EntireVerse
+DEU	14	26	Moses			Implicit			EntireVerse
+DEU	14	27	Moses			Implicit			EntireVerse
+DEU	14	28	Moses			Implicit			EntireVerse
+DEU	14	29	Moses			Implicit			EntireVerse
+DEU	15	1	Moses			Implicit			EntireVerse
+DEU	15	2	Moses			Implicit			EntireVerse
+DEU	15	3	Moses			Implicit			EntireVerse
+DEU	15	4	Moses			Implicit			EntireVerse
+DEU	15	5	Moses			Implicit			EntireVerse
+DEU	15	6	Moses			Implicit			EntireVerse
+DEU	15	7	Moses			Implicit			EntireVerse
+DEU	15	8	Moses			Implicit			EntireVerse
+DEU	15	9	Moses			Implicit			EntireVerse
 DEU	15	9	Israel			Hypothetical			Unspecified
-DEU	15	10	Moses			Implicit			
-DEU	15	11	Moses			Implicit			
-DEU	15	12	Moses			Implicit			
-DEU	15	13	Moses			Implicit			
-DEU	15	14	Moses			Implicit			
-DEU	15	15	Moses			Implicit			
-DEU	15	16	Moses			Implicit			
-DEU	15	17	Moses			Implicit			
-DEU	15	18	Moses			Implicit			
-DEU	15	19	Moses			Implicit			
-DEU	15	20	Moses			Implicit			
-DEU	15	21	Moses			Implicit			
-DEU	15	22	Moses			Implicit			
-DEU	15	23	Moses			Implicit			
-DEU	16	1	Moses			Implicit			
-DEU	16	2	Moses			Implicit			
-DEU	16	3	Moses			Implicit			
-DEU	16	4	Moses			Implicit			
-DEU	16	5	Moses			Implicit			
-DEU	16	6	Moses			Implicit			
-DEU	16	7	Moses			Implicit			
-DEU	16	8	Moses			Implicit			
-DEU	16	9	Moses			Implicit			
-DEU	16	10	Moses			Implicit			
-DEU	16	11	Moses			Implicit			
-DEU	16	12	Moses			Implicit			
-DEU	16	13	Moses			Implicit			
-DEU	16	14	Moses			Implicit			
-DEU	16	15	Moses			Implicit			
-DEU	16	16	Moses			Implicit			
-DEU	16	17	Moses			Implicit			
-DEU	16	18	Moses			Implicit			
-DEU	16	19	Moses			Implicit			
-DEU	16	20	Moses			Implicit			
-DEU	16	21	Moses			Implicit			
-DEU	16	22	Moses			Implicit			
-DEU	17	1	Moses			Implicit			
-DEU	17	2	Moses			Implicit			
-DEU	17	3	Moses			Implicit			
-DEU	17	4	Moses			Implicit			
-DEU	17	5	Moses			Implicit			
-DEU	17	6	Moses			Implicit			
-DEU	17	7	Moses			Implicit			
-DEU	17	8	Moses			Implicit			
-DEU	17	9	Moses			Implicit			
-DEU	17	10	Moses			Implicit			
-DEU	17	11	Moses			Implicit			
-DEU	17	12	Moses			Implicit			
-DEU	17	13	Moses			Implicit			
-DEU	17	14	Moses			Implicit			
+DEU	15	10	Moses			Implicit			EntireVerse
+DEU	15	11	Moses			Implicit			EntireVerse
+DEU	15	12	Moses			Implicit			EntireVerse
+DEU	15	13	Moses			Implicit			EntireVerse
+DEU	15	14	Moses			Implicit			EntireVerse
+DEU	15	15	Moses			Implicit			EntireVerse
+DEU	15	16	Moses			Implicit			EntireVerse
+DEU	15	17	Moses			Implicit			EntireVerse
+DEU	15	18	Moses			Implicit			EntireVerse
+DEU	15	19	Moses			Implicit			EntireVerse
+DEU	15	20	Moses			Implicit			EntireVerse
+DEU	15	21	Moses			Implicit			EntireVerse
+DEU	15	22	Moses			Implicit			EntireVerse
+DEU	15	23	Moses			Implicit			EntireVerse
+DEU	16	1	Moses			Implicit			EntireVerse
+DEU	16	2	Moses			Implicit			EntireVerse
+DEU	16	3	Moses			Implicit			EntireVerse
+DEU	16	4	Moses			Implicit			EntireVerse
+DEU	16	5	Moses			Implicit			EntireVerse
+DEU	16	6	Moses			Implicit			EntireVerse
+DEU	16	7	Moses			Implicit			EntireVerse
+DEU	16	8	Moses			Implicit			EntireVerse
+DEU	16	9	Moses			Implicit			EntireVerse
+DEU	16	10	Moses			Implicit			EntireVerse
+DEU	16	11	Moses			Implicit			EntireVerse
+DEU	16	12	Moses			Implicit			EntireVerse
+DEU	16	13	Moses			Implicit			EntireVerse
+DEU	16	14	Moses			Implicit			EntireVerse
+DEU	16	15	Moses			Implicit			EntireVerse
+DEU	16	16	Moses			Implicit			EntireVerse
+DEU	16	17	Moses			Implicit			EntireVerse
+DEU	16	18	Moses			Implicit			EntireVerse
+DEU	16	19	Moses			Implicit			EntireVerse
+DEU	16	20	Moses			Implicit			EntireVerse
+DEU	16	21	Moses			Implicit			EntireVerse
+DEU	16	22	Moses			Implicit			EntireVerse
+DEU	17	1	Moses			Implicit			EntireVerse
+DEU	17	2	Moses			Implicit			EntireVerse
+DEU	17	3	Moses			Implicit			EntireVerse
+DEU	17	4	Moses			Implicit			EntireVerse
+DEU	17	5	Moses			Implicit			EntireVerse
+DEU	17	6	Moses			Implicit			EntireVerse
+DEU	17	7	Moses			Implicit			EntireVerse
+DEU	17	8	Moses			Implicit			EntireVerse
+DEU	17	9	Moses			Implicit			EntireVerse
+DEU	17	10	Moses			Implicit			EntireVerse
+DEU	17	11	Moses			Implicit			EntireVerse
+DEU	17	12	Moses			Implicit			EntireVerse
+DEU	17	13	Moses			Implicit			EntireVerse
+DEU	17	14	Moses			Implicit			EntireVerse
 DEU	17	14	Israel			Hypothetical			Unspecified
-DEU	17	15	Moses			Implicit			
-DEU	17	16	Moses			Implicit			
+DEU	17	15	Moses			Implicit			EntireVerse
+DEU	17	16	Moses			Implicit			EntireVerse
 DEU	17	16	God		God (Yahweh)	Quotation			Unspecified
-DEU	17	17	Moses			Implicit			
-DEU	17	18	Moses			Implicit			
-DEU	17	19	Moses			Implicit			
-DEU	17	20	Moses			Implicit			
-DEU	18	1	Moses			Implicit			
-DEU	18	2	Moses			Implicit			
-DEU	18	3	Moses			Implicit			
-DEU	18	4	Moses			Implicit			
-DEU	18	5	Moses			Implicit			
-DEU	18	6	Moses			Implicit			
-DEU	18	7	Moses			Implicit			
-DEU	18	8	Moses			Implicit			
-DEU	18	9	Moses			Implicit			
-DEU	18	10	Moses			Implicit			
-DEU	18	11	Moses			Implicit			
-DEU	18	12	Moses			Implicit			
-DEU	18	13	Moses			Implicit			
-DEU	18	14	Moses			Implicit			
-DEU	18	15	Moses			Implicit			
-DEU	18	16	Moses			Implicit			
+DEU	17	17	Moses			Implicit			EntireVerse
+DEU	17	18	Moses			Implicit			EntireVerse
+DEU	17	19	Moses			Implicit			EntireVerse
+DEU	17	20	Moses			Implicit			EntireVerse
+DEU	18	1	Moses			Implicit			EntireVerse
+DEU	18	2	Moses			Implicit			EntireVerse
+DEU	18	3	Moses			Implicit			EntireVerse
+DEU	18	4	Moses			Implicit			EntireVerse
+DEU	18	5	Moses			Implicit			EntireVerse
+DEU	18	6	Moses			Implicit			EntireVerse
+DEU	18	7	Moses			Implicit			EntireVerse
+DEU	18	8	Moses			Implicit			EntireVerse
+DEU	18	9	Moses			Implicit			EntireVerse
+DEU	18	10	Moses			Implicit			EntireVerse
+DEU	18	11	Moses			Implicit			EntireVerse
+DEU	18	12	Moses			Implicit			EntireVerse
+DEU	18	13	Moses			Implicit			EntireVerse
+DEU	18	14	Moses			Implicit			EntireVerse
+DEU	18	15	Moses			Implicit			EntireVerse
+DEU	18	16	Moses			Implicit			EntireVerse
 DEU	18	16	Israel			Quotation			Unspecified
-DEU	18	17	Moses			Implicit			
+DEU	18	17	Moses			Implicit			EntireVerse
 DEU	18	17	God		God (Yahweh)	Quotation			Unspecified
-DEU	18	18	Moses			Implicit			
+DEU	18	18	Moses			Implicit			EntireVerse
 DEU	18	18	God		God (Yahweh)	Quotation			Unspecified
-DEU	18	19	Moses			Implicit			
+DEU	18	19	Moses			Implicit			EntireVerse
 DEU	18	19	God		God (Yahweh)	Quotation			Unspecified
-DEU	18	20	Moses			Implicit			
+DEU	18	20	Moses			Implicit			EntireVerse
 DEU	18	20	God		God (Yahweh)	Quotation			Unspecified
-DEU	18	21	Moses			Implicit			
+DEU	18	21	Moses			Implicit			EntireVerse
 DEU	18	21	Israel			Hypothetical			Unspecified
-DEU	18	22	Moses			Implicit			
-DEU	19	1	Moses			Implicit			
-DEU	19	2	Moses			Implicit			
-DEU	19	3	Moses			Implicit			
-DEU	19	4	Moses			Implicit			
-DEU	19	5	Moses			Implicit			
-DEU	19	6	Moses			Implicit			
-DEU	19	7	Moses			Implicit			
-DEU	19	8	Moses			Implicit			
-DEU	19	9	Moses			Implicit			
-DEU	19	10	Moses			Implicit			
-DEU	19	11	Moses			Implicit			
-DEU	19	12	Moses			Implicit			
-DEU	19	13	Moses			Implicit			
-DEU	19	14	Moses			Implicit			
-DEU	19	15	Moses			Implicit			
-DEU	19	16	Moses			Implicit			
-DEU	19	17	Moses			Implicit			
-DEU	19	18	Moses			Implicit			
-DEU	19	19	Moses			Implicit			
-DEU	19	20	Moses			Implicit			
-DEU	19	21	Moses			Implicit			
-DEU	20	1	Moses			Implicit			
-DEU	20	2	Moses			Implicit			
-DEU	20	3	Moses			Implicit			
+DEU	18	22	Moses			Implicit			EntireVerse
+DEU	19	1	Moses			Implicit			EntireVerse
+DEU	19	2	Moses			Implicit			EntireVerse
+DEU	19	3	Moses			Implicit			EntireVerse
+DEU	19	4	Moses			Implicit			EntireVerse
+DEU	19	5	Moses			Implicit			EntireVerse
+DEU	19	6	Moses			Implicit			EntireVerse
+DEU	19	7	Moses			Implicit			EntireVerse
+DEU	19	8	Moses			Implicit			EntireVerse
+DEU	19	9	Moses			Implicit			EntireVerse
+DEU	19	10	Moses			Implicit			EntireVerse
+DEU	19	11	Moses			Implicit			EntireVerse
+DEU	19	12	Moses			Implicit			EntireVerse
+DEU	19	13	Moses			Implicit			EntireVerse
+DEU	19	14	Moses			Implicit			EntireVerse
+DEU	19	15	Moses			Implicit			EntireVerse
+DEU	19	16	Moses			Implicit			EntireVerse
+DEU	19	17	Moses			Implicit			EntireVerse
+DEU	19	18	Moses			Implicit			EntireVerse
+DEU	19	19	Moses			Implicit			EntireVerse
+DEU	19	20	Moses			Implicit			EntireVerse
+DEU	19	21	Moses			Implicit			EntireVerse
+DEU	20	1	Moses			Implicit			EntireVerse
+DEU	20	2	Moses			Implicit			EntireVerse
+DEU	20	3	Moses			Implicit			EntireVerse
 DEU	20	3	priest			Hypothetical			Unspecified
-DEU	20	4	Moses			Implicit			
+DEU	20	4	Moses			Implicit			EntireVerse
 DEU	20	4	priest			Hypothetical			Unspecified
-DEU	20	5	Moses			Implicit			
+DEU	20	5	Moses			Implicit			EntireVerse
 DEU	20	5	officers			Hypothetical			Unspecified
-DEU	20	6	Moses			Implicit			
+DEU	20	6	Moses			Implicit			EntireVerse
 DEU	20	6	officers			Hypothetical			Unspecified
-DEU	20	7	Moses			Implicit			
+DEU	20	7	Moses			Implicit			EntireVerse
 DEU	20	7	officers			Hypothetical			Unspecified
-DEU	20	8	Moses			Implicit			
+DEU	20	8	Moses			Implicit			EntireVerse
 DEU	20	8	officers			Hypothetical			Unspecified
-DEU	20	9	Moses			Implicit			
-DEU	20	10	Moses			Implicit			
-DEU	20	11	Moses			Implicit			
-DEU	20	12	Moses			Implicit			
-DEU	20	13	Moses			Implicit			
-DEU	20	14	Moses			Implicit			
-DEU	20	15	Moses			Implicit			
-DEU	20	16	Moses			Implicit			
-DEU	20	17	Moses			Implicit			
-DEU	20	18	Moses			Implicit			
-DEU	20	19	Moses			Implicit			
-DEU	20	20	Moses			Implicit			
-DEU	21	1	Moses			Implicit			
-DEU	21	2	Moses			Implicit			
-DEU	21	3	Moses			Implicit			
-DEU	21	4	Moses			Implicit			
-DEU	21	5	Moses			Implicit			
-DEU	21	6	Moses			Implicit			
-DEU	21	7	Moses			Implicit			
+DEU	20	9	Moses			Implicit			EntireVerse
+DEU	20	10	Moses			Implicit			EntireVerse
+DEU	20	11	Moses			Implicit			EntireVerse
+DEU	20	12	Moses			Implicit			EntireVerse
+DEU	20	13	Moses			Implicit			EntireVerse
+DEU	20	14	Moses			Implicit			EntireVerse
+DEU	20	15	Moses			Implicit			EntireVerse
+DEU	20	16	Moses			Implicit			EntireVerse
+DEU	20	17	Moses			Implicit			EntireVerse
+DEU	20	18	Moses			Implicit			EntireVerse
+DEU	20	19	Moses			Implicit			EntireVerse
+DEU	20	20	Moses			Implicit			EntireVerse
+DEU	21	1	Moses			Implicit			EntireVerse
+DEU	21	2	Moses			Implicit			EntireVerse
+DEU	21	3	Moses			Implicit			EntireVerse
+DEU	21	4	Moses			Implicit			EntireVerse
+DEU	21	5	Moses			Implicit			EntireVerse
+DEU	21	6	Moses			Implicit			EntireVerse
+DEU	21	7	Moses			Implicit			EntireVerse
 DEU	21	7	elders of the town			Hypothetical			Unspecified
-DEU	21	8	Moses			Implicit			
+DEU	21	8	Moses			Implicit			EntireVerse
 DEU	21	8	elders of the town			Hypothetical			Unspecified
-DEU	21	9	Moses			Implicit			
-DEU	21	10	Moses			Implicit			
-DEU	21	11	Moses			Implicit			
-DEU	21	12	Moses			Implicit			
-DEU	21	13	Moses			Implicit			
-DEU	21	14	Moses			Implicit			
-DEU	21	15	Moses			Implicit			
-DEU	21	16	Moses			Implicit			
-DEU	21	17	Moses			Implicit			
-DEU	21	18	Moses			Implicit			
-DEU	21	19	Moses			Implicit			
-DEU	21	20	Moses			Implicit			
+DEU	21	9	Moses			Implicit			EntireVerse
+DEU	21	10	Moses			Implicit			EntireVerse
+DEU	21	11	Moses			Implicit			EntireVerse
+DEU	21	12	Moses			Implicit			EntireVerse
+DEU	21	13	Moses			Implicit			EntireVerse
+DEU	21	14	Moses			Implicit			EntireVerse
+DEU	21	15	Moses			Implicit			EntireVerse
+DEU	21	16	Moses			Implicit			EntireVerse
+DEU	21	17	Moses			Implicit			EntireVerse
+DEU	21	18	Moses			Implicit			EntireVerse
+DEU	21	19	Moses			Implicit			EntireVerse
+DEU	21	20	Moses			Implicit			EntireVerse
 DEU	21	20	parents of rebellious son			Hypothetical			Unspecified
-DEU	21	21	Moses			Implicit			
-DEU	21	22	Moses			Implicit			
-DEU	21	23	Moses			Implicit			
-DEU	22	1	Moses			Implicit			
-DEU	22	2	Moses			Implicit			
-DEU	22	3	Moses			Implicit			
-DEU	22	4	Moses			Implicit			
-DEU	22	5	Moses			Implicit			
-DEU	22	6	Moses			Implicit			
-DEU	22	7	Moses			Implicit			
-DEU	22	8	Moses			Implicit			
-DEU	22	9	Moses			Implicit			
-DEU	22	10	Moses			Implicit			
-DEU	22	11	Moses			Implicit			
-DEU	22	12	Moses			Implicit			
-DEU	22	13	Moses			Implicit			
-DEU	22	14	Moses			Implicit			
+DEU	21	21	Moses			Implicit			EntireVerse
+DEU	21	22	Moses			Implicit			EntireVerse
+DEU	21	23	Moses			Implicit			EntireVerse
+DEU	22	1	Moses			Implicit			EntireVerse
+DEU	22	2	Moses			Implicit			EntireVerse
+DEU	22	3	Moses			Implicit			EntireVerse
+DEU	22	4	Moses			Implicit			EntireVerse
+DEU	22	5	Moses			Implicit			EntireVerse
+DEU	22	6	Moses			Implicit			EntireVerse
+DEU	22	7	Moses			Implicit			EntireVerse
+DEU	22	8	Moses			Implicit			EntireVerse
+DEU	22	9	Moses			Implicit			EntireVerse
+DEU	22	10	Moses			Implicit			EntireVerse
+DEU	22	11	Moses			Implicit			EntireVerse
+DEU	22	12	Moses			Implicit			EntireVerse
+DEU	22	13	Moses			Implicit			EntireVerse
+DEU	22	14	Moses			Implicit			EntireVerse
 DEU	22	14	husband accusing wife			Hypothetical			Unspecified
-DEU	22	15	Moses			Implicit			
-DEU	22	16	Moses			Implicit			
+DEU	22	15	Moses			Implicit			EntireVerse
+DEU	22	16	Moses			Implicit			EntireVerse
 DEU	22	16	father of accused daughter			Hypothetical			Unspecified
-DEU	22	17	Moses			Implicit			
+DEU	22	17	Moses			Implicit			EntireVerse
 DEU	22	17	father of accused daughter			Hypothetical			Unspecified
-DEU	22	18	Moses			Implicit			
-DEU	22	19	Moses			Implicit			
-DEU	22	20	Moses			Implicit			
-DEU	22	21	Moses			Implicit			
-DEU	22	22	Moses			Implicit			
-DEU	22	23	Moses			Implicit			
-DEU	22	24	Moses			Implicit			
-DEU	22	25	Moses			Implicit			
-DEU	22	26	Moses			Implicit			
-DEU	22	27	Moses			Implicit			
-DEU	22	28	Moses			Implicit			
-DEU	22	29	Moses			Implicit			
-DEU	22	30	Moses			Implicit			
-DEU	23	1	Moses			Implicit			
-DEU	23	2	Moses			Implicit			
-DEU	23	3	Moses			Implicit			
-DEU	23	4	Moses			Implicit			
-DEU	23	5	Moses			Implicit			
-DEU	23	6	Moses			Implicit			
-DEU	23	7	Moses			Implicit			
-DEU	23	8	Moses			Implicit			
-DEU	23	9	Moses			Implicit			
-DEU	23	10	Moses			Implicit			
-DEU	23	11	Moses			Implicit			
-DEU	23	12	Moses			Implicit			
-DEU	23	13	Moses			Implicit			
-DEU	23	14	Moses			Implicit			
-DEU	23	15	Moses			Implicit			
-DEU	23	16	Moses			Implicit			
-DEU	23	17	Moses			Implicit			
-DEU	23	18	Moses			Implicit			
-DEU	23	19	Moses			Implicit			
-DEU	23	20	Moses			Implicit			
-DEU	23	21	Moses			Implicit			
-DEU	23	22	Moses			Implicit			
-DEU	23	23	Moses			Implicit			
-DEU	23	24	Moses			Implicit			
-DEU	23	25	Moses			Implicit			
-DEU	24	1	Moses			Implicit			
-DEU	24	2	Moses			Implicit			
-DEU	24	3	Moses			Implicit			
-DEU	24	4	Moses			Implicit			
-DEU	24	5	Moses			Implicit			
-DEU	24	6	Moses			Implicit			
-DEU	24	7	Moses			Implicit			
-DEU	24	8	Moses			Implicit			
-DEU	24	9	Moses			Implicit			
-DEU	24	10	Moses			Implicit			
-DEU	24	11	Moses			Implicit			
-DEU	24	12	Moses			Implicit			
-DEU	24	13	Moses			Implicit			
-DEU	24	14	Moses			Implicit			
-DEU	24	15	Moses			Implicit			
-DEU	24	16	Moses			Implicit			
-DEU	24	17	Moses			Implicit			
-DEU	24	18	Moses			Implicit			
-DEU	24	19	Moses			Implicit			
-DEU	24	20	Moses			Implicit			
-DEU	24	21	Moses			Implicit			
-DEU	24	22	Moses			Implicit			
-DEU	25	1	Moses			Implicit			
-DEU	25	2	Moses			Implicit			
-DEU	25	3	Moses			Implicit			
-DEU	25	4	Moses			Implicit			
-DEU	25	5	Moses			Implicit			
-DEU	25	6	Moses			Implicit			
-DEU	25	7	Moses			Implicit			
+DEU	22	18	Moses			Implicit			EntireVerse
+DEU	22	19	Moses			Implicit			EntireVerse
+DEU	22	20	Moses			Implicit			EntireVerse
+DEU	22	21	Moses			Implicit			EntireVerse
+DEU	22	22	Moses			Implicit			EntireVerse
+DEU	22	23	Moses			Implicit			EntireVerse
+DEU	22	24	Moses			Implicit			EntireVerse
+DEU	22	25	Moses			Implicit			EntireVerse
+DEU	22	26	Moses			Implicit			EntireVerse
+DEU	22	27	Moses			Implicit			EntireVerse
+DEU	22	28	Moses			Implicit			EntireVerse
+DEU	22	29	Moses			Implicit			EntireVerse
+DEU	22	30	Moses			Implicit			EntireVerse
+DEU	23	1	Moses			Implicit			EntireVerse
+DEU	23	2	Moses			Implicit			EntireVerse
+DEU	23	3	Moses			Implicit			EntireVerse
+DEU	23	4	Moses			Implicit			EntireVerse
+DEU	23	5	Moses			Implicit			EntireVerse
+DEU	23	6	Moses			Implicit			EntireVerse
+DEU	23	7	Moses			Implicit			EntireVerse
+DEU	23	8	Moses			Implicit			EntireVerse
+DEU	23	9	Moses			Implicit			EntireVerse
+DEU	23	10	Moses			Implicit			EntireVerse
+DEU	23	11	Moses			Implicit			EntireVerse
+DEU	23	12	Moses			Implicit			EntireVerse
+DEU	23	13	Moses			Implicit			EntireVerse
+DEU	23	14	Moses			Implicit			EntireVerse
+DEU	23	15	Moses			Implicit			EntireVerse
+DEU	23	16	Moses			Implicit			EntireVerse
+DEU	23	17	Moses			Implicit			EntireVerse
+DEU	23	18	Moses			Implicit			EntireVerse
+DEU	23	19	Moses			Implicit			EntireVerse
+DEU	23	20	Moses			Implicit			EntireVerse
+DEU	23	21	Moses			Implicit			EntireVerse
+DEU	23	22	Moses			Implicit			EntireVerse
+DEU	23	23	Moses			Implicit			EntireVerse
+DEU	23	24	Moses			Implicit			EntireVerse
+DEU	23	25	Moses			Implicit			EntireVerse
+DEU	24	1	Moses			Implicit			EntireVerse
+DEU	24	2	Moses			Implicit			EntireVerse
+DEU	24	3	Moses			Implicit			EntireVerse
+DEU	24	4	Moses			Implicit			EntireVerse
+DEU	24	5	Moses			Implicit			EntireVerse
+DEU	24	6	Moses			Implicit			EntireVerse
+DEU	24	7	Moses			Implicit			EntireVerse
+DEU	24	8	Moses			Implicit			EntireVerse
+DEU	24	9	Moses			Implicit			EntireVerse
+DEU	24	10	Moses			Implicit			EntireVerse
+DEU	24	11	Moses			Implicit			EntireVerse
+DEU	24	12	Moses			Implicit			EntireVerse
+DEU	24	13	Moses			Implicit			EntireVerse
+DEU	24	14	Moses			Implicit			EntireVerse
+DEU	24	15	Moses			Implicit			EntireVerse
+DEU	24	16	Moses			Implicit			EntireVerse
+DEU	24	17	Moses			Implicit			EntireVerse
+DEU	24	18	Moses			Implicit			EntireVerse
+DEU	24	19	Moses			Implicit			EntireVerse
+DEU	24	20	Moses			Implicit			EntireVerse
+DEU	24	21	Moses			Implicit			EntireVerse
+DEU	24	22	Moses			Implicit			EntireVerse
+DEU	25	1	Moses			Implicit			EntireVerse
+DEU	25	2	Moses			Implicit			EntireVerse
+DEU	25	3	Moses			Implicit			EntireVerse
+DEU	25	4	Moses			Implicit			EntireVerse
+DEU	25	5	Moses			Implicit			EntireVerse
+DEU	25	6	Moses			Implicit			EntireVerse
+DEU	25	7	Moses			Implicit			EntireVerse
 DEU	25	7	widow			Hypothetical			Unspecified
-DEU	25	8	Moses			Implicit			
+DEU	25	8	Moses			Implicit			EntireVerse
 DEU	25	8	brother-in-law of widow			Hypothetical			Unspecified
 DEU	25	8	elders of the town			Indirect			
-DEU	25	9	Moses			Implicit			
+DEU	25	9	Moses			Implicit			EntireVerse
 DEU	25	9	widow			Hypothetical			Unspecified
-DEU	25	10	Moses			Implicit			
+DEU	25	10	Moses			Implicit			EntireVerse
 DEU	25	10	narrator-DEU			Quotation			Unspecified
-DEU	25	11	Moses			Implicit			
-DEU	25	12	Moses			Implicit			
-DEU	25	13	Moses			Implicit			
-DEU	25	14	Moses			Implicit			
-DEU	25	15	Moses			Implicit			
-DEU	25	16	Moses			Implicit			
-DEU	25	17	Moses			Implicit			
-DEU	25	18	Moses			Implicit			
-DEU	25	19	Moses			Implicit			
-DEU	26	1	Moses			Implicit			
-DEU	26	2	Moses			Implicit			
-DEU	26	3	Moses			Implicit			
+DEU	25	11	Moses			Implicit			EntireVerse
+DEU	25	12	Moses			Implicit			EntireVerse
+DEU	25	13	Moses			Implicit			EntireVerse
+DEU	25	14	Moses			Implicit			EntireVerse
+DEU	25	15	Moses			Implicit			EntireVerse
+DEU	25	16	Moses			Implicit			EntireVerse
+DEU	25	17	Moses			Implicit			EntireVerse
+DEU	25	18	Moses			Implicit			EntireVerse
+DEU	25	19	Moses			Implicit			EntireVerse
+DEU	26	1	Moses			Implicit			EntireVerse
+DEU	26	2	Moses			Implicit			EntireVerse
+DEU	26	3	Moses			Implicit			EntireVerse
 DEU	26	3	Israel			Hypothetical			Unspecified
-DEU	26	4	Moses			Implicit			
-DEU	26	5	Moses			Implicit			
+DEU	26	4	Moses			Implicit			EntireVerse
+DEU	26	5	Moses			Implicit			EntireVerse
 DEU	26	5	Israel			Hypothetical			Unspecified
-DEU	26	6	Moses			Implicit			
+DEU	26	6	Moses			Implicit			EntireVerse
 DEU	26	6	Israel			Hypothetical			Unspecified
-DEU	26	7	Moses			Implicit			
+DEU	26	7	Moses			Implicit			EntireVerse
 DEU	26	7	Israel			Hypothetical			Unspecified
-DEU	26	8	Moses			Implicit			
+DEU	26	8	Moses			Implicit			EntireVerse
 DEU	26	8	Israel			Hypothetical			Unspecified
-DEU	26	9	Moses			Implicit			
+DEU	26	9	Moses			Implicit			EntireVerse
 DEU	26	9	Israel			Hypothetical			Unspecified
-DEU	26	10	Moses			Implicit			
+DEU	26	10	Moses			Implicit			EntireVerse
 DEU	26	10	Israel			Hypothetical			Unspecified
-DEU	26	11	Moses			Implicit			
-DEU	26	12	Moses			Implicit			
-DEU	26	13	Moses			Implicit			
+DEU	26	11	Moses			Implicit			EntireVerse
+DEU	26	12	Moses			Implicit			EntireVerse
+DEU	26	13	Moses			Implicit			EntireVerse
 DEU	26	13	Israel			Hypothetical			Unspecified
-DEU	26	14	Moses			Implicit			
+DEU	26	14	Moses			Implicit			EntireVerse
 DEU	26	14	Israel			Hypothetical			Unspecified
-DEU	26	15	Moses			Implicit			
+DEU	26	15	Moses			Implicit			EntireVerse
 DEU	26	15	Israel			Hypothetical			Unspecified
-DEU	26	16	Moses			Implicit			
-DEU	26	17	Moses			Implicit			
-DEU	26	18	Moses			Implicit			
-DEU	26	19	Moses			Implicit			
+DEU	26	16	Moses			Implicit			EntireVerse
+DEU	26	17	Moses			Implicit			EntireVerse
+DEU	26	18	Moses			Implicit			EntireVerse
+DEU	26	19	Moses			Implicit			EntireVerse
 DEU	27	1	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	2	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	3	Moses/elders of Israel			Normal	Moses		Unspecified
@@ -4032,243 +4032,243 @@ DEU	27	8	Moses/elders of Israel			Normal	Moses		Unspecified
 DEU	27	9	Moses/priests			Normal	Moses		EndOfVerse
 DEU	27	10	Moses/priests			Normal	Moses		EntireVerse
 DEU	27	11	Moses			Indirect			
-DEU	27	12	Moses			Implicit			
-DEU	27	13	Moses			Implicit			
-DEU	27	14	Moses			Implicit			
-DEU	27	15	Moses			Implicit			
-DEU	27	16	Moses			Implicit			
-DEU	27	17	Moses			Implicit			
-DEU	27	18	Moses			Implicit			
-DEU	27	19	Moses			Implicit			
-DEU	27	20	Moses			Implicit			
-DEU	27	21	Moses			Implicit			
-DEU	27	22	Moses			Implicit			
-DEU	27	23	Moses			Implicit			
-DEU	27	24	Moses			Implicit			
-DEU	27	25	Moses			Implicit			
-DEU	27	26	Moses			Implicit			
-DEU	28	1	Moses			Implicit			
-DEU	28	2	Moses			Implicit			
-DEU	28	3	Moses			Implicit			
-DEU	28	4	Moses			Implicit			
-DEU	28	5	Moses			Implicit			
-DEU	28	6	Moses			Implicit			
-DEU	28	7	Moses			Implicit			
-DEU	28	8	Moses			Implicit			
-DEU	28	9	Moses			Implicit			
-DEU	28	10	Moses			Implicit			
-DEU	28	11	Moses			Implicit			
-DEU	28	12	Moses			Implicit			
-DEU	28	13	Moses			Implicit			
-DEU	28	14	Moses			Implicit			
-DEU	28	15	Moses			Implicit			
-DEU	28	16	Moses			Implicit			
-DEU	28	17	Moses			Implicit			
-DEU	28	18	Moses			Implicit			
-DEU	28	19	Moses			Implicit			
-DEU	28	20	Moses			Implicit			
-DEU	28	21	Moses			Implicit			
-DEU	28	22	Moses			Implicit			
-DEU	28	23	Moses			Implicit			
-DEU	28	24	Moses			Implicit			
-DEU	28	25	Moses			Implicit			
-DEU	28	26	Moses			Implicit			
-DEU	28	27	Moses			Implicit			
-DEU	28	28	Moses			Implicit			
-DEU	28	29	Moses			Implicit			
-DEU	28	30	Moses			Implicit			
-DEU	28	31	Moses			Implicit			
-DEU	28	32	Moses			Implicit			
-DEU	28	33	Moses			Implicit			
-DEU	28	34	Moses			Implicit			
-DEU	28	35	Moses			Implicit			
-DEU	28	36	Moses			Implicit			
-DEU	28	37	Moses			Implicit			
-DEU	28	38	Moses			Implicit			
-DEU	28	39	Moses			Implicit			
-DEU	28	40	Moses			Implicit			
-DEU	28	41	Moses			Implicit			
-DEU	28	42	Moses			Implicit			
-DEU	28	43	Moses			Implicit			
-DEU	28	44	Moses			Implicit			
-DEU	28	45	Moses			Implicit			
-DEU	28	46	Moses			Implicit			
-DEU	28	47	Moses			Implicit			
-DEU	28	48	Moses			Implicit			
-DEU	28	49	Moses			Implicit			
-DEU	28	50	Moses			Implicit			
-DEU	28	51	Moses			Implicit			
-DEU	28	52	Moses			Implicit			
-DEU	28	53	Moses			Implicit			
-DEU	28	54	Moses			Implicit			
-DEU	28	55	Moses			Implicit			
-DEU	28	56	Moses			Implicit			
-DEU	28	57	Moses			Implicit			
-DEU	28	58	Moses			Implicit			
-DEU	28	59	Moses			Implicit			
-DEU	28	60	Moses			Implicit			
-DEU	28	61	Moses			Implicit			
-DEU	28	62	Moses			Implicit			
-DEU	28	63	Moses			Implicit			
-DEU	28	64	Moses			Implicit			
-DEU	28	65	Moses			Implicit			
-DEU	28	66	Moses			Implicit			
-DEU	28	67	Moses			Implicit			
-DEU	28	68	Moses			Implicit			
-DEU	29	2	Moses			Implicit			
-DEU	29	3	Moses			Implicit			
-DEU	29	4	Moses			Implicit			
-DEU	29	5	Moses			Implicit			
-DEU	29	6	Moses			Implicit			
-DEU	29	7	Moses			Implicit			
-DEU	29	8	Moses			Implicit			
-DEU	29	9	Moses			Implicit			
-DEU	29	10	Moses			Implicit			
-DEU	29	11	Moses			Implicit			
-DEU	29	12	Moses			Implicit			
-DEU	29	13	Moses			Implicit			
-DEU	29	14	Moses			Implicit			
-DEU	29	15	Moses			Implicit			
-DEU	29	16	Moses			Implicit			
-DEU	29	17	Moses			Implicit			
-DEU	29	18	Moses			Implicit			
-DEU	29	19	Moses			Implicit			
-DEU	29	20	Moses			Implicit			
-DEU	29	21	Moses			Implicit			
-DEU	29	22	Moses			Implicit			
-DEU	29	23	Moses			Implicit			
-DEU	29	24	Moses			Implicit			
-DEU	29	25	Moses			Implicit			
-DEU	29	26	Moses			Implicit			
-DEU	29	27	Moses			Implicit			
-DEU	29	28	Moses			Implicit			
-DEU	29	29	Moses			Implicit			
-DEU	30	1	Moses			Implicit			
-DEU	30	2	Moses			Implicit			
-DEU	30	3	Moses			Implicit			
-DEU	30	4	Moses			Implicit			
-DEU	30	5	Moses			Implicit			
-DEU	30	6	Moses			Implicit			
-DEU	30	7	Moses			Implicit			
-DEU	30	8	Moses			Implicit			
-DEU	30	9	Moses			Implicit			
-DEU	30	10	Moses			Implicit			
-DEU	30	11	Moses			Implicit			
-DEU	30	12	Moses			Implicit			
-DEU	30	13	Moses			Implicit			
-DEU	30	14	Moses			Implicit			
-DEU	30	15	Moses			Implicit			
-DEU	30	16	Moses			Implicit			
-DEU	30	17	Moses			Implicit			
-DEU	30	18	Moses			Implicit			
-DEU	30	19	Moses			Implicit			
-DEU	30	20	Moses			Implicit			
-DEU	31	2	Moses			Implicit			
-DEU	31	3	Moses			Implicit			
-DEU	31	4	Moses			Implicit			
-DEU	31	5	Moses			Implicit			
-DEU	31	6	Moses			Implicit			
-DEU	31	7	Moses			Implicit			
-DEU	31	8	Moses			Implicit			
-DEU	31	10	Moses			Implicit			
-DEU	31	11	Moses			Implicit			
-DEU	31	12	Moses			Implicit			
-DEU	31	13	Moses			Implicit			
+DEU	27	12	Moses			Implicit			EntireVerse
+DEU	27	13	Moses			Implicit			EntireVerse
+DEU	27	14	Moses			Implicit			EntireVerse
+DEU	27	15	Moses			Implicit			EntireVerse
+DEU	27	16	Moses			Implicit			EntireVerse
+DEU	27	17	Moses			Implicit			EntireVerse
+DEU	27	18	Moses			Implicit			EntireVerse
+DEU	27	19	Moses			Implicit			EntireVerse
+DEU	27	20	Moses			Implicit			EntireVerse
+DEU	27	21	Moses			Implicit			EntireVerse
+DEU	27	22	Moses			Implicit			EntireVerse
+DEU	27	23	Moses			Implicit			EntireVerse
+DEU	27	24	Moses			Implicit			EntireVerse
+DEU	27	25	Moses			Implicit			EntireVerse
+DEU	27	26	Moses			Implicit			EntireVerse
+DEU	28	1	Moses			Implicit			EntireVerse
+DEU	28	2	Moses			Implicit			EntireVerse
+DEU	28	3	Moses			Implicit			EntireVerse
+DEU	28	4	Moses			Implicit			EntireVerse
+DEU	28	5	Moses			Implicit			EntireVerse
+DEU	28	6	Moses			Implicit			EntireVerse
+DEU	28	7	Moses			Implicit			EntireVerse
+DEU	28	8	Moses			Implicit			EntireVerse
+DEU	28	9	Moses			Implicit			EntireVerse
+DEU	28	10	Moses			Implicit			EntireVerse
+DEU	28	11	Moses			Implicit			EntireVerse
+DEU	28	12	Moses			Implicit			EntireVerse
+DEU	28	13	Moses			Implicit			EntireVerse
+DEU	28	14	Moses			Implicit			EntireVerse
+DEU	28	15	Moses			Implicit			EntireVerse
+DEU	28	16	Moses			Implicit			EntireVerse
+DEU	28	17	Moses			Implicit			EntireVerse
+DEU	28	18	Moses			Implicit			EntireVerse
+DEU	28	19	Moses			Implicit			EntireVerse
+DEU	28	20	Moses			Implicit			EntireVerse
+DEU	28	21	Moses			Implicit			EntireVerse
+DEU	28	22	Moses			Implicit			EntireVerse
+DEU	28	23	Moses			Implicit			EntireVerse
+DEU	28	24	Moses			Implicit			EntireVerse
+DEU	28	25	Moses			Implicit			EntireVerse
+DEU	28	26	Moses			Implicit			EntireVerse
+DEU	28	27	Moses			Implicit			EntireVerse
+DEU	28	28	Moses			Implicit			EntireVerse
+DEU	28	29	Moses			Implicit			EntireVerse
+DEU	28	30	Moses			Implicit			EntireVerse
+DEU	28	31	Moses			Implicit			EntireVerse
+DEU	28	32	Moses			Implicit			EntireVerse
+DEU	28	33	Moses			Implicit			EntireVerse
+DEU	28	34	Moses			Implicit			EntireVerse
+DEU	28	35	Moses			Implicit			EntireVerse
+DEU	28	36	Moses			Implicit			EntireVerse
+DEU	28	37	Moses			Implicit			EntireVerse
+DEU	28	38	Moses			Implicit			EntireVerse
+DEU	28	39	Moses			Implicit			EntireVerse
+DEU	28	40	Moses			Implicit			EntireVerse
+DEU	28	41	Moses			Implicit			EntireVerse
+DEU	28	42	Moses			Implicit			EntireVerse
+DEU	28	43	Moses			Implicit			EntireVerse
+DEU	28	44	Moses			Implicit			EntireVerse
+DEU	28	45	Moses			Implicit			EntireVerse
+DEU	28	46	Moses			Implicit			EntireVerse
+DEU	28	47	Moses			Implicit			EntireVerse
+DEU	28	48	Moses			Implicit			EntireVerse
+DEU	28	49	Moses			Implicit			EntireVerse
+DEU	28	50	Moses			Implicit			EntireVerse
+DEU	28	51	Moses			Implicit			EntireVerse
+DEU	28	52	Moses			Implicit			EntireVerse
+DEU	28	53	Moses			Implicit			EntireVerse
+DEU	28	54	Moses			Implicit			EntireVerse
+DEU	28	55	Moses			Implicit			EntireVerse
+DEU	28	56	Moses			Implicit			EntireVerse
+DEU	28	57	Moses			Implicit			EntireVerse
+DEU	28	58	Moses			Implicit			EntireVerse
+DEU	28	59	Moses			Implicit			EntireVerse
+DEU	28	60	Moses			Implicit			EntireVerse
+DEU	28	61	Moses			Implicit			EntireVerse
+DEU	28	62	Moses			Implicit			EntireVerse
+DEU	28	63	Moses			Implicit			EntireVerse
+DEU	28	64	Moses			Implicit			EntireVerse
+DEU	28	65	Moses			Implicit			EntireVerse
+DEU	28	66	Moses			Implicit			EntireVerse
+DEU	28	67	Moses			Implicit			EntireVerse
+DEU	28	68	Moses			Implicit			EntireVerse
+DEU	29	2	Moses			Implicit			EntireVerse
+DEU	29	3	Moses			Implicit			EntireVerse
+DEU	29	4	Moses			Implicit			EntireVerse
+DEU	29	5	Moses			Implicit			EntireVerse
+DEU	29	6	Moses			Implicit			EntireVerse
+DEU	29	7	Moses			Implicit			EntireVerse
+DEU	29	8	Moses			Implicit			EntireVerse
+DEU	29	9	Moses			Implicit			EntireVerse
+DEU	29	10	Moses			Implicit			EntireVerse
+DEU	29	11	Moses			Implicit			EntireVerse
+DEU	29	12	Moses			Implicit			EntireVerse
+DEU	29	13	Moses			Implicit			EntireVerse
+DEU	29	14	Moses			Implicit			EntireVerse
+DEU	29	15	Moses			Implicit			EntireVerse
+DEU	29	16	Moses			Implicit			EntireVerse
+DEU	29	17	Moses			Implicit			EntireVerse
+DEU	29	18	Moses			Implicit			EntireVerse
+DEU	29	19	Moses			Implicit			EntireVerse
+DEU	29	20	Moses			Implicit			EntireVerse
+DEU	29	21	Moses			Implicit			EntireVerse
+DEU	29	22	Moses			Implicit			EntireVerse
+DEU	29	23	Moses			Implicit			EntireVerse
+DEU	29	24	Moses			Implicit			EntireVerse
+DEU	29	25	Moses			Implicit			EntireVerse
+DEU	29	26	Moses			Implicit			EntireVerse
+DEU	29	27	Moses			Implicit			EntireVerse
+DEU	29	28	Moses			Implicit			EntireVerse
+DEU	29	29	Moses			Implicit			EntireVerse
+DEU	30	1	Moses			Implicit			EntireVerse
+DEU	30	2	Moses			Implicit			EntireVerse
+DEU	30	3	Moses			Implicit			EntireVerse
+DEU	30	4	Moses			Implicit			EntireVerse
+DEU	30	5	Moses			Implicit			EntireVerse
+DEU	30	6	Moses			Implicit			EntireVerse
+DEU	30	7	Moses			Implicit			EntireVerse
+DEU	30	8	Moses			Implicit			EntireVerse
+DEU	30	9	Moses			Implicit			EntireVerse
+DEU	30	10	Moses			Implicit			EntireVerse
+DEU	30	11	Moses			Implicit			EntireVerse
+DEU	30	12	Moses			Implicit			EntireVerse
+DEU	30	13	Moses			Implicit			EntireVerse
+DEU	30	14	Moses			Implicit			EntireVerse
+DEU	30	15	Moses			Implicit			EntireVerse
+DEU	30	16	Moses			Implicit			EntireVerse
+DEU	30	17	Moses			Implicit			EntireVerse
+DEU	30	18	Moses			Implicit			EntireVerse
+DEU	30	19	Moses			Implicit			EntireVerse
+DEU	30	20	Moses			Implicit			EntireVerse
+DEU	31	2	Moses			Implicit			EntireVerse
+DEU	31	3	Moses			Implicit			EntireVerse
+DEU	31	4	Moses			Implicit			EntireVerse
+DEU	31	5	Moses			Implicit			EntireVerse
+DEU	31	6	Moses			Implicit			EntireVerse
+DEU	31	7	Moses			Implicit			EntireVerse
+DEU	31	8	Moses			Implicit			EntireVerse
+DEU	31	10	Moses			Implicit			EntireVerse
+DEU	31	11	Moses			Implicit			EntireVerse
+DEU	31	12	Moses			Implicit			EntireVerse
+DEU	31	13	Moses			Implicit			EntireVerse
 DEU	31	14	God		God (Yahweh)	Normal			ContainedWithinVerse
 DEU	31	16	God		God (Yahweh)	Normal			EndOfVerse
-DEU	31	17	God		God (Yahweh)	Implicit			
-DEU	31	18	God		God (Yahweh)	Implicit			
-DEU	31	19	God		God (Yahweh)	Implicit			
-DEU	31	20	God		God (Yahweh)	Implicit			
-DEU	31	21	God		God (Yahweh)	Implicit			
+DEU	31	17	God		God (Yahweh)	Implicit			EntireVerse
+DEU	31	18	God		God (Yahweh)	Implicit			EntireVerse
+DEU	31	19	God		God (Yahweh)	Implicit			EntireVerse
+DEU	31	20	God		God (Yahweh)	Implicit			EntireVerse
+DEU	31	21	God		God (Yahweh)	Implicit			EntireVerse
 DEU	31	23	God		God (Yahweh)	Normal			EndOfVerse
-DEU	31	26	Moses			Implicit			
-DEU	31	27	Moses			Implicit			
-DEU	31	28	Moses			Implicit			
-DEU	31	29	Moses			Implicit			
-DEU	32	1	Moses			Implicit			
-DEU	32	2	Moses			Implicit			
-DEU	32	3	Moses			Implicit			
-DEU	32	4	Moses			Implicit			
-DEU	32	5	Moses			Implicit			
-DEU	32	6	Moses			Implicit			
-DEU	32	7	Moses			Implicit			
-DEU	32	8	Moses			Implicit			
-DEU	32	9	Moses			Implicit			
-DEU	32	10	Moses			Implicit			
-DEU	32	11	Moses			Implicit			
-DEU	32	12	Moses			Implicit			
-DEU	32	13	Moses			Implicit			
-DEU	32	14	Moses			Implicit			
-DEU	32	15	Moses			Implicit			
-DEU	32	16	Moses			Implicit			
-DEU	32	17	Moses			Implicit			
-DEU	32	18	Moses			Implicit			
-DEU	32	19	Moses			Implicit			
-DEU	32	20	Moses			Implicit			
+DEU	31	26	Moses			Implicit			EntireVerse
+DEU	31	27	Moses			Implicit			EntireVerse
+DEU	31	28	Moses			Implicit			EntireVerse
+DEU	31	29	Moses			Implicit			EntireVerse
+DEU	32	1	Moses			Implicit			EntireVerse
+DEU	32	2	Moses			Implicit			EntireVerse
+DEU	32	3	Moses			Implicit			EntireVerse
+DEU	32	4	Moses			Implicit			EntireVerse
+DEU	32	5	Moses			Implicit			EntireVerse
+DEU	32	6	Moses			Implicit			EntireVerse
+DEU	32	7	Moses			Implicit			EntireVerse
+DEU	32	8	Moses			Implicit			EntireVerse
+DEU	32	9	Moses			Implicit			EntireVerse
+DEU	32	10	Moses			Implicit			EntireVerse
+DEU	32	11	Moses			Implicit			EntireVerse
+DEU	32	12	Moses			Implicit			EntireVerse
+DEU	32	13	Moses			Implicit			EntireVerse
+DEU	32	14	Moses			Implicit			EntireVerse
+DEU	32	15	Moses			Implicit			EntireVerse
+DEU	32	16	Moses			Implicit			EntireVerse
+DEU	32	17	Moses			Implicit			EntireVerse
+DEU	32	18	Moses			Implicit			EntireVerse
+DEU	32	19	Moses			Implicit			EntireVerse
+DEU	32	20	Moses			Implicit			EntireVerse
 DEU	32	20	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	21	Moses			Implicit			
+DEU	32	21	Moses			Implicit			EntireVerse
 DEU	32	21	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	22	Moses			Implicit			
+DEU	32	22	Moses			Implicit			EntireVerse
 DEU	32	22	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	23	Moses			Implicit			
+DEU	32	23	Moses			Implicit			EntireVerse
 DEU	32	23	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	24	Moses			Implicit			
+DEU	32	24	Moses			Implicit			EntireVerse
 DEU	32	24	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	25	Moses			Implicit			
+DEU	32	25	Moses			Implicit			EntireVerse
 DEU	32	25	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	26	Moses			Implicit			
+DEU	32	26	Moses			Implicit			EntireVerse
 DEU	32	26	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	27	Moses			Implicit			
+DEU	32	27	Moses			Implicit			EntireVerse
 DEU	32	27	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	28	Moses			Implicit			
-DEU	32	29	Moses			Implicit			
-DEU	32	30	Moses			Implicit			
-DEU	32	31	Moses			Implicit			
-DEU	32	32	Moses			Implicit			
-DEU	32	33	Moses			Implicit			
-DEU	32	34	Moses			Implicit			
+DEU	32	28	Moses			Implicit			EntireVerse
+DEU	32	29	Moses			Implicit			EntireVerse
+DEU	32	30	Moses			Implicit			EntireVerse
+DEU	32	31	Moses			Implicit			EntireVerse
+DEU	32	32	Moses			Implicit			EntireVerse
+DEU	32	33	Moses			Implicit			EntireVerse
+DEU	32	34	Moses			Implicit			EntireVerse
 DEU	32	34	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	35	Moses			Implicit			
+DEU	32	35	Moses			Implicit			EntireVerse
 DEU	32	35	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	36	Moses			Implicit			
-DEU	32	37	Moses			Implicit			
+DEU	32	36	Moses			Implicit			EntireVerse
+DEU	32	37	Moses			Implicit			EntireVerse
 DEU	32	37	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	38	Moses			Implicit			
+DEU	32	38	Moses			Implicit			EntireVerse
 DEU	32	38	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	39	Moses			Implicit			
+DEU	32	39	Moses			Implicit			EntireVerse
 DEU	32	39	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	40	Moses			Implicit			
+DEU	32	40	Moses			Implicit			EntireVerse
 DEU	32	40	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	41	Moses			Implicit			
+DEU	32	41	Moses			Implicit			EntireVerse
 DEU	32	41	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	42	Moses			Implicit			
+DEU	32	42	Moses			Implicit			EntireVerse
 DEU	32	42	God		God (Yahweh)	Quotation			Unspecified
-DEU	32	43	Moses			Implicit			
+DEU	32	43	Moses			Implicit			EntireVerse
 DEU	32	46	Moses			Normal			Unspecified
 DEU	32	47	Moses			Normal			StartOfVerse
-DEU	32	49	God		God (Yahweh)	Implicit			
-DEU	32	50	God		God (Yahweh)	Implicit			
-DEU	32	51	God		God (Yahweh)	Implicit			
-DEU	32	52	God		God (Yahweh)	Implicit			
+DEU	32	49	God		God (Yahweh)	Implicit			EntireVerse
+DEU	32	50	God		God (Yahweh)	Implicit			EntireVerse
+DEU	32	51	God		God (Yahweh)	Implicit			EntireVerse
+DEU	32	52	God		God (Yahweh)	Implicit			EntireVerse
 DEU	33	2	Moses			Normal			Unspecified
-DEU	33	3	Moses			Implicit			
-DEU	33	4	Moses			Implicit			
-DEU	33	5	Moses			Implicit			
-DEU	33	6	Moses			Implicit			
+DEU	33	3	Moses			Implicit			EntireVerse
+DEU	33	4	Moses			Implicit			EntireVerse
+DEU	33	5	Moses			Implicit			EntireVerse
+DEU	33	6	Moses			Implicit			EntireVerse
 DEU	33	7	Moses			Normal			Unspecified
 DEU	33	8	Moses			Normal			Unspecified
-DEU	33	9	Moses			Implicit			
-DEU	33	10	Moses			Implicit			
-DEU	33	11	Moses			Implicit			
+DEU	33	9	Moses			Implicit			EntireVerse
+DEU	33	10	Moses			Implicit			EntireVerse
+DEU	33	11	Moses			Implicit			EntireVerse
 DEU	33	12	Moses			Normal			Unspecified
 DEU	33	13	Moses			Normal			Unspecified
-DEU	33	14	Moses			Implicit			
-DEU	33	15	Moses			Implicit			
-DEU	33	16	Moses			Implicit			
-DEU	33	17	Moses			Implicit			
+DEU	33	14	Moses			Implicit			EntireVerse
+DEU	33	15	Moses			Implicit			EntireVerse
+DEU	33	16	Moses			Implicit			EntireVerse
+DEU	33	17	Moses			Implicit			EntireVerse
 DEU	33	18	Moses			Normal			Unspecified
-DEU	33	19	Moses			Implicit			
+DEU	33	19	Moses			Implicit			EntireVerse
 DEU	33	20	Moses			Normal			Unspecified
 DEU	33	21	Moses			Normal			Unspecified
 DEU	33	22	Moses			Normal			Unspecified
@@ -4280,14 +4280,14 @@ DEU	33	27	Moses			Normal			Unspecified
 DEU	33	28	Moses			Normal			Unspecified
 DEU	33	29	Moses			Normal			Unspecified
 DEU	34	4	God		God (Yahweh)	Normal			EndOfVerse
-JOS	1	2	God		God (Yahweh)	Implicit			
-JOS	1	3	God		God (Yahweh)	Implicit			
-JOS	1	4	God		God (Yahweh)	Implicit			
-JOS	1	5	God		God (Yahweh)	Implicit			
-JOS	1	6	God		God (Yahweh)	Implicit			
-JOS	1	7	God		God (Yahweh)	Implicit			
-JOS	1	8	God		God (Yahweh)	Implicit			
-JOS	1	9	God		God (Yahweh)	Implicit			
+JOS	1	2	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	3	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	4	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	5	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	6	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	7	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	8	God		God (Yahweh)	Implicit			EntireVerse
+JOS	1	9	God		God (Yahweh)	Implicit			EntireVerse
 JOS	1	11	Joshua			Normal			Unspecified
 JOS	1	13	Joshua			Normal			EntireVerse
 JOS	1	14	Joshua			Normal			EntireVerse
@@ -4534,8 +4534,8 @@ JDG	1	14	Caleb			Normal
 JDG	1	15	Achsah, Caleb's daughter			Normal			Unspecified
 JDG	1	24	Israelite spies from house of Joseph			Normal			EndOfVerse
 JDG	2	1	Yahweh's angel			Normal	Jesus		EndOfVerse
-JDG	2	2	Yahweh's angel			Implicit	Jesus		
-JDG	2	3	Yahweh's angel			Implicit	Jesus		
+JDG	2	2	Yahweh's angel			Implicit	Jesus		EntireVerse
+JDG	2	3	Yahweh's angel			Implicit	Jesus		EntireVerse
 JDG	2	20	God		God (Yahweh)	Normal			EndOfVerse
 JDG	2	21	God		God (Yahweh)	Normal			EntireVerse
 JDG	2	22	God		God (Yahweh)	Normal			EntireVerse
@@ -4555,36 +4555,36 @@ JDG	4	18	Jael			Normal			ContainedWithinVerse
 JDG	4	19	Sisera			Normal			Unspecified
 JDG	4	20	Sisera			Normal			Unspecified
 JDG	4	22	Jael			Normal			ContainedWithinVerse
-JDG	5	2	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	3	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	4	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	5	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	6	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	7	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	8	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	9	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	10	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	11	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	12	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	13	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	14	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	15	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	16	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	17	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	18	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	19	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	20	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	21	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	22	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	23	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	24	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	25	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	26	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	27	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	28	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	29	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	30	Deborah/Barak	singing		Implicit	Deborah		
-JDG	5	31	Deborah/Barak	singing		Implicit	Deborah		
+JDG	5	2	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	3	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	4	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	5	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	6	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	7	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	8	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	9	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	10	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	11	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	12	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	13	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	14	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	15	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	16	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	17	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	18	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	19	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	20	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	21	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	22	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	23	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	24	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	25	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	26	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	27	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	28	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	29	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	30	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
+JDG	5	31	Deborah/Barak	singing		Implicit	Deborah		EntireVerse
 JDG	6	8	prophet of Yahweh sent to Israel			Normal			EndOfVerse
 JDG	6	8	God		God (Yahweh)	Alternate			
 JDG	6	9	prophet of Yahweh sent to Israel			Normal			Unspecified
@@ -5916,12 +5916,12 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2SA	22	50	David		David, king	Normal			Unspecified
 2SA	22	51	David		David, king	Normal			Unspecified
 2SA	23	1	David		David, king	Potential			
-2SA	23	2	David		David, king	Implicit			
-2SA	23	3	David		David, king	Implicit			
-2SA	23	4	David		David, king	Implicit			
-2SA	23	5	David		David, king	Implicit			
-2SA	23	6	David		David, king	Implicit			
-2SA	23	7	David		David, king	Implicit			
+2SA	23	2	David		David, king	Implicit			EntireVerse
+2SA	23	3	David		David, king	Implicit			EntireVerse
+2SA	23	4	David		David, king	Implicit			EntireVerse
+2SA	23	5	David		David, king	Implicit			EntireVerse
+2SA	23	6	David		David, king	Implicit			EntireVerse
+2SA	23	7	David		David, king	Implicit			EntireVerse
 2SA	23	15	David		David, king	Normal			EndOfVerse
 2SA	23	17	David		David, king	Normal			ContainedWithinVerse
 2SA	24	1	God			Normal			
@@ -6780,34 +6780,34 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 1CH	15	2	David		David, king	Normal			Unspecified
 1CH	15	12	David		David, king	Normal			EndOfVerse
 1CH	15	13	David		David, king	Normal			EntireVerse
-1CH	16	8	David	psalm	David, king	Implicit			
-1CH	16	9	David	psalm	David, king	Implicit			
-1CH	16	10	David	psalm	David, king	Implicit			
-1CH	16	11	David	psalm	David, king	Implicit			
-1CH	16	12	David	psalm	David, king	Implicit			
-1CH	16	13	David	psalm	David, king	Implicit			
-1CH	16	14	David	psalm	David, king	Implicit			
-1CH	16	15	David	psalm	David, king	Implicit			
-1CH	16	16	David	psalm	David, king	Implicit			
-1CH	16	17	David	psalm	David, king	Implicit			
-1CH	16	18	David	psalm	David, king	Implicit			
-1CH	16	19	David	psalm	David, king	Implicit			
-1CH	16	20	David	psalm	David, king	Implicit			
-1CH	16	21	David	psalm	David, king	Implicit			
-1CH	16	22	David	psalm	David, king	Implicit			
-1CH	16	23	David	psalm	David, king	Implicit			
-1CH	16	24	David	psalm	David, king	Implicit			
-1CH	16	25	David	psalm	David, king	Implicit			
-1CH	16	26	David	psalm	David, king	Implicit			
-1CH	16	27	David	psalm	David, king	Implicit			
-1CH	16	28	David	psalm	David, king	Implicit			
-1CH	16	29	David	psalm	David, king	Implicit			
-1CH	16	30	David	psalm	David, king	Implicit			
-1CH	16	31	David	psalm	David, king	Implicit			
-1CH	16	32	David	psalm	David, king	Implicit			
-1CH	16	33	David	psalm	David, king	Implicit			
-1CH	16	34	David	psalm	David, king	Implicit			
-1CH	16	35	David	psalm	David, king	Implicit			
+1CH	16	8	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	9	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	10	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	11	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	12	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	13	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	14	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	15	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	16	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	17	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	18	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	19	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	20	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	21	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	22	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	23	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	24	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	25	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	26	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	27	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	28	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	29	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	30	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	31	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	32	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	33	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	34	David	psalm	David, king	Implicit			EntireVerse
+1CH	16	35	David	psalm	David, king	Implicit			EntireVerse
 # Ideally, the start of verse 36 (the poetry portion) should also be Implicit, but we don't have a way to indicate that part of a verse is an implicit quotation.								
 1CH	16	36	David	psalm	David, king	Normal			
 1CH	16	36	people, all the			Normal			
@@ -7178,9 +7178,9 @@ RUT	4	17	women of Bethlehem			Normal			ContainedWithinVerse
 2CH	35	21	Neco, king of Egypt		ambassador from Neco, king of Egypt	Normal			Unspecified
 2CH	35	23	Josiah, king of Judah			Normal			EndOfVerse
 2CH	36	23	Cyrus, king of Persia			Normal			Unspecified
-EZR	1	2	Cyrus, king of Persia	written proclamation		Implicit			
-EZR	1	3	Cyrus, king of Persia	written proclamation		Implicit			
-EZR	1	4	Cyrus, king of Persia	written proclamation		Implicit			
+EZR	1	2	Cyrus, king of Persia	written proclamation		Implicit			EntireVerse
+EZR	1	3	Cyrus, king of Persia	written proclamation		Implicit			EntireVerse
+EZR	1	4	Cyrus, king of Persia	written proclamation		Implicit			EntireVerse
 EZR	3	11	priests/Levites	singing		Normal			ContainedWithinVerse
 EZR	4	2	enemies of Judah and Benjamin			Normal			EndOfVerse
 EZR	4	3	Zerubbabel/Jeshua/rest of heads of families			Normal			EndOfVerse
@@ -7188,22 +7188,22 @@ EZR	4	3	Zerubbabel/Jeshua/rest of heads of families			Normal			EndOfVerse
 # colon, implying that these two verses are part of the letter. They might be heading, salutation
 # or "envelope" information. In the WEB, it is hard to tell what the translators intended.
 EZR	4	9	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
-EZR	4	9	Needs Review			Implicit			
+EZR	4	9	Needs Review			Implicit			EntireVerse
 EZR	4	10	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
-EZR	4	10	Needs Review			Implicit			
+EZR	4	10	Needs Review			Implicit			EntireVerse
 EZR	4	11	Rehum, commanding officer/Shimshai, secretary	letter		Potential			
-EZR	4	11	Needs Review			Implicit			
-EZR	4	12	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
-EZR	4	13	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
-EZR	4	14	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
-EZR	4	15	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
-EZR	4	16	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			
+EZR	4	11	Needs Review			Implicit			EntireVerse
+EZR	4	12	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			EntireVerse
+EZR	4	13	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			EntireVerse
+EZR	4	14	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			EntireVerse
+EZR	4	15	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			EntireVerse
+EZR	4	16	Rehum, commanding officer/Shimshai, secretary	letter		Implicit			EntireVerse
 EZR	4	17	Artaxerxes, king of Persia	letter		Potential			
-EZR	4	18	Artaxerxes, king of Persia	letter		Implicit			
-EZR	4	19	Artaxerxes, king of Persia	letter		Implicit			
-EZR	4	20	Artaxerxes, king of Persia	letter		Implicit			
-EZR	4	21	Artaxerxes, king of Persia	letter		Implicit			
-EZR	4	22	Artaxerxes, king of Persia	letter		Implicit			
+EZR	4	18	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	4	19	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	4	20	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	4	21	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	4	22	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
 EZR	5	3	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates			Normal			EndOfVerse
 # EZR 5:4 is a tricky verse to translate. Some translations make it a direct quote and some make it
 # indirect. In some it is a statement, and in others it is a question. Some have Tattenai and co.
@@ -7211,18 +7211,18 @@ EZR	5	3	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates			Normal
 EZR	5	4	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates			Indirect			
 EZR	5	4	Jews, the			Indirect			
 EZR	5	4	Ezra, priest and teacher			Indirect			
-EZR	5	4	Needs Review			Implicit			
+EZR	5	4	Needs Review			Implicit			EntireVerse
 EZR	5	7	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Potential			
-EZR	5	8	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	9	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	10	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	11	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	12	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	13	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	14	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	15	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	16	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
-EZR	5	17	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			
+EZR	5	8	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	9	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	10	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	11	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	12	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	13	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	14	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	15	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	16	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
+EZR	5	17	Tattenai, governor/Shethar-Bozenai/officials of Trans-Euphrates	letter		Implicit			EntireVerse
 EZR	6	1	Darius, king of Medes and Persians	decree		Potential			
 EZR	6	2	Darius, king of Medes and Persians	decree		Potential			
 EZR	6	3	royal record		written record on scroll	Potential			
@@ -7231,28 +7231,28 @@ EZR	6	4	royal record		written record on scroll	Potential
 EZR	6	4	Cyrus, king of Persia	decree		Quotation			Unspecified
 EZR	6	5	royal record		written record on scroll	Potential			
 EZR	6	5	Cyrus, king of Persia	decree		Quotation			Unspecified
-EZR	6	6	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	7	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	8	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	9	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	10	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	11	Darius, king of Medes and Persians	decree		Implicit			
-EZR	6	12	Darius, king of Medes and Persians	decree		Implicit			
-EZR	7	12	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	13	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	14	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	15	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	16	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	17	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	18	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	19	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	20	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	21	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	22	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	23	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	24	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	25	Artaxerxes, king of Persia	letter		Implicit			
-EZR	7	26	Artaxerxes, king of Persia	letter		Implicit			
+EZR	6	6	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	7	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	8	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	9	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	10	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	11	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	6	12	Darius, king of Medes and Persians	decree		Implicit			EntireVerse
+EZR	7	12	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	13	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	14	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	15	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	16	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	17	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	18	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	19	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	20	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	21	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	22	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	23	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	24	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	25	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
+EZR	7	26	Artaxerxes, king of Persia	letter		Implicit			EntireVerse
 EZR	8	22	narrator-EZR			Quotation			
 EZR	8	28	narrator-EZR			Quotation			
 EZR	8	29	narrator-EZR			Quotation			
@@ -7292,7 +7292,7 @@ NEH	1	9	Nehemiah	praying		Alternate
 NEH	1	10	Nehemiah	praying		Alternate			
 NEH	1	11	Nehemiah	praying		Alternate			
 NEH	2	2	Artaxerxes, king of Persia			Normal			
-NEH	2	3	narrator-NEH			ImplicitWithPotentialSelfQuote			
+NEH	2	3	narrator-NEH			ImplicitWithPotentialSelfQuote			EntireVerse
 NEH	2	3	Nehemiah	sad, very afraid, with respect		Alternate			
 NEH	2	4	Artaxerxes, king of Persia			Normal			
 NEH	2	5	Nehemiah			Normal			
@@ -7309,8 +7309,8 @@ NEH	4	1	report to Sanballat and Tobiah			Rare
 NEH	4	1	Needs Review			Potential			
 NEH	4	2	Sanballat the Horonite	angry	Sanballat	Normal			
 NEH	4	3	Tobiah the Ammonite official	mocking	Tobiah the Ammonite	Normal			
-NEH	4	4	Nehemiah	praying		Implicit			
-NEH	4	5	Nehemiah	praying		Implicit			
+NEH	4	4	Nehemiah	praying		Implicit			EntireVerse
+NEH	4	5	Nehemiah	praying		Implicit			EntireVerse
 NEH	4	7	report to Sanballat and Tobiah			Potential			
 NEH	4	8	Sanballat the Horonite/Tobiah the Ammonite official/men of Ashdod	conspiring		Potential	Sanballat the Horonite		
 NEH	4	10	Judah, people in			Normal			
@@ -7514,997 +7514,997 @@ JOB	2	5	Satan (Devil)			Normal			EntireVerse
 JOB	2	6	God		God (Yahweh)	Normal			Unspecified
 JOB	2	9	Job's wife			Normal			EndOfVerse
 JOB	2	10	Job			Normal			ContainedWithinVerse
-JOB	3	3	Job			Implicit			
-JOB	3	4	Job			Implicit			
-JOB	3	5	Job			Implicit			
-JOB	3	6	Job			Implicit			
-JOB	3	7	Job			Implicit			
-JOB	3	8	Job			Implicit			
-JOB	3	9	Job			Implicit			
-JOB	3	10	Job			Implicit			
-JOB	3	11	Job			Implicit			
-JOB	3	12	Job			Implicit			
-JOB	3	13	Job			Implicit			
-JOB	3	14	Job			Implicit			
-JOB	3	15	Job			Implicit			
-JOB	3	16	Job			Implicit			
-JOB	3	17	Job			Implicit			
-JOB	3	18	Job			Implicit			
-JOB	3	19	Job			Implicit			
-JOB	3	20	Job			Implicit			
-JOB	3	21	Job			Implicit			
-JOB	3	22	Job			Implicit			
-JOB	3	23	Job			Implicit			
-JOB	3	24	Job			Implicit			
-JOB	3	25	Job			Implicit			
-JOB	3	26	Job			Implicit			
-JOB	4	2	Eliphaz the Temanite			Implicit			
-JOB	4	3	Eliphaz the Temanite			Implicit			
-JOB	4	4	Eliphaz the Temanite			Implicit			
-JOB	4	5	Eliphaz the Temanite			Implicit			
-JOB	4	6	Eliphaz the Temanite			Implicit			
-JOB	4	7	Eliphaz the Temanite			Implicit			
-JOB	4	8	Eliphaz the Temanite			Implicit			
-JOB	4	9	Eliphaz the Temanite			Implicit			
-JOB	4	10	Eliphaz the Temanite			Implicit			
-JOB	4	11	Eliphaz the Temanite			Implicit			
-JOB	4	12	Eliphaz the Temanite			Implicit			
-JOB	4	13	Eliphaz the Temanite			Implicit			
-JOB	4	14	Eliphaz the Temanite			Implicit			
-JOB	4	15	Eliphaz the Temanite			Implicit			
-JOB	4	16	Eliphaz the Temanite			Implicit			
-JOB	4	17	Eliphaz the Temanite			Implicit			
-JOB	4	18	Eliphaz the Temanite			Implicit			
-JOB	4	19	Eliphaz the Temanite			Implicit			
-JOB	4	20	Eliphaz the Temanite			Implicit			
-JOB	4	21	Eliphaz the Temanite			Implicit			
-JOB	5	1	Eliphaz the Temanite			Implicit			
-JOB	5	2	Eliphaz the Temanite			Implicit			
-JOB	5	3	Eliphaz the Temanite			Implicit			
-JOB	5	4	Eliphaz the Temanite			Implicit			
-JOB	5	5	Eliphaz the Temanite			Implicit			
-JOB	5	6	Eliphaz the Temanite			Implicit			
-JOB	5	7	Eliphaz the Temanite			Implicit			
-JOB	5	8	Eliphaz the Temanite			Implicit			
-JOB	5	9	Eliphaz the Temanite			Implicit			
-JOB	5	10	Eliphaz the Temanite			Implicit			
-JOB	5	11	Eliphaz the Temanite			Implicit			
-JOB	5	12	Eliphaz the Temanite			Implicit			
-JOB	5	13	Eliphaz the Temanite			Implicit			
-JOB	5	14	Eliphaz the Temanite			Implicit			
-JOB	5	15	Eliphaz the Temanite			Implicit			
-JOB	5	16	Eliphaz the Temanite			Implicit			
-JOB	5	17	Eliphaz the Temanite			Implicit			
-JOB	5	18	Eliphaz the Temanite			Implicit			
-JOB	5	19	Eliphaz the Temanite			Implicit			
-JOB	5	20	Eliphaz the Temanite			Implicit			
-JOB	5	21	Eliphaz the Temanite			Implicit			
-JOB	5	22	Eliphaz the Temanite			Implicit			
-JOB	5	23	Eliphaz the Temanite			Implicit			
-JOB	5	24	Eliphaz the Temanite			Implicit			
-JOB	5	25	Eliphaz the Temanite			Implicit			
-JOB	5	26	Eliphaz the Temanite			Implicit			
-JOB	5	27	Eliphaz the Temanite			Implicit			
-JOB	6	2	Job			Implicit			
-JOB	6	3	Job			Implicit			
-JOB	6	4	Job			Implicit			
-JOB	6	5	Job			Implicit			
-JOB	6	6	Job			Implicit			
-JOB	6	7	Job			Implicit			
-JOB	6	8	Job			Implicit			
-JOB	6	9	Job			Implicit			
-JOB	6	10	Job			Implicit			
-JOB	6	11	Job			Implicit			
-JOB	6	12	Job			Implicit			
-JOB	6	13	Job			Implicit			
-JOB	6	14	Job			Implicit			
-JOB	6	15	Job			Implicit			
-JOB	6	16	Job			Implicit			
-JOB	6	17	Job			Implicit			
-JOB	6	18	Job			Implicit			
-JOB	6	19	Job			Implicit			
-JOB	6	20	Job			Implicit			
-JOB	6	21	Job			Implicit			
-JOB	6	22	Job			Implicit			
-JOB	6	23	Job			Implicit			
-JOB	6	24	Job			Implicit			
-JOB	6	25	Job			Implicit			
-JOB	6	26	Job			Implicit			
-JOB	6	27	Job			Implicit			
-JOB	6	28	Job			Implicit			
-JOB	6	29	Job			Implicit			
-JOB	6	30	Job			Implicit			
-JOB	7	1	Job			Implicit			
-JOB	7	2	Job			Implicit			
-JOB	7	3	Job			Implicit			
-JOB	7	4	Job			Implicit			
-JOB	7	5	Job			Implicit			
-JOB	7	6	Job			Implicit			
-JOB	7	7	Job			Implicit			
-JOB	7	8	Job			Implicit			
-JOB	7	9	Job			Implicit			
-JOB	7	10	Job			Implicit			
-JOB	7	11	Job			Implicit			
-JOB	7	12	Job			Implicit			
-JOB	7	13	Job			Implicit			
-JOB	7	14	Job			Implicit			
-JOB	7	15	Job			Implicit			
-JOB	7	16	Job			Implicit			
-JOB	7	17	Job			Implicit			
-JOB	7	18	Job			Implicit			
-JOB	7	19	Job			Implicit			
-JOB	7	20	Job			Implicit			
-JOB	7	21	Job			Implicit			
-JOB	8	2	Bildad the Shuhite			Implicit			
-JOB	8	3	Bildad the Shuhite			Implicit			
-JOB	8	4	Bildad the Shuhite			Implicit			
-JOB	8	5	Bildad the Shuhite			Implicit			
-JOB	8	6	Bildad the Shuhite			Implicit			
-JOB	8	7	Bildad the Shuhite			Implicit			
-JOB	8	8	Bildad the Shuhite			Implicit			
-JOB	8	9	Bildad the Shuhite			Implicit			
-JOB	8	10	Bildad the Shuhite			Implicit			
-JOB	8	11	Bildad the Shuhite			Implicit			
-JOB	8	12	Bildad the Shuhite			Implicit			
-JOB	8	13	Bildad the Shuhite			Implicit			
-JOB	8	14	Bildad the Shuhite			Implicit			
-JOB	8	15	Bildad the Shuhite			Implicit			
-JOB	8	16	Bildad the Shuhite			Implicit			
-JOB	8	17	Bildad the Shuhite			Implicit			
-JOB	8	18	Bildad the Shuhite			Implicit			
-JOB	8	19	Bildad the Shuhite			Implicit			
-JOB	8	20	Bildad the Shuhite			Implicit			
-JOB	8	21	Bildad the Shuhite			Implicit			
-JOB	8	22	Bildad the Shuhite			Implicit			
-JOB	9	2	Job			Implicit			
-JOB	9	3	Job			Implicit			
-JOB	9	4	Job			Implicit			
-JOB	9	5	Job			Implicit			
-JOB	9	6	Job			Implicit			
-JOB	9	7	Job			Implicit			
-JOB	9	8	Job			Implicit			
-JOB	9	9	Job			Implicit			
-JOB	9	10	Job			Implicit			
-JOB	9	11	Job			Implicit			
-JOB	9	12	Job			Implicit			
-JOB	9	13	Job			Implicit			
-JOB	9	14	Job			Implicit			
-JOB	9	15	Job			Implicit			
-JOB	9	16	Job			Implicit			
-JOB	9	17	Job			Implicit			
-JOB	9	18	Job			Implicit			
-JOB	9	19	Job			Implicit			
-JOB	9	20	Job			Implicit			
-JOB	9	21	Job			Implicit			
-JOB	9	22	Job			Implicit			
-JOB	9	23	Job			Implicit			
-JOB	9	24	Job			Implicit			
-JOB	9	25	Job			Implicit			
-JOB	9	26	Job			Implicit			
-JOB	9	27	Job			Implicit			
-JOB	9	28	Job			Implicit			
-JOB	9	29	Job			Implicit			
-JOB	9	30	Job			Implicit			
-JOB	9	31	Job			Implicit			
-JOB	9	32	Job			Implicit			
-JOB	9	33	Job			Implicit			
-JOB	9	34	Job			Implicit			
-JOB	9	35	Job			Implicit			
-JOB	10	1	Job			Implicit			
-JOB	10	2	Job			Implicit			
-JOB	10	3	Job			Implicit			
-JOB	10	4	Job			Implicit			
-JOB	10	5	Job			Implicit			
-JOB	10	6	Job			Implicit			
-JOB	10	7	Job			Implicit			
-JOB	10	8	Job			Implicit			
-JOB	10	9	Job			Implicit			
-JOB	10	10	Job			Implicit			
-JOB	10	11	Job			Implicit			
-JOB	10	12	Job			Implicit			
-JOB	10	13	Job			Implicit			
-JOB	10	14	Job			Implicit			
-JOB	10	15	Job			Implicit			
-JOB	10	16	Job			Implicit			
-JOB	10	17	Job			Implicit			
-JOB	10	18	Job			Implicit			
-JOB	10	19	Job			Implicit			
-JOB	10	20	Job			Implicit			
-JOB	10	21	Job			Implicit			
-JOB	10	22	Job			Implicit			
-JOB	11	2	Zophar the Naamathite			Implicit			
-JOB	11	3	Zophar the Naamathite			Implicit			
-JOB	11	4	Zophar the Naamathite			Implicit			
-JOB	11	5	Zophar the Naamathite			Implicit			
-JOB	11	6	Zophar the Naamathite			Implicit			
-JOB	11	7	Zophar the Naamathite			Implicit			
-JOB	11	8	Zophar the Naamathite			Implicit			
-JOB	11	9	Zophar the Naamathite			Implicit			
-JOB	11	10	Zophar the Naamathite			Implicit			
-JOB	11	11	Zophar the Naamathite			Implicit			
-JOB	11	12	Zophar the Naamathite			Implicit			
-JOB	11	13	Zophar the Naamathite			Implicit			
-JOB	11	14	Zophar the Naamathite			Implicit			
-JOB	11	15	Zophar the Naamathite			Implicit			
-JOB	11	16	Zophar the Naamathite			Implicit			
-JOB	11	17	Zophar the Naamathite			Implicit			
-JOB	11	18	Zophar the Naamathite			Implicit			
-JOB	11	19	Zophar the Naamathite			Implicit			
-JOB	11	20	Zophar the Naamathite			Implicit			
-JOB	12	2	Job			Implicit			
-JOB	12	3	Job			Implicit			
-JOB	12	4	Job			Implicit			
-JOB	12	5	Job			Implicit			
-JOB	12	6	Job			Implicit			
-JOB	12	7	Job			Implicit			
-JOB	12	8	Job			Implicit			
-JOB	12	9	Job			Implicit			
-JOB	12	10	Job			Implicit			
-JOB	12	11	Job			Implicit			
-JOB	12	12	Job			Implicit			
-JOB	12	13	Job			Implicit			
-JOB	12	14	Job			Implicit			
-JOB	12	15	Job			Implicit			
-JOB	12	16	Job			Implicit			
-JOB	12	17	Job			Implicit			
-JOB	12	18	Job			Implicit			
-JOB	12	19	Job			Implicit			
-JOB	12	20	Job			Implicit			
-JOB	12	21	Job			Implicit			
-JOB	12	22	Job			Implicit			
-JOB	12	23	Job			Implicit			
-JOB	12	24	Job			Implicit			
-JOB	12	25	Job			Implicit			
-JOB	13	1	Job			Implicit			
-JOB	13	2	Job			Implicit			
-JOB	13	3	Job			Implicit			
-JOB	13	4	Job			Implicit			
-JOB	13	5	Job			Implicit			
-JOB	13	6	Job			Implicit			
-JOB	13	7	Job			Implicit			
-JOB	13	8	Job			Implicit			
-JOB	13	9	Job			Implicit			
-JOB	13	10	Job			Implicit			
-JOB	13	11	Job			Implicit			
-JOB	13	12	Job			Implicit			
-JOB	13	13	Job			Implicit			
-JOB	13	14	Job			Implicit			
-JOB	13	15	Job			Implicit			
-JOB	13	16	Job			Implicit			
-JOB	13	17	Job			Implicit			
-JOB	13	18	Job			Implicit			
-JOB	13	19	Job			Implicit			
-JOB	13	20	Job			Implicit			
-JOB	13	21	Job			Implicit			
-JOB	13	22	Job			Implicit			
-JOB	13	23	Job			Implicit			
-JOB	13	24	Job			Implicit			
-JOB	13	25	Job			Implicit			
-JOB	13	26	Job			Implicit			
-JOB	13	27	Job			Implicit			
-JOB	13	28	Job			Implicit			
-JOB	14	1	Job			Implicit			
-JOB	14	2	Job			Implicit			
-JOB	14	3	Job			Implicit			
-JOB	14	4	Job			Implicit			
-JOB	14	5	Job			Implicit			
-JOB	14	6	Job			Implicit			
-JOB	14	7	Job			Implicit			
-JOB	14	8	Job			Implicit			
-JOB	14	9	Job			Implicit			
-JOB	14	10	Job			Implicit			
-JOB	14	11	Job			Implicit			
-JOB	14	12	Job			Implicit			
-JOB	14	13	Job			Implicit			
-JOB	14	14	Job			Implicit			
-JOB	14	15	Job			Implicit			
-JOB	14	16	Job			Implicit			
-JOB	14	17	Job			Implicit			
-JOB	14	18	Job			Implicit			
-JOB	14	19	Job			Implicit			
-JOB	14	20	Job			Implicit			
-JOB	14	21	Job			Implicit			
-JOB	14	22	Job			Implicit			
-JOB	15	2	Eliphaz the Temanite			Implicit			
-JOB	15	3	Eliphaz the Temanite			Implicit			
-JOB	15	4	Eliphaz the Temanite			Implicit			
-JOB	15	5	Eliphaz the Temanite			Implicit			
-JOB	15	6	Eliphaz the Temanite			Implicit			
-JOB	15	7	Eliphaz the Temanite			Implicit			
-JOB	15	8	Eliphaz the Temanite			Implicit			
-JOB	15	9	Eliphaz the Temanite			Implicit			
-JOB	15	10	Eliphaz the Temanite			Implicit			
-JOB	15	11	Eliphaz the Temanite			Implicit			
-JOB	15	12	Eliphaz the Temanite			Implicit			
-JOB	15	13	Eliphaz the Temanite			Implicit			
-JOB	15	14	Eliphaz the Temanite			Implicit			
-JOB	15	15	Eliphaz the Temanite			Implicit			
-JOB	15	16	Eliphaz the Temanite			Implicit			
-JOB	15	17	Eliphaz the Temanite			Implicit			
-JOB	15	18	Eliphaz the Temanite			Implicit			
-JOB	15	19	Eliphaz the Temanite			Implicit			
-JOB	15	20	Eliphaz the Temanite			Implicit			
-JOB	15	21	Eliphaz the Temanite			Implicit			
-JOB	15	22	Eliphaz the Temanite			Implicit			
-JOB	15	23	Eliphaz the Temanite			Implicit			
-JOB	15	24	Eliphaz the Temanite			Implicit			
-JOB	15	25	Eliphaz the Temanite			Implicit			
-JOB	15	26	Eliphaz the Temanite			Implicit			
-JOB	15	27	Eliphaz the Temanite			Implicit			
-JOB	15	28	Eliphaz the Temanite			Implicit			
-JOB	15	29	Eliphaz the Temanite			Implicit			
-JOB	15	30	Eliphaz the Temanite			Implicit			
-JOB	15	31	Eliphaz the Temanite			Implicit			
-JOB	15	32	Eliphaz the Temanite			Implicit			
-JOB	15	33	Eliphaz the Temanite			Implicit			
-JOB	15	34	Eliphaz the Temanite			Implicit			
-JOB	15	35	Eliphaz the Temanite			Implicit			
-JOB	16	2	Job			Implicit			
-JOB	16	3	Job			Implicit			
-JOB	16	4	Job			Implicit			
-JOB	16	5	Job			Implicit			
-JOB	16	6	Job			Implicit			
-JOB	16	7	Job			Implicit			
-JOB	16	8	Job			Implicit			
-JOB	16	9	Job			Implicit			
-JOB	16	10	Job			Implicit			
-JOB	16	11	Job			Implicit			
-JOB	16	12	Job			Implicit			
-JOB	16	13	Job			Implicit			
-JOB	16	14	Job			Implicit			
-JOB	16	15	Job			Implicit			
-JOB	16	16	Job			Implicit			
-JOB	16	17	Job			Implicit			
-JOB	16	18	Job			Implicit			
-JOB	16	19	Job			Implicit			
-JOB	16	20	Job			Implicit			
-JOB	16	21	Job			Implicit			
-JOB	16	22	Job			Implicit			
-JOB	17	1	Job			Implicit			
-JOB	17	2	Job			Implicit			
-JOB	17	3	Job			Implicit			
-JOB	17	4	Job			Implicit			
-JOB	17	5	Job			Implicit			
-JOB	17	6	Job			Implicit			
-JOB	17	7	Job			Implicit			
-JOB	17	8	Job			Implicit			
-JOB	17	9	Job			Implicit			
-JOB	17	10	Job			Implicit			
-JOB	17	11	Job			Implicit			
-JOB	17	12	Job			Implicit			
-JOB	17	13	Job			Implicit			
-JOB	17	14	Job			Implicit			
-JOB	17	15	Job			Implicit			
-JOB	17	16	Job			Implicit			
-JOB	18	2	Bildad the Shuhite			Implicit			
-JOB	18	3	Bildad the Shuhite			Implicit			
-JOB	18	4	Bildad the Shuhite			Implicit			
-JOB	18	5	Bildad the Shuhite			Implicit			
-JOB	18	6	Bildad the Shuhite			Implicit			
-JOB	18	7	Bildad the Shuhite			Implicit			
-JOB	18	8	Bildad the Shuhite			Implicit			
-JOB	18	9	Bildad the Shuhite			Implicit			
-JOB	18	10	Bildad the Shuhite			Implicit			
-JOB	18	11	Bildad the Shuhite			Implicit			
-JOB	18	12	Bildad the Shuhite			Implicit			
-JOB	18	13	Bildad the Shuhite			Implicit			
-JOB	18	14	Bildad the Shuhite			Implicit			
-JOB	18	15	Bildad the Shuhite			Implicit			
-JOB	18	16	Bildad the Shuhite			Implicit			
-JOB	18	17	Bildad the Shuhite			Implicit			
-JOB	18	18	Bildad the Shuhite			Implicit			
-JOB	18	19	Bildad the Shuhite			Implicit			
-JOB	18	20	Bildad the Shuhite			Implicit			
-JOB	18	21	Bildad the Shuhite			Implicit			
-JOB	19	2	Job			Implicit			
-JOB	19	3	Job			Implicit			
-JOB	19	4	Job			Implicit			
-JOB	19	5	Job			Implicit			
-JOB	19	6	Job			Implicit			
-JOB	19	7	Job			Implicit			
-JOB	19	8	Job			Implicit			
-JOB	19	9	Job			Implicit			
-JOB	19	10	Job			Implicit			
-JOB	19	11	Job			Implicit			
-JOB	19	12	Job			Implicit			
-JOB	19	13	Job			Implicit			
-JOB	19	14	Job			Implicit			
-JOB	19	15	Job			Implicit			
-JOB	19	16	Job			Implicit			
-JOB	19	17	Job			Implicit			
-JOB	19	18	Job			Implicit			
-JOB	19	19	Job			Implicit			
-JOB	19	20	Job			Implicit			
-JOB	19	21	Job			Implicit			
-JOB	19	22	Job			Implicit			
-JOB	19	23	Job			Implicit			
-JOB	19	24	Job			Implicit			
-JOB	19	25	Job			Implicit			
-JOB	19	26	Job			Implicit			
-JOB	19	27	Job			Implicit			
-JOB	19	28	Job			Implicit			
-JOB	19	29	Job			Implicit			
-JOB	20	2	Zophar the Naamathite			Implicit			
-JOB	20	3	Zophar the Naamathite			Implicit			
-JOB	20	4	Zophar the Naamathite			Implicit			
-JOB	20	5	Zophar the Naamathite			Implicit			
-JOB	20	6	Zophar the Naamathite			Implicit			
-JOB	20	7	Zophar the Naamathite			Implicit			
-JOB	20	8	Zophar the Naamathite			Implicit			
-JOB	20	9	Zophar the Naamathite			Implicit			
-JOB	20	10	Zophar the Naamathite			Implicit			
-JOB	20	11	Zophar the Naamathite			Implicit			
-JOB	20	12	Zophar the Naamathite			Implicit			
-JOB	20	13	Zophar the Naamathite			Implicit			
-JOB	20	14	Zophar the Naamathite			Implicit			
-JOB	20	15	Zophar the Naamathite			Implicit			
-JOB	20	16	Zophar the Naamathite			Implicit			
-JOB	20	17	Zophar the Naamathite			Implicit			
-JOB	20	18	Zophar the Naamathite			Implicit			
-JOB	20	19	Zophar the Naamathite			Implicit			
-JOB	20	20	Zophar the Naamathite			Implicit			
-JOB	20	21	Zophar the Naamathite			Implicit			
-JOB	20	22	Zophar the Naamathite			Implicit			
-JOB	20	23	Zophar the Naamathite			Implicit			
-JOB	20	24	Zophar the Naamathite			Implicit			
-JOB	20	25	Zophar the Naamathite			Implicit			
-JOB	20	26	Zophar the Naamathite			Implicit			
-JOB	20	27	Zophar the Naamathite			Implicit			
-JOB	20	28	Zophar the Naamathite			Implicit			
-JOB	20	29	Zophar the Naamathite			Implicit			
-JOB	21	2	Job			Implicit			
-JOB	21	3	Job			Implicit			
-JOB	21	4	Job			Implicit			
-JOB	21	5	Job			Implicit			
-JOB	21	6	Job			Implicit			
-JOB	21	7	Job			Implicit			
-JOB	21	8	Job			Implicit			
-JOB	21	9	Job			Implicit			
-JOB	21	10	Job			Implicit			
-JOB	21	11	Job			Implicit			
-JOB	21	12	Job			Implicit			
-JOB	21	13	Job			Implicit			
-JOB	21	14	Job			Implicit			
-JOB	21	15	Job			Implicit			
-JOB	21	16	Job			Implicit			
-JOB	21	17	Job			Implicit			
-JOB	21	18	Job			Implicit			
-JOB	21	19	Job			Implicit			
-JOB	21	20	Job			Implicit			
-JOB	21	21	Job			Implicit			
-JOB	21	22	Job			Implicit			
-JOB	21	23	Job			Implicit			
-JOB	21	24	Job			Implicit			
-JOB	21	25	Job			Implicit			
-JOB	21	26	Job			Implicit			
-JOB	21	27	Job			Implicit			
-JOB	21	28	Job			Implicit			
-JOB	21	29	Job			Implicit			
-JOB	21	30	Job			Implicit			
-JOB	21	31	Job			Implicit			
-JOB	21	32	Job			Implicit			
-JOB	21	33	Job			Implicit			
-JOB	21	34	Job			Implicit			
-JOB	22	2	Eliphaz the Temanite			Implicit			
-JOB	22	3	Eliphaz the Temanite			Implicit			
-JOB	22	4	Eliphaz the Temanite			Implicit			
-JOB	22	5	Eliphaz the Temanite			Implicit			
-JOB	22	6	Eliphaz the Temanite			Implicit			
-JOB	22	7	Eliphaz the Temanite			Implicit			
-JOB	22	8	Eliphaz the Temanite			Implicit			
-JOB	22	9	Eliphaz the Temanite			Implicit			
-JOB	22	10	Eliphaz the Temanite			Implicit			
-JOB	22	11	Eliphaz the Temanite			Implicit			
-JOB	22	12	Eliphaz the Temanite			Implicit			
-JOB	22	13	Eliphaz the Temanite			Implicit			
-JOB	22	14	Eliphaz the Temanite			Implicit			
-JOB	22	15	Eliphaz the Temanite			Implicit			
-JOB	22	16	Eliphaz the Temanite			Implicit			
-JOB	22	17	Eliphaz the Temanite			Implicit			
-JOB	22	18	Eliphaz the Temanite			Implicit			
-JOB	22	19	Eliphaz the Temanite			Implicit			
-JOB	22	20	Eliphaz the Temanite			Implicit			
-JOB	22	21	Eliphaz the Temanite			Implicit			
-JOB	22	22	Eliphaz the Temanite			Implicit			
-JOB	22	23	Eliphaz the Temanite			Implicit			
-JOB	22	24	Eliphaz the Temanite			Implicit			
-JOB	22	25	Eliphaz the Temanite			Implicit			
-JOB	22	26	Eliphaz the Temanite			Implicit			
-JOB	22	27	Eliphaz the Temanite			Implicit			
-JOB	22	28	Eliphaz the Temanite			Implicit			
-JOB	22	29	Eliphaz the Temanite			Implicit			
-JOB	22	30	Eliphaz the Temanite			Implicit			
-JOB	23	2	Job			Implicit			
-JOB	23	3	Job			Implicit			
-JOB	23	4	Job			Implicit			
-JOB	23	5	Job			Implicit			
-JOB	23	6	Job			Implicit			
-JOB	23	7	Job			Implicit			
-JOB	23	8	Job			Implicit			
-JOB	23	9	Job			Implicit			
-JOB	23	10	Job			Implicit			
-JOB	23	11	Job			Implicit			
-JOB	23	12	Job			Implicit			
-JOB	23	13	Job			Implicit			
-JOB	23	14	Job			Implicit			
-JOB	23	15	Job			Implicit			
-JOB	23	16	Job			Implicit			
-JOB	23	17	Job			Implicit			
-JOB	24	1	Job			Implicit			
-JOB	24	2	Job			Implicit			
-JOB	24	3	Job			Implicit			
-JOB	24	4	Job			Implicit			
-JOB	24	5	Job			Implicit			
-JOB	24	6	Job			Implicit			
-JOB	24	7	Job			Implicit			
-JOB	24	8	Job			Implicit			
-JOB	24	9	Job			Implicit			
-JOB	24	10	Job			Implicit			
-JOB	24	11	Job			Implicit			
-JOB	24	12	Job			Implicit			
-JOB	24	13	Job			Implicit			
-JOB	24	14	Job			Implicit			
-JOB	24	15	Job			Implicit			
-JOB	24	16	Job			Implicit			
-JOB	24	17	Job			Implicit			
-JOB	24	18	Job			Implicit			
-JOB	24	19	Job			Implicit			
-JOB	24	20	Job			Implicit			
-JOB	24	21	Job			Implicit			
-JOB	24	22	Job			Implicit			
-JOB	24	23	Job			Implicit			
-JOB	24	24	Job			Implicit			
-JOB	24	25	Job			Implicit			
-JOB	25	2	Bildad the Shuhite			Implicit			
-JOB	25	3	Bildad the Shuhite			Implicit			
-JOB	25	4	Bildad the Shuhite			Implicit			
-JOB	25	5	Bildad the Shuhite			Implicit			
-JOB	25	6	Bildad the Shuhite			Implicit			
-JOB	26	2	Job			Implicit			
-JOB	26	3	Job			Implicit			
-JOB	26	4	Job			Implicit			
-JOB	26	5	Job			Implicit			
-JOB	26	6	Job			Implicit			
-JOB	26	7	Job			Implicit			
-JOB	26	8	Job			Implicit			
-JOB	26	9	Job			Implicit			
-JOB	26	10	Job			Implicit			
-JOB	26	11	Job			Implicit			
-JOB	26	12	Job			Implicit			
-JOB	26	13	Job			Implicit			
-JOB	26	14	Job			Implicit			
-JOB	27	2	Job			Implicit			
-JOB	27	3	Job			Implicit			
-JOB	27	4	Job			Implicit			
-JOB	27	5	Job			Implicit			
-JOB	27	6	Job			Implicit			
-JOB	27	7	Job			Implicit			
-JOB	27	8	Job			Implicit			
-JOB	27	9	Job			Implicit			
-JOB	27	10	Job			Implicit			
-JOB	27	11	Job			Implicit			
-JOB	27	12	Job			Implicit			
-JOB	27	13	Job			Implicit			
-JOB	27	14	Job			Implicit			
-JOB	27	15	Job			Implicit			
-JOB	27	16	Job			Implicit			
-JOB	27	17	Job			Implicit			
-JOB	27	18	Job			Implicit			
-JOB	27	19	Job			Implicit			
-JOB	27	20	Job			Implicit			
-JOB	27	21	Job			Implicit			
-JOB	27	22	Job			Implicit			
-JOB	27	23	Job			Implicit			
-JOB	28	1	Job			Implicit			
-JOB	28	2	Job			Implicit			
-JOB	28	3	Job			Implicit			
-JOB	28	4	Job			Implicit			
-JOB	28	5	Job			Implicit			
-JOB	28	6	Job			Implicit			
-JOB	28	7	Job			Implicit			
-JOB	28	8	Job			Implicit			
-JOB	28	9	Job			Implicit			
-JOB	28	10	Job			Implicit			
-JOB	28	11	Job			Implicit			
-JOB	28	12	Job			Implicit			
-JOB	28	13	Job			Implicit			
-JOB	28	14	Job			Implicit			
-JOB	28	15	Job			Implicit			
-JOB	28	16	Job			Implicit			
-JOB	28	17	Job			Implicit			
-JOB	28	18	Job			Implicit			
-JOB	28	19	Job			Implicit			
-JOB	28	20	Job			Implicit			
-JOB	28	21	Job			Implicit			
-JOB	28	22	Job			Implicit			
-JOB	28	23	Job			Implicit			
-JOB	28	24	Job			Implicit			
-JOB	28	25	Job			Implicit			
-JOB	28	26	Job			Implicit			
-JOB	28	27	Job			Implicit			
-JOB	28	28	Job			Implicit			
-JOB	29	2	Job			Implicit			
-JOB	29	3	Job			Implicit			
-JOB	29	4	Job			Implicit			
-JOB	29	5	Job			Implicit			
-JOB	29	6	Job			Implicit			
-JOB	29	7	Job			Implicit			
-JOB	29	8	Job			Implicit			
-JOB	29	9	Job			Implicit			
-JOB	29	10	Job			Implicit			
-JOB	29	11	Job			Implicit			
-JOB	29	12	Job			Implicit			
-JOB	29	13	Job			Implicit			
-JOB	29	14	Job			Implicit			
-JOB	29	15	Job			Implicit			
-JOB	29	16	Job			Implicit			
-JOB	29	17	Job			Implicit			
-JOB	29	18	Job			Implicit			
-JOB	29	19	Job			Implicit			
-JOB	29	20	Job			Implicit			
-JOB	29	21	Job			Implicit			
-JOB	29	22	Job			Implicit			
-JOB	29	23	Job			Implicit			
-JOB	29	24	Job			Implicit			
-JOB	29	25	Job			Implicit			
-JOB	30	1	Job			Implicit			
-JOB	30	2	Job			Implicit			
-JOB	30	3	Job			Implicit			
-JOB	30	4	Job			Implicit			
-JOB	30	5	Job			Implicit			
-JOB	30	6	Job			Implicit			
-JOB	30	7	Job			Implicit			
-JOB	30	8	Job			Implicit			
-JOB	30	9	Job			Implicit			
-JOB	30	10	Job			Implicit			
-JOB	30	11	Job			Implicit			
-JOB	30	12	Job			Implicit			
-JOB	30	13	Job			Implicit			
-JOB	30	14	Job			Implicit			
-JOB	30	15	Job			Implicit			
-JOB	30	16	Job			Implicit			
-JOB	30	17	Job			Implicit			
-JOB	30	18	Job			Implicit			
-JOB	30	19	Job			Implicit			
-JOB	30	20	Job			Implicit			
-JOB	30	21	Job			Implicit			
-JOB	30	22	Job			Implicit			
-JOB	30	23	Job			Implicit			
-JOB	30	24	Job			Implicit			
-JOB	30	25	Job			Implicit			
-JOB	30	26	Job			Implicit			
-JOB	30	27	Job			Implicit			
-JOB	30	28	Job			Implicit			
-JOB	30	29	Job			Implicit			
-JOB	30	30	Job			Implicit			
-JOB	30	31	Job			Implicit			
-JOB	31	1	Job			Implicit			
-JOB	31	2	Job			Implicit			
-JOB	31	3	Job			Implicit			
-JOB	31	4	Job			Implicit			
-JOB	31	5	Job			Implicit			
-JOB	31	6	Job			Implicit			
-JOB	31	7	Job			Implicit			
-JOB	31	8	Job			Implicit			
-JOB	31	9	Job			Implicit			
-JOB	31	10	Job			Implicit			
-JOB	31	11	Job			Implicit			
-JOB	31	12	Job			Implicit			
-JOB	31	13	Job			Implicit			
-JOB	31	14	Job			Implicit			
-JOB	31	15	Job			Implicit			
-JOB	31	16	Job			Implicit			
-JOB	31	17	Job			Implicit			
-JOB	31	18	Job			Implicit			
-JOB	31	19	Job			Implicit			
-JOB	31	20	Job			Implicit			
-JOB	31	21	Job			Implicit			
-JOB	31	22	Job			Implicit			
-JOB	31	23	Job			Implicit			
-JOB	31	24	Job			Implicit			
-JOB	31	25	Job			Implicit			
-JOB	31	26	Job			Implicit			
-JOB	31	27	Job			Implicit			
-JOB	31	28	Job			Implicit			
-JOB	31	29	Job			Implicit			
-JOB	31	30	Job			Implicit			
-JOB	31	31	Job			Implicit			
-JOB	31	32	Job			Implicit			
-JOB	31	33	Job			Implicit			
-JOB	31	34	Job			Implicit			
-JOB	31	35	Job			Implicit			
-JOB	31	36	Job			Implicit			
-JOB	31	37	Job			Implicit			
-JOB	31	38	Job			Implicit			
-JOB	31	39	Job			Implicit			
-JOB	31	40	Job			Implicit			
-JOB	32	6	Elihu, son of Barakel			Implicit			
-JOB	32	7	Elihu, son of Barakel			Implicit			
-JOB	32	8	Elihu, son of Barakel			Implicit			
-JOB	32	9	Elihu, son of Barakel			Implicit			
-JOB	32	10	Elihu, son of Barakel			Implicit			
-JOB	32	11	Elihu, son of Barakel			Implicit			
-JOB	32	12	Elihu, son of Barakel			Implicit			
-JOB	32	13	Elihu, son of Barakel			Implicit			
-JOB	32	14	Elihu, son of Barakel			Implicit			
-JOB	32	15	Elihu, son of Barakel			Implicit			
-JOB	32	16	Elihu, son of Barakel			Implicit			
-JOB	32	17	Elihu, son of Barakel			Implicit			
-JOB	32	18	Elihu, son of Barakel			Implicit			
-JOB	32	19	Elihu, son of Barakel			Implicit			
-JOB	32	20	Elihu, son of Barakel			Implicit			
-JOB	32	21	Elihu, son of Barakel			Implicit			
-JOB	32	22	Elihu, son of Barakel			Implicit			
-JOB	33	1	Elihu, son of Barakel			Implicit			
-JOB	33	2	Elihu, son of Barakel			Implicit			
-JOB	33	3	Elihu, son of Barakel			Implicit			
-JOB	33	4	Elihu, son of Barakel			Implicit			
-JOB	33	5	Elihu, son of Barakel			Implicit			
-JOB	33	6	Elihu, son of Barakel			Implicit			
-JOB	33	7	Elihu, son of Barakel			Implicit			
-JOB	33	8	Elihu, son of Barakel			Implicit			
-JOB	33	9	Elihu, son of Barakel			Implicit			
-JOB	33	10	Elihu, son of Barakel			Implicit			
-JOB	33	11	Elihu, son of Barakel			Implicit			
-JOB	33	12	Elihu, son of Barakel			Implicit			
-JOB	33	13	Elihu, son of Barakel			Implicit			
-JOB	33	14	Elihu, son of Barakel			Implicit			
-JOB	33	15	Elihu, son of Barakel			Implicit			
-JOB	33	16	Elihu, son of Barakel			Implicit			
-JOB	33	17	Elihu, son of Barakel			Implicit			
-JOB	33	18	Elihu, son of Barakel			Implicit			
-JOB	33	19	Elihu, son of Barakel			Implicit			
-JOB	33	20	Elihu, son of Barakel			Implicit			
-JOB	33	21	Elihu, son of Barakel			Implicit			
-JOB	33	22	Elihu, son of Barakel			Implicit			
-JOB	33	23	Elihu, son of Barakel			Implicit			
-JOB	33	24	Elihu, son of Barakel			Implicit			
-JOB	33	25	Elihu, son of Barakel			Implicit			
-JOB	33	26	Elihu, son of Barakel			Implicit			
-JOB	33	27	Elihu, son of Barakel			Implicit			
-JOB	33	28	Elihu, son of Barakel			Implicit			
-JOB	33	29	Elihu, son of Barakel			Implicit			
-JOB	33	30	Elihu, son of Barakel			Implicit			
-JOB	33	31	Elihu, son of Barakel			Implicit			
-JOB	33	32	Elihu, son of Barakel			Implicit			
-JOB	33	33	Elihu, son of Barakel			Implicit			
-JOB	34	2	Elihu, son of Barakel			Implicit			
-JOB	34	3	Elihu, son of Barakel			Implicit			
-JOB	34	4	Elihu, son of Barakel			Implicit			
-JOB	34	5	Elihu, son of Barakel			Implicit			
-JOB	34	6	Elihu, son of Barakel			Implicit			
-JOB	34	7	Elihu, son of Barakel			Implicit			
-JOB	34	8	Elihu, son of Barakel			Implicit			
-JOB	34	9	Elihu, son of Barakel			Implicit			
-JOB	34	10	Elihu, son of Barakel			Implicit			
-JOB	34	11	Elihu, son of Barakel			Implicit			
-JOB	34	12	Elihu, son of Barakel			Implicit			
-JOB	34	13	Elihu, son of Barakel			Implicit			
-JOB	34	14	Elihu, son of Barakel			Implicit			
-JOB	34	15	Elihu, son of Barakel			Implicit			
-JOB	34	16	Elihu, son of Barakel			Implicit			
-JOB	34	17	Elihu, son of Barakel			Implicit			
-JOB	34	18	Elihu, son of Barakel			Implicit			
-JOB	34	19	Elihu, son of Barakel			Implicit			
-JOB	34	20	Elihu, son of Barakel			Implicit			
-JOB	34	21	Elihu, son of Barakel			Implicit			
-JOB	34	22	Elihu, son of Barakel			Implicit			
-JOB	34	23	Elihu, son of Barakel			Implicit			
-JOB	34	24	Elihu, son of Barakel			Implicit			
-JOB	34	25	Elihu, son of Barakel			Implicit			
-JOB	34	26	Elihu, son of Barakel			Implicit			
-JOB	34	27	Elihu, son of Barakel			Implicit			
-JOB	34	28	Elihu, son of Barakel			Implicit			
-JOB	34	29	Elihu, son of Barakel			Implicit			
-JOB	34	30	Elihu, son of Barakel			Implicit			
-JOB	34	31	Elihu, son of Barakel			Implicit			
-JOB	34	32	Elihu, son of Barakel			Implicit			
-JOB	34	33	Elihu, son of Barakel			Implicit			
-JOB	34	34	Elihu, son of Barakel			Implicit			
-JOB	34	35	Elihu, son of Barakel			Implicit			
-JOB	34	36	Elihu, son of Barakel			Implicit			
-JOB	34	37	Elihu, son of Barakel			Implicit			
-JOB	35	2	Elihu, son of Barakel			Implicit			
-JOB	35	3	Elihu, son of Barakel			Implicit			
-JOB	35	4	Elihu, son of Barakel			Implicit			
-JOB	35	5	Elihu, son of Barakel			Implicit			
-JOB	35	6	Elihu, son of Barakel			Implicit			
-JOB	35	7	Elihu, son of Barakel			Implicit			
-JOB	35	8	Elihu, son of Barakel			Implicit			
-JOB	35	9	Elihu, son of Barakel			Implicit			
-JOB	35	10	Elihu, son of Barakel			Implicit			
-JOB	35	11	Elihu, son of Barakel			Implicit			
-JOB	35	12	Elihu, son of Barakel			Implicit			
-JOB	35	13	Elihu, son of Barakel			Implicit			
-JOB	35	14	Elihu, son of Barakel			Implicit			
-JOB	35	15	Elihu, son of Barakel			Implicit			
-JOB	35	16	Elihu, son of Barakel			Implicit			
-JOB	36	2	Elihu, son of Barakel			Implicit			
-JOB	36	3	Elihu, son of Barakel			Implicit			
-JOB	36	4	Elihu, son of Barakel			Implicit			
-JOB	36	5	Elihu, son of Barakel			Implicit			
-JOB	36	6	Elihu, son of Barakel			Implicit			
-JOB	36	7	Elihu, son of Barakel			Implicit			
-JOB	36	8	Elihu, son of Barakel			Implicit			
-JOB	36	9	Elihu, son of Barakel			Implicit			
-JOB	36	10	Elihu, son of Barakel			Implicit			
-JOB	36	11	Elihu, son of Barakel			Implicit			
-JOB	36	12	Elihu, son of Barakel			Implicit			
-JOB	36	13	Elihu, son of Barakel			Implicit			
-JOB	36	14	Elihu, son of Barakel			Implicit			
-JOB	36	15	Elihu, son of Barakel			Implicit			
-JOB	36	16	Elihu, son of Barakel			Implicit			
-JOB	36	17	Elihu, son of Barakel			Implicit			
-JOB	36	18	Elihu, son of Barakel			Implicit			
-JOB	36	19	Elihu, son of Barakel			Implicit			
-JOB	36	20	Elihu, son of Barakel			Implicit			
-JOB	36	21	Elihu, son of Barakel			Implicit			
-JOB	36	22	Elihu, son of Barakel			Implicit			
-JOB	36	23	Elihu, son of Barakel			Implicit			
-JOB	36	24	Elihu, son of Barakel			Implicit			
-JOB	36	25	Elihu, son of Barakel			Implicit			
-JOB	36	26	Elihu, son of Barakel			Implicit			
-JOB	36	27	Elihu, son of Barakel			Implicit			
-JOB	36	28	Elihu, son of Barakel			Implicit			
-JOB	36	29	Elihu, son of Barakel			Implicit			
-JOB	36	30	Elihu, son of Barakel			Implicit			
-JOB	36	31	Elihu, son of Barakel			Implicit			
-JOB	36	32	Elihu, son of Barakel			Implicit			
-JOB	36	33	Elihu, son of Barakel			Implicit			
-JOB	37	1	Elihu, son of Barakel			Implicit			
-JOB	37	2	Elihu, son of Barakel			Implicit			
-JOB	37	3	Elihu, son of Barakel			Implicit			
-JOB	37	4	Elihu, son of Barakel			Implicit			
-JOB	37	5	Elihu, son of Barakel			Implicit			
-JOB	37	6	Elihu, son of Barakel			Implicit			
-JOB	37	7	Elihu, son of Barakel			Implicit			
-JOB	37	8	Elihu, son of Barakel			Implicit			
-JOB	37	9	Elihu, son of Barakel			Implicit			
-JOB	37	10	Elihu, son of Barakel			Implicit			
-JOB	37	11	Elihu, son of Barakel			Implicit			
-JOB	37	12	Elihu, son of Barakel			Implicit			
-JOB	37	13	Elihu, son of Barakel			Implicit			
-JOB	37	14	Elihu, son of Barakel			Implicit			
-JOB	37	15	Elihu, son of Barakel			Implicit			
-JOB	37	16	Elihu, son of Barakel			Implicit			
-JOB	37	17	Elihu, son of Barakel			Implicit			
-JOB	37	18	Elihu, son of Barakel			Implicit			
-JOB	37	19	Elihu, son of Barakel			Implicit			
-JOB	37	20	Elihu, son of Barakel			Implicit			
-JOB	37	21	Elihu, son of Barakel			Implicit			
-JOB	37	22	Elihu, son of Barakel			Implicit			
-JOB	37	23	Elihu, son of Barakel			Implicit			
-JOB	37	24	Elihu, son of Barakel			Implicit			
-JOB	38	2	God		God (Yahweh)	Implicit			
-JOB	38	3	God		God (Yahweh)	Implicit			
-JOB	38	4	God		God (Yahweh)	Implicit			
-JOB	38	5	God		God (Yahweh)	Implicit			
-JOB	38	6	God		God (Yahweh)	Implicit			
-JOB	38	7	God		God (Yahweh)	Implicit			
-JOB	38	8	God		God (Yahweh)	Implicit			
-JOB	38	9	God		God (Yahweh)	Implicit			
-JOB	38	10	God		God (Yahweh)	Implicit			
-JOB	38	11	God		God (Yahweh)	Implicit			
-JOB	38	12	God		God (Yahweh)	Implicit			
-JOB	38	13	God		God (Yahweh)	Implicit			
-JOB	38	14	God		God (Yahweh)	Implicit			
-JOB	38	15	God		God (Yahweh)	Implicit			
-JOB	38	16	God		God (Yahweh)	Implicit			
-JOB	38	17	God		God (Yahweh)	Implicit			
-JOB	38	18	God		God (Yahweh)	Implicit			
-JOB	38	19	God		God (Yahweh)	Implicit			
-JOB	38	20	God		God (Yahweh)	Implicit			
-JOB	38	21	God		God (Yahweh)	Implicit			
-JOB	38	22	God		God (Yahweh)	Implicit			
-JOB	38	23	God		God (Yahweh)	Implicit			
-JOB	38	24	God		God (Yahweh)	Implicit			
-JOB	38	25	God		God (Yahweh)	Implicit			
-JOB	38	26	God		God (Yahweh)	Implicit			
-JOB	38	27	God		God (Yahweh)	Implicit			
-JOB	38	28	God		God (Yahweh)	Implicit			
-JOB	38	29	God		God (Yahweh)	Implicit			
-JOB	38	30	God		God (Yahweh)	Implicit			
-JOB	38	31	God		God (Yahweh)	Implicit			
-JOB	38	32	God		God (Yahweh)	Implicit			
-JOB	38	33	God		God (Yahweh)	Implicit			
-JOB	38	34	God		God (Yahweh)	Implicit			
-JOB	38	35	God		God (Yahweh)	Implicit			
-JOB	38	36	God		God (Yahweh)	Implicit			
-JOB	38	37	God		God (Yahweh)	Implicit			
-JOB	38	38	God		God (Yahweh)	Implicit			
-JOB	38	39	God		God (Yahweh)	Implicit			
-JOB	38	40	God		God (Yahweh)	Implicit			
-JOB	38	41	God		God (Yahweh)	Implicit			
-JOB	39	1	God		God (Yahweh)	Implicit			
-JOB	39	2	God		God (Yahweh)	Implicit			
-JOB	39	3	God		God (Yahweh)	Implicit			
-JOB	39	4	God		God (Yahweh)	Implicit			
-JOB	39	5	God		God (Yahweh)	Implicit			
-JOB	39	6	God		God (Yahweh)	Implicit			
-JOB	39	7	God		God (Yahweh)	Implicit			
-JOB	39	8	God		God (Yahweh)	Implicit			
-JOB	39	9	God		God (Yahweh)	Implicit			
-JOB	39	10	God		God (Yahweh)	Implicit			
-JOB	39	11	God		God (Yahweh)	Implicit			
-JOB	39	12	God		God (Yahweh)	Implicit			
-JOB	39	13	God		God (Yahweh)	Implicit			
-JOB	39	14	God		God (Yahweh)	Implicit			
-JOB	39	15	God		God (Yahweh)	Implicit			
-JOB	39	16	God		God (Yahweh)	Implicit			
-JOB	39	17	God		God (Yahweh)	Implicit			
-JOB	39	18	God		God (Yahweh)	Implicit			
-JOB	39	19	God		God (Yahweh)	Implicit			
-JOB	39	20	God		God (Yahweh)	Implicit			
-JOB	39	21	God		God (Yahweh)	Implicit			
-JOB	39	22	God		God (Yahweh)	Implicit			
-JOB	39	23	God		God (Yahweh)	Implicit			
-JOB	39	24	God		God (Yahweh)	Implicit			
-JOB	39	25	God		God (Yahweh)	Implicit			
-JOB	39	26	God		God (Yahweh)	Implicit			
-JOB	39	27	God		God (Yahweh)	Implicit			
-JOB	39	28	God		God (Yahweh)	Implicit			
-JOB	39	29	God		God (Yahweh)	Implicit			
-JOB	39	30	God		God (Yahweh)	Implicit			
-JOB	40	2	God		God (Yahweh)	Implicit			
-JOB	40	4	Job			Implicit			
-JOB	40	5	Job			Implicit			
-JOB	40	7	God		God (Yahweh)	Implicit			
-JOB	40	8	God		God (Yahweh)	Implicit			
-JOB	40	9	God		God (Yahweh)	Implicit			
-JOB	40	10	God		God (Yahweh)	Implicit			
-JOB	40	11	God		God (Yahweh)	Implicit			
-JOB	40	12	God		God (Yahweh)	Implicit			
-JOB	40	13	God		God (Yahweh)	Implicit			
-JOB	40	14	God		God (Yahweh)	Implicit			
-JOB	40	15	God		God (Yahweh)	Implicit			
-JOB	40	16	God		God (Yahweh)	Implicit			
-JOB	40	17	God		God (Yahweh)	Implicit			
-JOB	40	18	God		God (Yahweh)	Implicit			
-JOB	40	19	God		God (Yahweh)	Implicit			
-JOB	40	20	God		God (Yahweh)	Implicit			
-JOB	40	21	God		God (Yahweh)	Implicit			
-JOB	40	22	God		God (Yahweh)	Implicit			
-JOB	40	23	God		God (Yahweh)	Implicit			
-JOB	40	24	God		God (Yahweh)	Implicit			
-JOB	41	1	God		God (Yahweh)	Implicit			
-JOB	41	2	God		God (Yahweh)	Implicit			
-JOB	41	3	God		God (Yahweh)	Implicit			
-JOB	41	4	God		God (Yahweh)	Implicit			
-JOB	41	5	God		God (Yahweh)	Implicit			
-JOB	41	6	God		God (Yahweh)	Implicit			
-JOB	41	7	God		God (Yahweh)	Implicit			
-JOB	41	8	God		God (Yahweh)	Implicit			
-JOB	41	9	God		God (Yahweh)	Implicit			
-JOB	41	10	God		God (Yahweh)	Implicit			
-JOB	41	11	God		God (Yahweh)	Implicit			
-JOB	41	12	God		God (Yahweh)	Implicit			
-JOB	41	13	God		God (Yahweh)	Implicit			
-JOB	41	14	God		God (Yahweh)	Implicit			
-JOB	41	15	God		God (Yahweh)	Implicit			
-JOB	41	16	God		God (Yahweh)	Implicit			
-JOB	41	17	God		God (Yahweh)	Implicit			
-JOB	41	18	God		God (Yahweh)	Implicit			
-JOB	41	19	God		God (Yahweh)	Implicit			
-JOB	41	20	God		God (Yahweh)	Implicit			
-JOB	41	21	God		God (Yahweh)	Implicit			
-JOB	41	22	God		God (Yahweh)	Implicit			
-JOB	41	23	God		God (Yahweh)	Implicit			
-JOB	41	24	God		God (Yahweh)	Implicit			
-JOB	41	25	God		God (Yahweh)	Implicit			
-JOB	41	26	God		God (Yahweh)	Implicit			
-JOB	41	27	God		God (Yahweh)	Implicit			
-JOB	41	28	God		God (Yahweh)	Implicit			
-JOB	41	29	God		God (Yahweh)	Implicit			
-JOB	41	30	God		God (Yahweh)	Implicit			
-JOB	41	31	God		God (Yahweh)	Implicit			
-JOB	41	32	God		God (Yahweh)	Implicit			
-JOB	41	33	God		God (Yahweh)	Implicit			
-JOB	41	34	God		God (Yahweh)	Implicit			
-JOB	42	2	Job			Implicit			
-JOB	42	3	Job			Implicit			
-JOB	42	4	Job			Implicit			
-JOB	42	5	Job			Implicit			
-JOB	42	6	Job			Implicit			
+JOB	3	3	Job			Implicit			EntireVerse
+JOB	3	4	Job			Implicit			EntireVerse
+JOB	3	5	Job			Implicit			EntireVerse
+JOB	3	6	Job			Implicit			EntireVerse
+JOB	3	7	Job			Implicit			EntireVerse
+JOB	3	8	Job			Implicit			EntireVerse
+JOB	3	9	Job			Implicit			EntireVerse
+JOB	3	10	Job			Implicit			EntireVerse
+JOB	3	11	Job			Implicit			EntireVerse
+JOB	3	12	Job			Implicit			EntireVerse
+JOB	3	13	Job			Implicit			EntireVerse
+JOB	3	14	Job			Implicit			EntireVerse
+JOB	3	15	Job			Implicit			EntireVerse
+JOB	3	16	Job			Implicit			EntireVerse
+JOB	3	17	Job			Implicit			EntireVerse
+JOB	3	18	Job			Implicit			EntireVerse
+JOB	3	19	Job			Implicit			EntireVerse
+JOB	3	20	Job			Implicit			EntireVerse
+JOB	3	21	Job			Implicit			EntireVerse
+JOB	3	22	Job			Implicit			EntireVerse
+JOB	3	23	Job			Implicit			EntireVerse
+JOB	3	24	Job			Implicit			EntireVerse
+JOB	3	25	Job			Implicit			EntireVerse
+JOB	3	26	Job			Implicit			EntireVerse
+JOB	4	2	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	3	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	4	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	5	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	6	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	7	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	8	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	9	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	10	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	11	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	12	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	13	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	14	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	15	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	16	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	17	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	18	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	19	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	20	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	4	21	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	1	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	2	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	3	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	4	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	5	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	6	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	7	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	8	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	9	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	10	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	11	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	12	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	13	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	14	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	15	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	16	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	17	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	18	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	19	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	20	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	21	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	22	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	23	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	24	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	25	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	26	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	5	27	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	6	2	Job			Implicit			EntireVerse
+JOB	6	3	Job			Implicit			EntireVerse
+JOB	6	4	Job			Implicit			EntireVerse
+JOB	6	5	Job			Implicit			EntireVerse
+JOB	6	6	Job			Implicit			EntireVerse
+JOB	6	7	Job			Implicit			EntireVerse
+JOB	6	8	Job			Implicit			EntireVerse
+JOB	6	9	Job			Implicit			EntireVerse
+JOB	6	10	Job			Implicit			EntireVerse
+JOB	6	11	Job			Implicit			EntireVerse
+JOB	6	12	Job			Implicit			EntireVerse
+JOB	6	13	Job			Implicit			EntireVerse
+JOB	6	14	Job			Implicit			EntireVerse
+JOB	6	15	Job			Implicit			EntireVerse
+JOB	6	16	Job			Implicit			EntireVerse
+JOB	6	17	Job			Implicit			EntireVerse
+JOB	6	18	Job			Implicit			EntireVerse
+JOB	6	19	Job			Implicit			EntireVerse
+JOB	6	20	Job			Implicit			EntireVerse
+JOB	6	21	Job			Implicit			EntireVerse
+JOB	6	22	Job			Implicit			EntireVerse
+JOB	6	23	Job			Implicit			EntireVerse
+JOB	6	24	Job			Implicit			EntireVerse
+JOB	6	25	Job			Implicit			EntireVerse
+JOB	6	26	Job			Implicit			EntireVerse
+JOB	6	27	Job			Implicit			EntireVerse
+JOB	6	28	Job			Implicit			EntireVerse
+JOB	6	29	Job			Implicit			EntireVerse
+JOB	6	30	Job			Implicit			EntireVerse
+JOB	7	1	Job			Implicit			EntireVerse
+JOB	7	2	Job			Implicit			EntireVerse
+JOB	7	3	Job			Implicit			EntireVerse
+JOB	7	4	Job			Implicit			EntireVerse
+JOB	7	5	Job			Implicit			EntireVerse
+JOB	7	6	Job			Implicit			EntireVerse
+JOB	7	7	Job			Implicit			EntireVerse
+JOB	7	8	Job			Implicit			EntireVerse
+JOB	7	9	Job			Implicit			EntireVerse
+JOB	7	10	Job			Implicit			EntireVerse
+JOB	7	11	Job			Implicit			EntireVerse
+JOB	7	12	Job			Implicit			EntireVerse
+JOB	7	13	Job			Implicit			EntireVerse
+JOB	7	14	Job			Implicit			EntireVerse
+JOB	7	15	Job			Implicit			EntireVerse
+JOB	7	16	Job			Implicit			EntireVerse
+JOB	7	17	Job			Implicit			EntireVerse
+JOB	7	18	Job			Implicit			EntireVerse
+JOB	7	19	Job			Implicit			EntireVerse
+JOB	7	20	Job			Implicit			EntireVerse
+JOB	7	21	Job			Implicit			EntireVerse
+JOB	8	2	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	3	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	4	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	5	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	6	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	7	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	8	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	9	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	10	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	11	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	12	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	13	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	14	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	15	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	16	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	17	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	18	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	19	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	20	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	21	Bildad the Shuhite			Implicit			EntireVerse
+JOB	8	22	Bildad the Shuhite			Implicit			EntireVerse
+JOB	9	2	Job			Implicit			EntireVerse
+JOB	9	3	Job			Implicit			EntireVerse
+JOB	9	4	Job			Implicit			EntireVerse
+JOB	9	5	Job			Implicit			EntireVerse
+JOB	9	6	Job			Implicit			EntireVerse
+JOB	9	7	Job			Implicit			EntireVerse
+JOB	9	8	Job			Implicit			EntireVerse
+JOB	9	9	Job			Implicit			EntireVerse
+JOB	9	10	Job			Implicit			EntireVerse
+JOB	9	11	Job			Implicit			EntireVerse
+JOB	9	12	Job			Implicit			EntireVerse
+JOB	9	13	Job			Implicit			EntireVerse
+JOB	9	14	Job			Implicit			EntireVerse
+JOB	9	15	Job			Implicit			EntireVerse
+JOB	9	16	Job			Implicit			EntireVerse
+JOB	9	17	Job			Implicit			EntireVerse
+JOB	9	18	Job			Implicit			EntireVerse
+JOB	9	19	Job			Implicit			EntireVerse
+JOB	9	20	Job			Implicit			EntireVerse
+JOB	9	21	Job			Implicit			EntireVerse
+JOB	9	22	Job			Implicit			EntireVerse
+JOB	9	23	Job			Implicit			EntireVerse
+JOB	9	24	Job			Implicit			EntireVerse
+JOB	9	25	Job			Implicit			EntireVerse
+JOB	9	26	Job			Implicit			EntireVerse
+JOB	9	27	Job			Implicit			EntireVerse
+JOB	9	28	Job			Implicit			EntireVerse
+JOB	9	29	Job			Implicit			EntireVerse
+JOB	9	30	Job			Implicit			EntireVerse
+JOB	9	31	Job			Implicit			EntireVerse
+JOB	9	32	Job			Implicit			EntireVerse
+JOB	9	33	Job			Implicit			EntireVerse
+JOB	9	34	Job			Implicit			EntireVerse
+JOB	9	35	Job			Implicit			EntireVerse
+JOB	10	1	Job			Implicit			EntireVerse
+JOB	10	2	Job			Implicit			EntireVerse
+JOB	10	3	Job			Implicit			EntireVerse
+JOB	10	4	Job			Implicit			EntireVerse
+JOB	10	5	Job			Implicit			EntireVerse
+JOB	10	6	Job			Implicit			EntireVerse
+JOB	10	7	Job			Implicit			EntireVerse
+JOB	10	8	Job			Implicit			EntireVerse
+JOB	10	9	Job			Implicit			EntireVerse
+JOB	10	10	Job			Implicit			EntireVerse
+JOB	10	11	Job			Implicit			EntireVerse
+JOB	10	12	Job			Implicit			EntireVerse
+JOB	10	13	Job			Implicit			EntireVerse
+JOB	10	14	Job			Implicit			EntireVerse
+JOB	10	15	Job			Implicit			EntireVerse
+JOB	10	16	Job			Implicit			EntireVerse
+JOB	10	17	Job			Implicit			EntireVerse
+JOB	10	18	Job			Implicit			EntireVerse
+JOB	10	19	Job			Implicit			EntireVerse
+JOB	10	20	Job			Implicit			EntireVerse
+JOB	10	21	Job			Implicit			EntireVerse
+JOB	10	22	Job			Implicit			EntireVerse
+JOB	11	2	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	3	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	4	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	5	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	6	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	7	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	8	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	9	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	10	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	11	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	12	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	13	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	14	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	15	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	16	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	17	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	18	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	19	Zophar the Naamathite			Implicit			EntireVerse
+JOB	11	20	Zophar the Naamathite			Implicit			EntireVerse
+JOB	12	2	Job			Implicit			EntireVerse
+JOB	12	3	Job			Implicit			EntireVerse
+JOB	12	4	Job			Implicit			EntireVerse
+JOB	12	5	Job			Implicit			EntireVerse
+JOB	12	6	Job			Implicit			EntireVerse
+JOB	12	7	Job			Implicit			EntireVerse
+JOB	12	8	Job			Implicit			EntireVerse
+JOB	12	9	Job			Implicit			EntireVerse
+JOB	12	10	Job			Implicit			EntireVerse
+JOB	12	11	Job			Implicit			EntireVerse
+JOB	12	12	Job			Implicit			EntireVerse
+JOB	12	13	Job			Implicit			EntireVerse
+JOB	12	14	Job			Implicit			EntireVerse
+JOB	12	15	Job			Implicit			EntireVerse
+JOB	12	16	Job			Implicit			EntireVerse
+JOB	12	17	Job			Implicit			EntireVerse
+JOB	12	18	Job			Implicit			EntireVerse
+JOB	12	19	Job			Implicit			EntireVerse
+JOB	12	20	Job			Implicit			EntireVerse
+JOB	12	21	Job			Implicit			EntireVerse
+JOB	12	22	Job			Implicit			EntireVerse
+JOB	12	23	Job			Implicit			EntireVerse
+JOB	12	24	Job			Implicit			EntireVerse
+JOB	12	25	Job			Implicit			EntireVerse
+JOB	13	1	Job			Implicit			EntireVerse
+JOB	13	2	Job			Implicit			EntireVerse
+JOB	13	3	Job			Implicit			EntireVerse
+JOB	13	4	Job			Implicit			EntireVerse
+JOB	13	5	Job			Implicit			EntireVerse
+JOB	13	6	Job			Implicit			EntireVerse
+JOB	13	7	Job			Implicit			EntireVerse
+JOB	13	8	Job			Implicit			EntireVerse
+JOB	13	9	Job			Implicit			EntireVerse
+JOB	13	10	Job			Implicit			EntireVerse
+JOB	13	11	Job			Implicit			EntireVerse
+JOB	13	12	Job			Implicit			EntireVerse
+JOB	13	13	Job			Implicit			EntireVerse
+JOB	13	14	Job			Implicit			EntireVerse
+JOB	13	15	Job			Implicit			EntireVerse
+JOB	13	16	Job			Implicit			EntireVerse
+JOB	13	17	Job			Implicit			EntireVerse
+JOB	13	18	Job			Implicit			EntireVerse
+JOB	13	19	Job			Implicit			EntireVerse
+JOB	13	20	Job			Implicit			EntireVerse
+JOB	13	21	Job			Implicit			EntireVerse
+JOB	13	22	Job			Implicit			EntireVerse
+JOB	13	23	Job			Implicit			EntireVerse
+JOB	13	24	Job			Implicit			EntireVerse
+JOB	13	25	Job			Implicit			EntireVerse
+JOB	13	26	Job			Implicit			EntireVerse
+JOB	13	27	Job			Implicit			EntireVerse
+JOB	13	28	Job			Implicit			EntireVerse
+JOB	14	1	Job			Implicit			EntireVerse
+JOB	14	2	Job			Implicit			EntireVerse
+JOB	14	3	Job			Implicit			EntireVerse
+JOB	14	4	Job			Implicit			EntireVerse
+JOB	14	5	Job			Implicit			EntireVerse
+JOB	14	6	Job			Implicit			EntireVerse
+JOB	14	7	Job			Implicit			EntireVerse
+JOB	14	8	Job			Implicit			EntireVerse
+JOB	14	9	Job			Implicit			EntireVerse
+JOB	14	10	Job			Implicit			EntireVerse
+JOB	14	11	Job			Implicit			EntireVerse
+JOB	14	12	Job			Implicit			EntireVerse
+JOB	14	13	Job			Implicit			EntireVerse
+JOB	14	14	Job			Implicit			EntireVerse
+JOB	14	15	Job			Implicit			EntireVerse
+JOB	14	16	Job			Implicit			EntireVerse
+JOB	14	17	Job			Implicit			EntireVerse
+JOB	14	18	Job			Implicit			EntireVerse
+JOB	14	19	Job			Implicit			EntireVerse
+JOB	14	20	Job			Implicit			EntireVerse
+JOB	14	21	Job			Implicit			EntireVerse
+JOB	14	22	Job			Implicit			EntireVerse
+JOB	15	2	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	3	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	4	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	5	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	6	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	7	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	8	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	9	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	10	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	11	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	12	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	13	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	14	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	15	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	16	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	17	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	18	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	19	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	20	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	21	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	22	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	23	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	24	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	25	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	26	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	27	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	28	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	29	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	30	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	31	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	32	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	33	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	34	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	15	35	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	16	2	Job			Implicit			EntireVerse
+JOB	16	3	Job			Implicit			EntireVerse
+JOB	16	4	Job			Implicit			EntireVerse
+JOB	16	5	Job			Implicit			EntireVerse
+JOB	16	6	Job			Implicit			EntireVerse
+JOB	16	7	Job			Implicit			EntireVerse
+JOB	16	8	Job			Implicit			EntireVerse
+JOB	16	9	Job			Implicit			EntireVerse
+JOB	16	10	Job			Implicit			EntireVerse
+JOB	16	11	Job			Implicit			EntireVerse
+JOB	16	12	Job			Implicit			EntireVerse
+JOB	16	13	Job			Implicit			EntireVerse
+JOB	16	14	Job			Implicit			EntireVerse
+JOB	16	15	Job			Implicit			EntireVerse
+JOB	16	16	Job			Implicit			EntireVerse
+JOB	16	17	Job			Implicit			EntireVerse
+JOB	16	18	Job			Implicit			EntireVerse
+JOB	16	19	Job			Implicit			EntireVerse
+JOB	16	20	Job			Implicit			EntireVerse
+JOB	16	21	Job			Implicit			EntireVerse
+JOB	16	22	Job			Implicit			EntireVerse
+JOB	17	1	Job			Implicit			EntireVerse
+JOB	17	2	Job			Implicit			EntireVerse
+JOB	17	3	Job			Implicit			EntireVerse
+JOB	17	4	Job			Implicit			EntireVerse
+JOB	17	5	Job			Implicit			EntireVerse
+JOB	17	6	Job			Implicit			EntireVerse
+JOB	17	7	Job			Implicit			EntireVerse
+JOB	17	8	Job			Implicit			EntireVerse
+JOB	17	9	Job			Implicit			EntireVerse
+JOB	17	10	Job			Implicit			EntireVerse
+JOB	17	11	Job			Implicit			EntireVerse
+JOB	17	12	Job			Implicit			EntireVerse
+JOB	17	13	Job			Implicit			EntireVerse
+JOB	17	14	Job			Implicit			EntireVerse
+JOB	17	15	Job			Implicit			EntireVerse
+JOB	17	16	Job			Implicit			EntireVerse
+JOB	18	2	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	3	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	4	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	5	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	6	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	7	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	8	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	9	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	10	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	11	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	12	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	13	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	14	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	15	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	16	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	17	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	18	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	19	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	20	Bildad the Shuhite			Implicit			EntireVerse
+JOB	18	21	Bildad the Shuhite			Implicit			EntireVerse
+JOB	19	2	Job			Implicit			EntireVerse
+JOB	19	3	Job			Implicit			EntireVerse
+JOB	19	4	Job			Implicit			EntireVerse
+JOB	19	5	Job			Implicit			EntireVerse
+JOB	19	6	Job			Implicit			EntireVerse
+JOB	19	7	Job			Implicit			EntireVerse
+JOB	19	8	Job			Implicit			EntireVerse
+JOB	19	9	Job			Implicit			EntireVerse
+JOB	19	10	Job			Implicit			EntireVerse
+JOB	19	11	Job			Implicit			EntireVerse
+JOB	19	12	Job			Implicit			EntireVerse
+JOB	19	13	Job			Implicit			EntireVerse
+JOB	19	14	Job			Implicit			EntireVerse
+JOB	19	15	Job			Implicit			EntireVerse
+JOB	19	16	Job			Implicit			EntireVerse
+JOB	19	17	Job			Implicit			EntireVerse
+JOB	19	18	Job			Implicit			EntireVerse
+JOB	19	19	Job			Implicit			EntireVerse
+JOB	19	20	Job			Implicit			EntireVerse
+JOB	19	21	Job			Implicit			EntireVerse
+JOB	19	22	Job			Implicit			EntireVerse
+JOB	19	23	Job			Implicit			EntireVerse
+JOB	19	24	Job			Implicit			EntireVerse
+JOB	19	25	Job			Implicit			EntireVerse
+JOB	19	26	Job			Implicit			EntireVerse
+JOB	19	27	Job			Implicit			EntireVerse
+JOB	19	28	Job			Implicit			EntireVerse
+JOB	19	29	Job			Implicit			EntireVerse
+JOB	20	2	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	3	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	4	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	5	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	6	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	7	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	8	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	9	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	10	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	11	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	12	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	13	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	14	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	15	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	16	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	17	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	18	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	19	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	20	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	21	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	22	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	23	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	24	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	25	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	26	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	27	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	28	Zophar the Naamathite			Implicit			EntireVerse
+JOB	20	29	Zophar the Naamathite			Implicit			EntireVerse
+JOB	21	2	Job			Implicit			EntireVerse
+JOB	21	3	Job			Implicit			EntireVerse
+JOB	21	4	Job			Implicit			EntireVerse
+JOB	21	5	Job			Implicit			EntireVerse
+JOB	21	6	Job			Implicit			EntireVerse
+JOB	21	7	Job			Implicit			EntireVerse
+JOB	21	8	Job			Implicit			EntireVerse
+JOB	21	9	Job			Implicit			EntireVerse
+JOB	21	10	Job			Implicit			EntireVerse
+JOB	21	11	Job			Implicit			EntireVerse
+JOB	21	12	Job			Implicit			EntireVerse
+JOB	21	13	Job			Implicit			EntireVerse
+JOB	21	14	Job			Implicit			EntireVerse
+JOB	21	15	Job			Implicit			EntireVerse
+JOB	21	16	Job			Implicit			EntireVerse
+JOB	21	17	Job			Implicit			EntireVerse
+JOB	21	18	Job			Implicit			EntireVerse
+JOB	21	19	Job			Implicit			EntireVerse
+JOB	21	20	Job			Implicit			EntireVerse
+JOB	21	21	Job			Implicit			EntireVerse
+JOB	21	22	Job			Implicit			EntireVerse
+JOB	21	23	Job			Implicit			EntireVerse
+JOB	21	24	Job			Implicit			EntireVerse
+JOB	21	25	Job			Implicit			EntireVerse
+JOB	21	26	Job			Implicit			EntireVerse
+JOB	21	27	Job			Implicit			EntireVerse
+JOB	21	28	Job			Implicit			EntireVerse
+JOB	21	29	Job			Implicit			EntireVerse
+JOB	21	30	Job			Implicit			EntireVerse
+JOB	21	31	Job			Implicit			EntireVerse
+JOB	21	32	Job			Implicit			EntireVerse
+JOB	21	33	Job			Implicit			EntireVerse
+JOB	21	34	Job			Implicit			EntireVerse
+JOB	22	2	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	3	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	4	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	5	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	6	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	7	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	8	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	9	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	10	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	11	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	12	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	13	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	14	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	15	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	16	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	17	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	18	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	19	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	20	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	21	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	22	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	23	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	24	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	25	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	26	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	27	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	28	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	29	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	22	30	Eliphaz the Temanite			Implicit			EntireVerse
+JOB	23	2	Job			Implicit			EntireVerse
+JOB	23	3	Job			Implicit			EntireVerse
+JOB	23	4	Job			Implicit			EntireVerse
+JOB	23	5	Job			Implicit			EntireVerse
+JOB	23	6	Job			Implicit			EntireVerse
+JOB	23	7	Job			Implicit			EntireVerse
+JOB	23	8	Job			Implicit			EntireVerse
+JOB	23	9	Job			Implicit			EntireVerse
+JOB	23	10	Job			Implicit			EntireVerse
+JOB	23	11	Job			Implicit			EntireVerse
+JOB	23	12	Job			Implicit			EntireVerse
+JOB	23	13	Job			Implicit			EntireVerse
+JOB	23	14	Job			Implicit			EntireVerse
+JOB	23	15	Job			Implicit			EntireVerse
+JOB	23	16	Job			Implicit			EntireVerse
+JOB	23	17	Job			Implicit			EntireVerse
+JOB	24	1	Job			Implicit			EntireVerse
+JOB	24	2	Job			Implicit			EntireVerse
+JOB	24	3	Job			Implicit			EntireVerse
+JOB	24	4	Job			Implicit			EntireVerse
+JOB	24	5	Job			Implicit			EntireVerse
+JOB	24	6	Job			Implicit			EntireVerse
+JOB	24	7	Job			Implicit			EntireVerse
+JOB	24	8	Job			Implicit			EntireVerse
+JOB	24	9	Job			Implicit			EntireVerse
+JOB	24	10	Job			Implicit			EntireVerse
+JOB	24	11	Job			Implicit			EntireVerse
+JOB	24	12	Job			Implicit			EntireVerse
+JOB	24	13	Job			Implicit			EntireVerse
+JOB	24	14	Job			Implicit			EntireVerse
+JOB	24	15	Job			Implicit			EntireVerse
+JOB	24	16	Job			Implicit			EntireVerse
+JOB	24	17	Job			Implicit			EntireVerse
+JOB	24	18	Job			Implicit			EntireVerse
+JOB	24	19	Job			Implicit			EntireVerse
+JOB	24	20	Job			Implicit			EntireVerse
+JOB	24	21	Job			Implicit			EntireVerse
+JOB	24	22	Job			Implicit			EntireVerse
+JOB	24	23	Job			Implicit			EntireVerse
+JOB	24	24	Job			Implicit			EntireVerse
+JOB	24	25	Job			Implicit			EntireVerse
+JOB	25	2	Bildad the Shuhite			Implicit			EntireVerse
+JOB	25	3	Bildad the Shuhite			Implicit			EntireVerse
+JOB	25	4	Bildad the Shuhite			Implicit			EntireVerse
+JOB	25	5	Bildad the Shuhite			Implicit			EntireVerse
+JOB	25	6	Bildad the Shuhite			Implicit			EntireVerse
+JOB	26	2	Job			Implicit			EntireVerse
+JOB	26	3	Job			Implicit			EntireVerse
+JOB	26	4	Job			Implicit			EntireVerse
+JOB	26	5	Job			Implicit			EntireVerse
+JOB	26	6	Job			Implicit			EntireVerse
+JOB	26	7	Job			Implicit			EntireVerse
+JOB	26	8	Job			Implicit			EntireVerse
+JOB	26	9	Job			Implicit			EntireVerse
+JOB	26	10	Job			Implicit			EntireVerse
+JOB	26	11	Job			Implicit			EntireVerse
+JOB	26	12	Job			Implicit			EntireVerse
+JOB	26	13	Job			Implicit			EntireVerse
+JOB	26	14	Job			Implicit			EntireVerse
+JOB	27	2	Job			Implicit			EntireVerse
+JOB	27	3	Job			Implicit			EntireVerse
+JOB	27	4	Job			Implicit			EntireVerse
+JOB	27	5	Job			Implicit			EntireVerse
+JOB	27	6	Job			Implicit			EntireVerse
+JOB	27	7	Job			Implicit			EntireVerse
+JOB	27	8	Job			Implicit			EntireVerse
+JOB	27	9	Job			Implicit			EntireVerse
+JOB	27	10	Job			Implicit			EntireVerse
+JOB	27	11	Job			Implicit			EntireVerse
+JOB	27	12	Job			Implicit			EntireVerse
+JOB	27	13	Job			Implicit			EntireVerse
+JOB	27	14	Job			Implicit			EntireVerse
+JOB	27	15	Job			Implicit			EntireVerse
+JOB	27	16	Job			Implicit			EntireVerse
+JOB	27	17	Job			Implicit			EntireVerse
+JOB	27	18	Job			Implicit			EntireVerse
+JOB	27	19	Job			Implicit			EntireVerse
+JOB	27	20	Job			Implicit			EntireVerse
+JOB	27	21	Job			Implicit			EntireVerse
+JOB	27	22	Job			Implicit			EntireVerse
+JOB	27	23	Job			Implicit			EntireVerse
+JOB	28	1	Job			Implicit			EntireVerse
+JOB	28	2	Job			Implicit			EntireVerse
+JOB	28	3	Job			Implicit			EntireVerse
+JOB	28	4	Job			Implicit			EntireVerse
+JOB	28	5	Job			Implicit			EntireVerse
+JOB	28	6	Job			Implicit			EntireVerse
+JOB	28	7	Job			Implicit			EntireVerse
+JOB	28	8	Job			Implicit			EntireVerse
+JOB	28	9	Job			Implicit			EntireVerse
+JOB	28	10	Job			Implicit			EntireVerse
+JOB	28	11	Job			Implicit			EntireVerse
+JOB	28	12	Job			Implicit			EntireVerse
+JOB	28	13	Job			Implicit			EntireVerse
+JOB	28	14	Job			Implicit			EntireVerse
+JOB	28	15	Job			Implicit			EntireVerse
+JOB	28	16	Job			Implicit			EntireVerse
+JOB	28	17	Job			Implicit			EntireVerse
+JOB	28	18	Job			Implicit			EntireVerse
+JOB	28	19	Job			Implicit			EntireVerse
+JOB	28	20	Job			Implicit			EntireVerse
+JOB	28	21	Job			Implicit			EntireVerse
+JOB	28	22	Job			Implicit			EntireVerse
+JOB	28	23	Job			Implicit			EntireVerse
+JOB	28	24	Job			Implicit			EntireVerse
+JOB	28	25	Job			Implicit			EntireVerse
+JOB	28	26	Job			Implicit			EntireVerse
+JOB	28	27	Job			Implicit			EntireVerse
+JOB	28	28	Job			Implicit			EntireVerse
+JOB	29	2	Job			Implicit			EntireVerse
+JOB	29	3	Job			Implicit			EntireVerse
+JOB	29	4	Job			Implicit			EntireVerse
+JOB	29	5	Job			Implicit			EntireVerse
+JOB	29	6	Job			Implicit			EntireVerse
+JOB	29	7	Job			Implicit			EntireVerse
+JOB	29	8	Job			Implicit			EntireVerse
+JOB	29	9	Job			Implicit			EntireVerse
+JOB	29	10	Job			Implicit			EntireVerse
+JOB	29	11	Job			Implicit			EntireVerse
+JOB	29	12	Job			Implicit			EntireVerse
+JOB	29	13	Job			Implicit			EntireVerse
+JOB	29	14	Job			Implicit			EntireVerse
+JOB	29	15	Job			Implicit			EntireVerse
+JOB	29	16	Job			Implicit			EntireVerse
+JOB	29	17	Job			Implicit			EntireVerse
+JOB	29	18	Job			Implicit			EntireVerse
+JOB	29	19	Job			Implicit			EntireVerse
+JOB	29	20	Job			Implicit			EntireVerse
+JOB	29	21	Job			Implicit			EntireVerse
+JOB	29	22	Job			Implicit			EntireVerse
+JOB	29	23	Job			Implicit			EntireVerse
+JOB	29	24	Job			Implicit			EntireVerse
+JOB	29	25	Job			Implicit			EntireVerse
+JOB	30	1	Job			Implicit			EntireVerse
+JOB	30	2	Job			Implicit			EntireVerse
+JOB	30	3	Job			Implicit			EntireVerse
+JOB	30	4	Job			Implicit			EntireVerse
+JOB	30	5	Job			Implicit			EntireVerse
+JOB	30	6	Job			Implicit			EntireVerse
+JOB	30	7	Job			Implicit			EntireVerse
+JOB	30	8	Job			Implicit			EntireVerse
+JOB	30	9	Job			Implicit			EntireVerse
+JOB	30	10	Job			Implicit			EntireVerse
+JOB	30	11	Job			Implicit			EntireVerse
+JOB	30	12	Job			Implicit			EntireVerse
+JOB	30	13	Job			Implicit			EntireVerse
+JOB	30	14	Job			Implicit			EntireVerse
+JOB	30	15	Job			Implicit			EntireVerse
+JOB	30	16	Job			Implicit			EntireVerse
+JOB	30	17	Job			Implicit			EntireVerse
+JOB	30	18	Job			Implicit			EntireVerse
+JOB	30	19	Job			Implicit			EntireVerse
+JOB	30	20	Job			Implicit			EntireVerse
+JOB	30	21	Job			Implicit			EntireVerse
+JOB	30	22	Job			Implicit			EntireVerse
+JOB	30	23	Job			Implicit			EntireVerse
+JOB	30	24	Job			Implicit			EntireVerse
+JOB	30	25	Job			Implicit			EntireVerse
+JOB	30	26	Job			Implicit			EntireVerse
+JOB	30	27	Job			Implicit			EntireVerse
+JOB	30	28	Job			Implicit			EntireVerse
+JOB	30	29	Job			Implicit			EntireVerse
+JOB	30	30	Job			Implicit			EntireVerse
+JOB	30	31	Job			Implicit			EntireVerse
+JOB	31	1	Job			Implicit			EntireVerse
+JOB	31	2	Job			Implicit			EntireVerse
+JOB	31	3	Job			Implicit			EntireVerse
+JOB	31	4	Job			Implicit			EntireVerse
+JOB	31	5	Job			Implicit			EntireVerse
+JOB	31	6	Job			Implicit			EntireVerse
+JOB	31	7	Job			Implicit			EntireVerse
+JOB	31	8	Job			Implicit			EntireVerse
+JOB	31	9	Job			Implicit			EntireVerse
+JOB	31	10	Job			Implicit			EntireVerse
+JOB	31	11	Job			Implicit			EntireVerse
+JOB	31	12	Job			Implicit			EntireVerse
+JOB	31	13	Job			Implicit			EntireVerse
+JOB	31	14	Job			Implicit			EntireVerse
+JOB	31	15	Job			Implicit			EntireVerse
+JOB	31	16	Job			Implicit			EntireVerse
+JOB	31	17	Job			Implicit			EntireVerse
+JOB	31	18	Job			Implicit			EntireVerse
+JOB	31	19	Job			Implicit			EntireVerse
+JOB	31	20	Job			Implicit			EntireVerse
+JOB	31	21	Job			Implicit			EntireVerse
+JOB	31	22	Job			Implicit			EntireVerse
+JOB	31	23	Job			Implicit			EntireVerse
+JOB	31	24	Job			Implicit			EntireVerse
+JOB	31	25	Job			Implicit			EntireVerse
+JOB	31	26	Job			Implicit			EntireVerse
+JOB	31	27	Job			Implicit			EntireVerse
+JOB	31	28	Job			Implicit			EntireVerse
+JOB	31	29	Job			Implicit			EntireVerse
+JOB	31	30	Job			Implicit			EntireVerse
+JOB	31	31	Job			Implicit			EntireVerse
+JOB	31	32	Job			Implicit			EntireVerse
+JOB	31	33	Job			Implicit			EntireVerse
+JOB	31	34	Job			Implicit			EntireVerse
+JOB	31	35	Job			Implicit			EntireVerse
+JOB	31	36	Job			Implicit			EntireVerse
+JOB	31	37	Job			Implicit			EntireVerse
+JOB	31	38	Job			Implicit			EntireVerse
+JOB	31	39	Job			Implicit			EntireVerse
+JOB	31	40	Job			Implicit			EntireVerse
+JOB	32	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	17	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	18	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	19	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	20	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	21	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	32	22	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	1	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	2	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	3	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	4	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	5	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	17	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	18	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	19	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	20	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	21	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	22	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	23	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	24	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	25	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	26	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	27	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	28	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	29	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	30	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	31	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	32	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	33	33	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	2	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	3	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	4	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	5	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	17	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	18	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	19	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	20	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	21	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	22	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	23	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	24	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	25	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	26	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	27	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	28	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	29	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	30	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	31	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	32	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	33	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	34	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	35	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	36	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	34	37	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	2	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	3	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	4	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	5	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	35	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	2	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	3	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	4	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	5	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	17	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	18	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	19	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	20	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	21	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	22	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	23	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	24	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	25	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	26	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	27	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	28	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	29	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	30	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	31	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	32	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	36	33	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	1	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	2	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	3	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	4	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	5	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	6	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	7	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	8	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	9	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	10	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	11	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	12	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	13	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	14	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	15	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	16	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	17	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	18	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	19	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	20	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	21	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	22	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	23	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	37	24	Elihu, son of Barakel			Implicit			EntireVerse
+JOB	38	2	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	3	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	4	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	5	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	6	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	7	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	8	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	9	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	10	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	11	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	12	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	13	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	14	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	15	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	16	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	17	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	18	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	19	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	20	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	21	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	22	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	23	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	24	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	25	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	26	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	27	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	28	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	29	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	30	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	31	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	32	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	33	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	34	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	35	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	36	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	37	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	38	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	39	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	40	God		God (Yahweh)	Implicit			EntireVerse
+JOB	38	41	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	1	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	2	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	3	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	4	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	5	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	6	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	7	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	8	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	9	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	10	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	11	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	12	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	13	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	14	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	15	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	16	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	17	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	18	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	19	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	20	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	21	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	22	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	23	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	24	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	25	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	26	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	27	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	28	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	29	God		God (Yahweh)	Implicit			EntireVerse
+JOB	39	30	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	2	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	4	Job			Implicit			EntireVerse
+JOB	40	5	Job			Implicit			EntireVerse
+JOB	40	7	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	8	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	9	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	10	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	11	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	12	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	13	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	14	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	15	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	16	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	17	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	18	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	19	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	20	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	21	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	22	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	23	God		God (Yahweh)	Implicit			EntireVerse
+JOB	40	24	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	1	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	2	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	3	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	4	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	5	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	6	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	7	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	8	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	9	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	10	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	11	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	12	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	13	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	14	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	15	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	16	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	17	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	18	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	19	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	20	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	21	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	22	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	23	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	24	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	25	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	26	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	27	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	28	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	29	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	30	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	31	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	32	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	33	God		God (Yahweh)	Implicit			EntireVerse
+JOB	41	34	God		God (Yahweh)	Implicit			EntireVerse
+JOB	42	2	Job			Implicit			EntireVerse
+JOB	42	3	Job			Implicit			EntireVerse
+JOB	42	4	Job			Implicit			EntireVerse
+JOB	42	5	Job			Implicit			EntireVerse
+JOB	42	6	Job			Implicit			EntireVerse
 JOB	42	7	God		God (Yahweh)	Normal			EndOfVerse
 JOB	42	8	God		God (Yahweh)	Normal			EntireVerse
 PSA	2	3	kings of the earth			Normal			
@@ -8574,17 +8574,17 @@ PSA	42	9	narrator-PSA			Quotation
 PSA	42	10	David's enemies			Normal			
 PSA	45	0	narrator-PSA			Quotation			Unspecified
 PSA	46	10	God		God (Yahweh)	Normal			
-PSA	50	5	God		God (Yahweh)	Implicit			
-PSA	50	7	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	8	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	9	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	10	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	11	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	12	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
-PSA	50	13	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
+PSA	50	5	God		God (Yahweh)	Implicit			EntireVerse
+PSA	50	7	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	8	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	9	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	10	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	11	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	12	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
+PSA	50	13	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
 PSA	50	14	God		God (Yahweh)(the Mighty One)	Quotation			
 PSA	50	14	narrator-PSA			Quotation			
-PSA	50	15	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			
+PSA	50	15	God		God (Yahweh)(the Mighty One)	ImplicitWithPotentialSelfQuote			EntireVerse
 PSA	50	16	God		God (Yahweh)(the Mighty One)	Quotation			
 PSA	50	16	narrator-PSA			Quotation			
 PSA	50	17	God		God (Yahweh)(the Mighty One)	Quotation			
@@ -8680,7 +8680,7 @@ PSA	83	12	Zebah/Zalmunna			Quotation
 PSA	83	12	Needs Review			Normal			
 PSA	87	4	God			Potential			
 PSA	87	4	saying about Gentile nations			Hypothetical			
-PSA	87	4	Needs Review			ImplicitWithPotentialSelfQuote			
+PSA	87	4	Needs Review			ImplicitWithPotentialSelfQuote			EntireVerse
 PSA	87	5	God			Normal			
 # Two options supplied here since, if it is decided to dramatize this hypothetical speech, it could be the same speaker as in the previous verse or a different one.
 PSA	87	5	saying about Gentile nations			Hypothetical			
@@ -8787,18 +8787,18 @@ PRO	1	11	sinners			Hypothetical
 PRO	1	12	sinners			Hypothetical			
 PRO	1	13	sinners			Hypothetical			
 PRO	1	14	sinners			Hypothetical			
-PRO	1	22	Wisdom			Implicit			
-PRO	1	23	Wisdom			Implicit			
-PRO	1	24	Wisdom			Implicit			
-PRO	1	25	Wisdom			Implicit			
-PRO	1	26	Wisdom			Implicit			
-PRO	1	27	Wisdom			Implicit			
-PRO	1	28	Wisdom			Implicit			
-PRO	1	29	Wisdom			Implicit			
-PRO	1	30	Wisdom			Implicit			
-PRO	1	31	Wisdom			Implicit			
-PRO	1	32	Wisdom			Implicit			
-PRO	1	33	Wisdom			Implicit			
+PRO	1	22	Wisdom			Implicit			EntireVerse
+PRO	1	23	Wisdom			Implicit			EntireVerse
+PRO	1	24	Wisdom			Implicit			EntireVerse
+PRO	1	25	Wisdom			Implicit			EntireVerse
+PRO	1	26	Wisdom			Implicit			EntireVerse
+PRO	1	27	Wisdom			Implicit			EntireVerse
+PRO	1	28	Wisdom			Implicit			EntireVerse
+PRO	1	29	Wisdom			Implicit			EntireVerse
+PRO	1	30	Wisdom			Implicit			EntireVerse
+PRO	1	31	Wisdom			Implicit			EntireVerse
+PRO	1	32	Wisdom			Implicit			EntireVerse
+PRO	1	33	Wisdom			Implicit			EntireVerse
 PRO	3	7	narrator-PRO			Quotation			
 PRO	3	28	you (hypothetical)			Hypothetical			
 PRO	4	4	David		father of Solomon (King David)	Quotation			
@@ -8812,58 +8812,58 @@ PRO	5	13	sons (hypothetical), at end of life			Hypothetical
 PRO	5	14	sons (hypothetical), at end of life			Hypothetical			
 PRO	6	10	sluggard			Hypothetical			
 PRO	7	4	son (receiving instructions)			Hypothetical			
-PRO	7	14	immoral woman			Implicit			
-PRO	7	15	immoral woman			Implicit			
-PRO	7	16	immoral woman			Implicit			
-PRO	7	17	immoral woman			Implicit			
-PRO	7	18	immoral woman			Implicit			
-PRO	7	19	immoral woman			Implicit			
-PRO	7	20	immoral woman			Implicit			
-PRO	8	4	Wisdom			Implicit			
-PRO	8	5	Wisdom			Implicit			
-PRO	8	6	Wisdom			Implicit			
-PRO	8	7	Wisdom			Implicit			
-PRO	8	8	Wisdom			Implicit			
-PRO	8	9	Wisdom			Implicit			
-PRO	8	10	Wisdom			Implicit			
-PRO	8	11	Wisdom			Implicit			
-PRO	8	12	Wisdom			Implicit			
-PRO	8	13	Wisdom			Implicit			
-PRO	8	14	Wisdom			Implicit			
-PRO	8	15	Wisdom			Implicit			
-PRO	8	16	Wisdom			Implicit			
-PRO	8	17	Wisdom			Implicit			
-PRO	8	18	Wisdom			Implicit			
-PRO	8	19	Wisdom			Implicit			
-PRO	8	20	Wisdom			Implicit			
-PRO	8	21	Wisdom			Implicit			
-PRO	8	22	Wisdom			Implicit			
-PRO	8	23	Wisdom			Implicit			
-PRO	8	24	Wisdom			Implicit			
-PRO	8	25	Wisdom			Implicit			
-PRO	8	26	Wisdom			Implicit			
-PRO	8	27	Wisdom			Implicit			
-PRO	8	28	Wisdom			Implicit			
-PRO	8	29	Wisdom			Implicit			
-PRO	8	30	Wisdom			Implicit			
-PRO	8	31	Wisdom			Implicit			
-PRO	8	32	Wisdom			Implicit			
-PRO	8	33	Wisdom			Implicit			
-PRO	8	34	Wisdom			Implicit			
-PRO	8	35	Wisdom			Implicit			
-PRO	8	36	Wisdom			Implicit			
+PRO	7	14	immoral woman			Implicit			EntireVerse
+PRO	7	15	immoral woman			Implicit			EntireVerse
+PRO	7	16	immoral woman			Implicit			EntireVerse
+PRO	7	17	immoral woman			Implicit			EntireVerse
+PRO	7	18	immoral woman			Implicit			EntireVerse
+PRO	7	19	immoral woman			Implicit			EntireVerse
+PRO	7	20	immoral woman			Implicit			EntireVerse
+PRO	8	4	Wisdom			Implicit			EntireVerse
+PRO	8	5	Wisdom			Implicit			EntireVerse
+PRO	8	6	Wisdom			Implicit			EntireVerse
+PRO	8	7	Wisdom			Implicit			EntireVerse
+PRO	8	8	Wisdom			Implicit			EntireVerse
+PRO	8	9	Wisdom			Implicit			EntireVerse
+PRO	8	10	Wisdom			Implicit			EntireVerse
+PRO	8	11	Wisdom			Implicit			EntireVerse
+PRO	8	12	Wisdom			Implicit			EntireVerse
+PRO	8	13	Wisdom			Implicit			EntireVerse
+PRO	8	14	Wisdom			Implicit			EntireVerse
+PRO	8	15	Wisdom			Implicit			EntireVerse
+PRO	8	16	Wisdom			Implicit			EntireVerse
+PRO	8	17	Wisdom			Implicit			EntireVerse
+PRO	8	18	Wisdom			Implicit			EntireVerse
+PRO	8	19	Wisdom			Implicit			EntireVerse
+PRO	8	20	Wisdom			Implicit			EntireVerse
+PRO	8	21	Wisdom			Implicit			EntireVerse
+PRO	8	22	Wisdom			Implicit			EntireVerse
+PRO	8	23	Wisdom			Implicit			EntireVerse
+PRO	8	24	Wisdom			Implicit			EntireVerse
+PRO	8	25	Wisdom			Implicit			EntireVerse
+PRO	8	26	Wisdom			Implicit			EntireVerse
+PRO	8	27	Wisdom			Implicit			EntireVerse
+PRO	8	28	Wisdom			Implicit			EntireVerse
+PRO	8	29	Wisdom			Implicit			EntireVerse
+PRO	8	30	Wisdom			Implicit			EntireVerse
+PRO	8	31	Wisdom			Implicit			EntireVerse
+PRO	8	32	Wisdom			Implicit			EntireVerse
+PRO	8	33	Wisdom			Implicit			EntireVerse
+PRO	8	34	Wisdom			Implicit			EntireVerse
+PRO	8	35	Wisdom			Implicit			EntireVerse
+PRO	8	36	Wisdom			Implicit			EntireVerse
 PRO	9	4	Wisdom			Normal			
-PRO	9	5	Wisdom			Implicit			
-PRO	9	6	Wisdom			Implicit			
-PRO	9	7	Wisdom			Implicit			
-PRO	9	8	Wisdom			Implicit			
-PRO	9	9	Wisdom			Implicit			
-PRO	9	10	Wisdom			Implicit			
-PRO	9	11	Wisdom			Implicit			
+PRO	9	5	Wisdom			Implicit			EntireVerse
+PRO	9	6	Wisdom			Implicit			EntireVerse
+PRO	9	7	Wisdom			Implicit			EntireVerse
+PRO	9	8	Wisdom			Implicit			EntireVerse
+PRO	9	9	Wisdom			Implicit			EntireVerse
+PRO	9	10	Wisdom			Implicit			EntireVerse
+PRO	9	11	Wisdom			Implicit			EntireVerse
 PRO	9	11	God		God (Yahweh)	Alternate			
 PRO	9	12	Wisdom			Potential			
 PRO	9	16	Folly			Normal			
-PRO	9	17	Folly			Implicit			
+PRO	9	17	Folly			Implicit			EntireVerse
 PRO	19	3	narrator-PRO			Quotation			
 PRO	20	9	person claiming to have a pure heart			Hypothetical			
 PRO	20	14	buyer			Hypothetical			
@@ -8885,7 +8885,7 @@ PRO	30	1	Agur			Potential
 # Because of the difficult textual/translation issue in v. 1, if there are not explicit
 # quotes, it should be reviewed. The English reference text takes the traditional interpretation,
 # but even in that interpretation, the portion following the colon could be spoken by Agur
-PRO	30	1	Needs Review			Implicit			
+PRO	30	1	Needs Review			Implicit			EntireVerse
 PRO	30	2-33	Agur			Potential			
 PRO	30	8	narrator-PRO			Quotation			
 PRO	30	9	narrator-PRO			Quotation			
@@ -8976,15 +8976,15 @@ SNG	1	3	beloved			Potential
 SNG	1	4	beloved			Potential			
 SNG	1	4	Solomon, king		Solomon (lover)	Quotation			
 SNG	1	4	maidens			Potential			
-SNG	1	4	Needs Review			Implicit			
+SNG	1	4	Needs Review			Implicit			EntireVerse
 SNG	1	8	Solomon, king		Solomon (lover)	Potential			
 SNG	1	8	maidens			Potential			
-SNG	1	8	Needs Review			Implicit			
+SNG	1	8	Needs Review			Implicit			EntireVerse
 SNG	1	9	Solomon, king		Solomon (lover)	Potential			
 SNG	1	10	Solomon, king		Solomon (lover)	Potential			
 SNG	1	11	Solomon, king		Solomon (lover)	Potential			
 SNG	1	11	maidens			Potential			
-SNG	1	11	Needs Review			Implicit			
+SNG	1	11	Needs Review			Implicit			EntireVerse
 SNG	1	12	beloved			Potential			
 SNG	1	13	beloved			Potential			
 SNG	1	14	beloved			Potential			
@@ -8992,7 +8992,7 @@ SNG	1	15	Solomon, king		Solomon (lover)	Potential
 SNG	1	16	beloved			Potential			
 SNG	1	17	Solomon, king		Solomon (lover)	Potential			
 SNG	1	17	beloved			Potential			
-SNG	1	17	Needs Review			Implicit			
+SNG	1	17	Needs Review			Implicit			EntireVerse
 SNG	2	1	beloved			Potential			
 SNG	2	2	Solomon, king		Solomon (lover)	Potential			
 SNG	2	3	beloved			Potential			
@@ -9015,7 +9015,7 @@ SNG	2	14	Solomon, king		Solomon (lover)	Quotation
 SNG	2	15	Solomon, king		Solomon (lover)	Potential			
 SNG	2	15	beloved			Potential			
 SNG	2	15	maidens			Potential			
-SNG	2	15	Needs Review			Implicit			
+SNG	2	15	Needs Review			Implicit			EntireVerse
 SNG	2	16	beloved			Potential			
 SNG	2	17	beloved			Potential			
 SNG	3	1	beloved			Potential			
@@ -9055,7 +9055,7 @@ SNG	4	16	beloved			Potential
 SNG	5	1	Solomon, king		Solomon (lover)	Potential			
 SNG	5	1	maidens			Potential			
 SNG	5	1	God			Potential			
-SNG	5	1	Needs Review			Implicit			
+SNG	5	1	Needs Review			Implicit			EntireVerse
 SNG	5	2	beloved			Potential			
 SNG	5	2	Solomon, king		Solomon (lover)	Quotation			
 SNG	5	3	beloved			Potential			
@@ -9084,13 +9084,13 @@ SNG	6	9	Solomon, king		Solomon (lover)	Potential
 SNG	6	10	Solomon, king		Solomon (lover)	Potential			
 SNG	6	10	maidens			Potential			
 SNG	6	10	queens and concubines			Quotation			Unspecified
-SNG	6	10	Needs Review			Implicit			
+SNG	6	10	Needs Review			Implicit			EntireVerse
 SNG	6	11	Solomon, king		Solomon (lover)	Potential			
 SNG	6	11	beloved			Potential			
-SNG	6	11	Needs Review			Implicit			
+SNG	6	11	Needs Review			Implicit			EntireVerse
 SNG	6	12	Solomon, king		Solomon (lover)	Potential			
 SNG	6	12	beloved			Potential			
-SNG	6	12	Needs Review			Implicit			
+SNG	6	12	Needs Review			Implicit			EntireVerse
 SNG	6	13	Solomon, king		Solomon (lover)	Potential			
 SNG	6	13	maidens			Potential			
 SNG	7	1	Solomon, king		Solomon (lover)	Potential			
@@ -9101,7 +9101,7 @@ SNG	7	5	Solomon, king		Solomon (lover)	Potential
 SNG	7	6	Solomon, king		Solomon (lover)	Potential			
 SNG	7	7	Solomon, king		Solomon (lover)	Potential			
 SNG	7	8	Solomon, king		Solomon (lover)	Potential			
-SNG	7	9	Needs Review			Implicit			
+SNG	7	9	Needs Review			Implicit			EntireVerse
 SNG	7	9	beloved			Potential			
 SNG	7	9	Solomon, king		Solomon (lover)	Potential			
 SNG	7	10	beloved			Potential			
@@ -9121,11 +9121,11 @@ SNG	8	7	maidens			Potential
 SNG	8	8	brothers of beloved			Potential			
 SNG	8	8	sisters of beloved			Potential			
 SNG	8	8	maidens			Potential			
-SNG	8	8	Needs Review			Implicit			
+SNG	8	8	Needs Review			Implicit			EntireVerse
 SNG	8	9	brothers of beloved			Potential			
 SNG	8	9	sisters of beloved			Potential			
 SNG	8	9	maidens			Potential			
-SNG	8	9	Needs Review			Implicit			
+SNG	8	9	Needs Review			Implicit			EntireVerse
 SNG	8	10	beloved			Potential			
 SNG	8	11	beloved			Potential			
 SNG	8	12	beloved			Potential			
@@ -9150,14 +9150,14 @@ ISA	1	9	God		God (Yahweh) (in vision)	Alternate
 ISA	1	10	Isaiah			Potential			
 ISA	1	10	God		God (Yahweh) (in vision)	Alternate			
 ISA	1	11	God		God (Yahweh) (in vision)	Normal			
-ISA	1	12	God		God (Yahweh) (in vision)	Implicit			
-ISA	1	13	God		God (Yahweh) (in vision)	Implicit			
-ISA	1	14	God		God (Yahweh) (in vision)	Implicit			
-ISA	1	15	God		God (Yahweh) (in vision)	Implicit			
-ISA	1	16	God		God (Yahweh) (in vision)	Implicit			
-ISA	1	17	God		God (Yahweh) (in vision)	Implicit			
+ISA	1	12	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+ISA	1	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+ISA	1	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+ISA	1	15	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+ISA	1	16	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+ISA	1	17	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 ISA	1	18	God		God (Yahweh) (in vision)	Normal			
-ISA	1	19	God		God (Yahweh) (in vision)	Implicit			
+ISA	1	19	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 ISA	1	20	God		God (Yahweh) (in vision)	Normal			
 ISA	1	21	Isaiah			Potential			
 ISA	1	22	Isaiah			Potential			
@@ -9166,7 +9166,7 @@ ISA	1	24	God		God (Yahweh)	Normal
 ISA	1	24	Isaiah			Alternate			
 ISA	1	25	God		God (Yahweh)	Normal			
 ISA	1	25	Isaiah			Alternate			
-ISA	1	26	God		God (Yahweh)	Implicit			
+ISA	1	26	God		God (Yahweh)	Implicit			EntireVerse
 ISA	1	26	Isaiah			Alternate			
 ISA	1	27	God		God (Yahweh)	Potential			
 ISA	1	27	Isaiah			Alternate			
@@ -9208,7 +9208,7 @@ ISA	3	3	God		God (Yahweh)	Alternate
 # do put v. 4 in quotes and a few of the less literal ones add a reporting clause. Since the WEB does not do this,
 # the English reference text now keeps it as narrator (Isaiah). (As the prophet, he can certainly speak on God's
 # behalf.) By implicitly marking this verse as Needs Review, it should get the required scrutiny.
-ISA	3	4	Needs Review			Implicit			
+ISA	3	4	Needs Review			Implicit			EntireVerse
 ISA	3	4	God		God (Yahweh)	Potential			
 ISA	3	5	God		God (Yahweh)	Potential			
 ISA	3	5	Isaiah			Potential			
@@ -9232,7 +9232,7 @@ ISA	3	12	Isaiah			Potential
 ISA	3	14	God		God (Yahweh)	Normal			
 ISA	3	15	God		God (Yahweh)	Normal			
 ISA	3	16	God		God (Yahweh)	Normal			
-ISA	3	17	God		God (Yahweh)	Implicit			
+ISA	3	17	God		God (Yahweh)	Implicit			EntireVerse
 ISA	3	18	Isaiah			Potential			
 ISA	3	19	Isaiah			Potential			
 ISA	3	20	Isaiah			Potential			
@@ -9251,16 +9251,16 @@ ISA	4	5	Isaiah			Potential
 ISA	4	6	Isaiah			Potential			
 ISA	5	1	Isaiah			Potential			
 ISA	5	2	Isaiah			Potential			
-ISA	5	3	God		God (vineyard owner)	Implicit			
-ISA	5	4	God		God (vineyard owner)	Implicit			
-ISA	5	5	God		God (vineyard owner)	Implicit			
-ISA	5	6	God		God (vineyard owner)	Implicit			
+ISA	5	3	God		God (vineyard owner)	Implicit			EntireVerse
+ISA	5	4	God		God (vineyard owner)	Implicit			EntireVerse
+ISA	5	5	God		God (vineyard owner)	Implicit			EntireVerse
+ISA	5	6	God		God (vineyard owner)	Implicit			EntireVerse
 ISA	5	7	God		God (vineyard owner)	Alternate			
 ISA	5	7	Isaiah			Potential			
 ISA	5	8	Isaiah			Potential			
 ISA	5	9	God		God (Yahweh)	Normal			
 ISA	5	9	Isaiah			Alternate			
-ISA	5	10	God		God (Yahweh)	Implicit			
+ISA	5	10	God		God (Yahweh)	Implicit			EntireVerse
 ISA	5	10	Isaiah			Alternate			
 ISA	5	11	Isaiah			Potential			
 ISA	5	12	Isaiah			Potential			
@@ -9290,10 +9290,10 @@ ISA	6	7	seraph, one of the			Normal
 ISA	6	8	Isaiah			Dialogue			
 ISA	6	8	God		God (Yahweh)	Dialogue			
 ISA	6	9	God		God (Yahweh)	Dialogue			
-ISA	6	10	God		God (Yahweh)	Implicit			
+ISA	6	10	God		God (Yahweh)	Implicit			EntireVerse
 ISA	6	11	Isaiah			Dialogue			
 ISA	6	11	God		God (Yahweh)	Dialogue			
-ISA	6	12	God		God (Yahweh)	Implicit			
+ISA	6	12	God		God (Yahweh)	Implicit			EntireVerse
 ISA	6	13	God		God (Yahweh)	Normal			
 ISA	7	2	messenger			Normal			Unspecified
 ISA	7	3	God		God (Yahweh)	Normal			Unspecified
@@ -9306,12 +9306,12 @@ ISA	7	6	God		God (Yahweh)	Alternate
 ISA	7	6	Isaiah			Alternate			
 ISA	7	7	Isaiah			Normal			
 ISA	7	7	God		God (Yahweh)	Normal			
-ISA	7	8	God		God (Yahweh)	Implicit			
-ISA	7	9	God		God (Yahweh)	Implicit			
+ISA	7	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	7	9	God		God (Yahweh)	Implicit			EntireVerse
 # The text says that God spoke, but since it is directed to Ahaz, the words were presumably
 # delivered through Isaiah. A native speaker should review this to make sure the dramatization
 # makes sense in the target language.
-ISA	7	11	Needs Review			Implicit			
+ISA	7	11	Needs Review			Implicit			EntireVerse
 ISA	7	11	God		God (Yahweh)	Alternate			
 ISA	7	11	Isaiah			Alternate			
 ISA	7	12	Ahaz, king of Judah			Dialogue			Unspecified
@@ -9344,19 +9344,19 @@ ISA	8	1	God		God (Yahweh)	Normal
 ISA	8	2	God		God (Yahweh)	Normal			
 ISA	8	3	God		God (Yahweh)	Normal			
 ISA	8	4	God		God (Yahweh)	Normal			
-ISA	8	6	God		God (Yahweh)	Implicit			
-ISA	8	7	God		God (Yahweh)	Implicit			
-ISA	8	8	God		God (Yahweh)	Implicit			
+ISA	8	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	8	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	8	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	8	9	God		God (Yahweh)	Potential			
 ISA	8	9	Isaiah			Potential			
 ISA	8	10	God		God (Yahweh)	Potential			
 ISA	8	11	Isaiah			Potential			
-ISA	8	12	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
-ISA	8	13	God		God (Yahweh)	Implicit			
+ISA	8	12	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
+ISA	8	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	8	13	Isaiah			Alternate			
-ISA	8	14	God		God (Yahweh)	Implicit			
+ISA	8	14	God		God (Yahweh)	Implicit			EntireVerse
 ISA	8	14	Isaiah			Alternate			
-ISA	8	15	God		God (Yahweh)	Implicit			
+ISA	8	15	God		God (Yahweh)	Implicit			EntireVerse
 ISA	8	15	Isaiah			Alternate			
 ISA	8	16	Isaiah			Potential			
 ISA	8	16	God		God (Yahweh)	Alternate			
@@ -9386,8 +9386,8 @@ ISA	10	1	Isaiah			Potential
 ISA	10	2	Isaiah			Potential			
 ISA	10	3	Isaiah			Potential			
 ISA	10	4	Isaiah			Potential			
-ISA	10	5	God		God (Yahweh)	Implicit			
-ISA	10	6	God		God (Yahweh)	Implicit			
+ISA	10	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	10	6	God		God (Yahweh)	Implicit			EntireVerse
 ISA	10	7	God		God (Yahweh)	Potential			
 ISA	10	8	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
 ISA	10	8	God		God (Yahweh)	Potential			
@@ -9399,9 +9399,9 @@ ISA	10	10	Needs Review			Normal
 ISA	10	11	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
 ISA	10	11	God		God (Yahweh)	Potential			
 ISA	10	11	Needs Review			Normal			
-ISA	10	12	Needs Review			Implicit			
+ISA	10	12	Needs Review			Implicit			EntireVerse
 ISA	10	12	God		God (Yahweh)	Potential			
-ISA	10	13	Needs Review			Implicit			
+ISA	10	13	Needs Review			Implicit			EntireVerse
 ISA	10	13	God		God (Yahweh)	Potential			
 ISA	10	13	Isaiah			Potential			
 ISA	10	13	Sennacherib, king of Assyria		king of Assyria	Quotation			Unspecified
@@ -9419,7 +9419,7 @@ ISA	10	22	Isaiah			Potential
 ISA	10	23	Isaiah			Potential			
 ISA	10	24	God		God (Yahweh)	Normal			
 ISA	10	24	Isaiah			Alternate			
-ISA	10	25	God		God (Yahweh)	Implicit			
+ISA	10	25	God		God (Yahweh)	Implicit			EntireVerse
 ISA	10	25	Isaiah			Alternate			
 ISA	10	26	Isaiah			Potential			
 ISA	10	26	God		God (Yahweh)	Alternate			
@@ -9456,7 +9456,7 @@ ISA	12	6	Isaiah			Alternate
 ISA	13	2	Isaiah			Potential			
 ISA	13	2	God		God (Yahweh)	Potential			
 ISA	13	3	God		God (Yahweh)	Alternate			
-ISA	13	3	Needs Review			Implicit			
+ISA	13	3	Needs Review			Implicit			EntireVerse
 ISA	13	3	Isaiah			Alternate			
 ISA	13	4	Isaiah			Potential			
 ISA	13	4	God		God (Yahweh)	Alternate			
@@ -9473,13 +9473,13 @@ ISA	13	9	God		God (Yahweh)	Alternate
 ISA	13	10	Isaiah			Potential			
 ISA	13	10	God		God (Yahweh)	Alternate			
 ISA	13	11	God			Alternate			
-ISA	13	11	Needs Review			Implicit			
+ISA	13	11	Needs Review			Implicit			EntireVerse
 ISA	13	11	Isaiah			Alternate			
 ISA	13	12	God			Alternate			
-ISA	13	12	Needs Review			Implicit			
+ISA	13	12	Needs Review			Implicit			EntireVerse
 ISA	13	12	Isaiah			Alternate			
 ISA	13	13	God			Alternate			
-ISA	13	13	Needs Review			Implicit			
+ISA	13	13	Needs Review			Implicit			EntireVerse
 ISA	13	13	Isaiah			Alternate			
 ISA	13	14	Isaiah			Potential			
 ISA	13	14	God		God (Yahweh)	Alternate			
@@ -9488,7 +9488,7 @@ ISA	13	15	God		God (Yahweh)	Alternate
 ISA	13	16	Isaiah			Potential			
 ISA	13	16	God		God (Yahweh)	Alternate			
 ISA	13	17	God			Alternate			
-ISA	13	17	Needs Review			Implicit			
+ISA	13	17	Needs Review			Implicit			EntireVerse
 ISA	13	17	Isaiah			Alternate			
 ISA	13	18	Isaiah			Potential			
 ISA	13	18	God		God (Yahweh)	Alternate			
@@ -9552,7 +9552,7 @@ ISA	14	23	God		God (Yahweh)	Normal
 ISA	14	23	Isaiah			Alternate			
 ISA	14	24	God		God (Yahweh)	Normal			
 ISA	14	24	Isaiah			Alternate			
-ISA	14	25	God		God (Yahweh)	Implicit			
+ISA	14	25	God		God (Yahweh)	Implicit			EntireVerse
 ISA	14	25	Isaiah			Alternate			
 ISA	14	26	God		God (Yahweh)	Potential			
 ISA	14	26	Isaiah			Alternate			
@@ -9564,7 +9564,7 @@ ISA	14	30	God		God (Yahweh)	Potential
 ISA	14	30	Isaiah			Potential			
 ISA	14	31	God		God (Yahweh)	Potential			
 ISA	14	31	Isaiah			Potential			
-ISA	14	32	Needs Review			Implicit			
+ISA	14	32	Needs Review			Implicit			EntireVerse
 ISA	14	32	God		God (Yahweh)	Alternate			
 ISA	14	32	Isaiah			Alternate			
 ISA	14	32	answer from Israel			Hypothetical			
@@ -9579,22 +9579,22 @@ ISA	15	8	Isaiah			Potential
 ISA	15	9	Isaiah			Potential			
 ISA	16	3	Moabites			Hypothetical			
 ISA	16	3	Moabitesses (female)			Hypothetical			
-ISA	16	3	Needs Review			Implicit			
+ISA	16	3	Needs Review			Implicit			EntireVerse
 ISA	16	4	Moabites			Hypothetical			
 ISA	16	4	Moabitesses (female)			Hypothetical			
-ISA	16	4	Needs Review			Implicit			
+ISA	16	4	Needs Review			Implicit			EntireVerse
 ISA	16	14	God		God (Yahweh)	Normal			
 ISA	17	1	God		God (Yahweh)	Normal			
-ISA	17	2	God		God (Yahweh)	Implicit			
+ISA	17	2	God		God (Yahweh)	Implicit			EntireVerse
 ISA	17	3	God		God (Yahweh)	Normal			
-ISA	17	4	God		God (Yahweh)	Implicit			
-ISA	17	5	God		God (Yahweh)	Implicit			
+ISA	17	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	17	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	17	6	God		God (Yahweh)	Normal			
 ISA	18	2	ambassador sent by sea			Potential			
 ISA	18	4	God		God (Yahweh)	Normal			
 ISA	19	1	God		God (Yahweh)	Potential			
-ISA	19	2	God		God (Yahweh)	Implicit			
-ISA	19	3	God		God (Yahweh)	Implicit			
+ISA	19	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	19	3	God		God (Yahweh)	Implicit			EntireVerse
 ISA	19	4	God		God (Yahweh)	Normal			
 ISA	19	5	God		God (Yahweh)	Potential			
 ISA	19	5	Isaiah			Potential			
@@ -9623,8 +9623,8 @@ ISA	19	18	narrator-ISA			Quotation
 ISA	19	25	God		God (Yahweh)	Normal			
 ISA	20	2	God		God (Yahweh)	Normal			ContainedWithinVerse
 ISA	20	3	God		God (Yahweh)	Normal			EndOfVerse
-ISA	20	4	God		God (Yahweh)	Implicit			
-ISA	20	5	God		God (Yahweh)	Implicit			
+ISA	20	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	20	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	20	6	God		God (Yahweh)	Normal			
 ISA	20	6	inhabitants of Egyptian and Ethiopian coastlands			Hypothetical			Unspecified
 ISA	21	1	Isaiah			Potential			
@@ -9632,14 +9632,14 @@ ISA	21	1	God		God (Yahweh)	Alternate
 # Although quotes are not commonly used in v. 2, we're told that there was a declaration. Some translations
 # follow this with a colon, implying that what follows is the declaration. But even if not, the language
 # in many translations seem to imply that God is speaking. Others sseem to lean more toward Isaiah.
-ISA	21	2	Needs Review			Implicit			
+ISA	21	2	Needs Review			Implicit			EntireVerse
 ISA	21	2	Isaiah			Alternate			
 ISA	21	2	God		God (Yahweh) (in vision)	Alternate			
 ISA	21	3	Isaiah			Potential			
 ISA	21	4	Isaiah			Potential			
 ISA	21	5	Isaiah			Potential			
 ISA	21	6	God		God (the Lord)	Normal			
-ISA	21	7	God		God (Yahweh)	Implicit			
+ISA	21	7	God		God (Yahweh)	Implicit			EntireVerse
 ISA	21	8	lookout		watchman	Normal			
 ISA	21	9	lookout		watchman	Normal			
 ISA	21	9	God		God (Yahweh)	Normal			
@@ -9664,12 +9664,12 @@ ISA	22	17	Isaiah			Quotation
 ISA	22	17	God		God (Yahweh)	Alternate			
 ISA	22	18	Isaiah			Quotation			
 ISA	22	18	God		God (Yahweh)	Alternate			
-ISA	22	19	God		God (Yahweh)	Implicit			
-ISA	22	20	God		God (Yahweh)	Implicit			
-ISA	22	21	God		God (Yahweh)	Implicit			
-ISA	22	22	God		God (Yahweh)	Implicit			
-ISA	22	23	God		God (Yahweh)	Implicit			
-ISA	22	24	God		God (Yahweh)	Implicit			
+ISA	22	19	God		God (Yahweh)	Implicit			EntireVerse
+ISA	22	20	God		God (Yahweh)	Implicit			EntireVerse
+ISA	22	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	22	22	God		God (Yahweh)	Implicit			EntireVerse
+ISA	22	23	God		God (Yahweh)	Implicit			EntireVerse
+ISA	22	24	God		God (Yahweh)	Implicit			EntireVerse
 ISA	22	25	God		God (Yahweh)	Normal			
 ISA	23	4	sea			Hypothetical			
 ISA	23	12	God		God (Yahweh)	Normal			
@@ -9681,11 +9681,11 @@ ISA	24	16	singers from the ends of the earth			Hypothetical
 ISA	25	9	people, God's			Hypothetical			
 # Really, the singers in v. 1-6 is all hypothetical (future), but marking as implicit since we know we want to dramatize it.
 ISA	26	1	singers in Judah	singing		Hypothetical			
-ISA	26	2	singers in Judah	singing		Implicit			
-ISA	26	3	singers in Judah	singing		Implicit			
-ISA	26	4	singers in Judah	singing		Implicit			
-ISA	26	5	singers in Judah	singing		Implicit			
-ISA	26	6	singers in Judah	singing		Implicit			
+ISA	26	2	singers in Judah	singing		Implicit			EntireVerse
+ISA	26	3	singers in Judah	singing		Implicit			EntireVerse
+ISA	26	4	singers in Judah	singing		Implicit			EntireVerse
+ISA	26	5	singers in Judah	singing		Implicit			EntireVerse
+ISA	26	6	singers in Judah	singing		Implicit			EntireVerse
 # Almost all translations have the song stop at the end of v. 6 But some may have it continue through the whole chapter.
 ISA	26	7	singers in Judah	singing		Hypothetical			
 ISA	26	8	singers in Judah	singing		Hypothetical			
@@ -9703,9 +9703,9 @@ ISA	26	19	singers in Judah	singing		Hypothetical
 ISA	26	20	singers in Judah	singing		Hypothetical			
 ISA	26	21	singers in Judah	singing		Hypothetical			
 ISA	27	2	God		God (Yahweh)	Potential			
-ISA	27	3	God		God (Yahweh)	Implicit			
-ISA	27	4	God		God (Yahweh)	Implicit			
-ISA	27	5	God		God (Yahweh)	Implicit			
+ISA	27	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	27	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	27	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	28	9	hearers	mocking		Potential			
 ISA	28	9	Needs Review			Potential			
 ISA	28	10	hearers	mocking		Potential			
@@ -9729,15 +9729,15 @@ ISA	28	19	God		God (Yahweh)	Potential
 ISA	28	20	God		God (Yahweh)	Potential			
 ISA	28	20	saying about short bed and narrow blanket	ironic		Hypothetical			
 ISA	28	20	Needs Review			Potential			
-ISA	29	1	God		God (Yahweh)	Implicit			
-ISA	29	2	God		God (Yahweh)	Implicit			
-ISA	29	3	God		God (Yahweh)	Implicit			
+ISA	29	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	29	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	29	3	God		God (Yahweh)	Implicit			EntireVerse
 ISA	29	4	God		God (Yahweh)	Potential			
 ISA	29	4	Isaiah			Alternate			
-ISA	29	4	Needs Review			Implicit			
+ISA	29	4	Needs Review			Implicit			EntireVerse
 ISA	29	5	Isaiah			Alternate			
 ISA	29	5	God		God (Yahweh)	Potential			
-ISA	29	5	Needs Review			Implicit			
+ISA	29	5	Needs Review			Implicit			EntireVerse
 ISA	29	6	Isaiah			Alternate			
 ISA	29	6	God		God (Yahweh)	Potential			
 ISA	29	7	Isaiah			Alternate			
@@ -9757,7 +9757,7 @@ ISA	29	12	God		God (Yahweh)	Alternate
 ISA	29	12	person asking someone to read a sealed book			Hypothetical			
 ISA	29	12	non-reader			Normal			
 ISA	29	13	God		God (the Lord)	Normal			
-ISA	29	14	God		God (Yahweh)	Implicit			
+ISA	29	14	God		God (Yahweh)	Implicit			EntireVerse
 ISA	29	15	Isaiah			Potential			
 ISA	29	15	God		God (Yahweh)	Alternate			
 # A translation may either have two quotes by those hiding from Yahweh here or combine them into a single quote.
@@ -9774,13 +9774,13 @@ ISA	29	19	Isaiah			Potential
 ISA	29	20	Isaiah			Potential			
 ISA	29	21	Isaiah			Potential			
 ISA	29	22	God		God (Yahweh)	Normal			
-ISA	29	23	God		God (Yahweh)	Implicit			
-ISA	29	24	God		God (Yahweh)	Implicit			
+ISA	29	23	God		God (Yahweh)	Implicit			EntireVerse
+ISA	29	24	God		God (Yahweh)	Implicit			EntireVerse
 ISA	30	1	God		God (Yahweh)	Normal			
-ISA	30	2	God		God (Yahweh)	Implicit			
-ISA	30	3	God		God (Yahweh)	Implicit			
-ISA	30	4	God		God (Yahweh)	Implicit			
-ISA	30	5	God		God (Yahweh)	Implicit			
+ISA	30	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	30	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	30	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	30	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	30	6	God		God (Yahweh)	Potential			
 ISA	30	6	Isaiah			Alternate			
 ISA	30	7	God		God (Yahweh)	Potential			
@@ -9795,12 +9795,12 @@ ISA	30	11	God		God (Yahweh)	Potential
 ISA	30	11	Isaiah			Alternate			
 ISA	30	11	rebels			Hypothetical			
 ISA	30	12	God		God (Holy One of Israel)	Normal			
-ISA	30	13	God		God (Holy One of Israel)	Implicit			
-ISA	30	14	God		God (Holy One of Israel)	Implicit			
+ISA	30	13	God		God (Holy One of Israel)	Implicit			EntireVerse
+ISA	30	14	God		God (Holy One of Israel)	Implicit			EntireVerse
 ISA	30	15	God		God (Yahweh)	Normal			
 ISA	30	16	God		God (Yahweh)	Normal			
 ISA	30	16	rebels		you (rebellious people)	Quotation			
-ISA	30	17	God		God (Yahweh)	Implicit			
+ISA	30	17	God		God (Yahweh)	Implicit			EntireVerse
 ISA	30	18	Isaiah			Potential			
 ISA	30	18	God		God (Yahweh)	Alternate			
 ISA	30	20	narrator-ISA			Quotation			
@@ -9812,7 +9812,7 @@ ISA	31	4	God		God (Yahweh)	Normal
 ISA	31	5	God		God (Yahweh)	Normal			
 ISA	31	6	God		God (Yahweh)	Potential			
 ISA	31	7	God		God (Yahweh)	Potential			
-ISA	31	8	God		God (Yahweh)	Implicit			
+ISA	31	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	31	9	God		God (Yahweh)	Normal			
 ISA	32	9	Isaiah			Potential			
 ISA	32	9	God		God (Yahweh)	Alternate			
@@ -9839,9 +9839,9 @@ ISA	32	19	Isaiah			Alternate
 ISA	32	20	God		God (Yahweh)	Potential			
 ISA	32	20	Isaiah			Alternate			
 ISA	33	10	God		God (Yahweh)	Normal			
-ISA	33	11	God		God (Yahweh)	Implicit			
-ISA	33	12	God		God (Yahweh)	Implicit			
-ISA	33	13	God		God (Yahweh)	Implicit			
+ISA	33	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	33	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	33	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	33	14	sinners			Hypothetical			
 ISA	33	18	you (hypothetical)	thinking		Hypothetical			
 ISA	33	24	narrator-ISA			Quotation			
@@ -9850,45 +9850,45 @@ ISA	34	5	Isaiah			Alternate
 ISA	35	4	you (hypothetical)			Hypothetical			
 ISA	35	8	narrator-ISA			Quotation			
 ISA	36	4	Rabshakeh			Normal		2KI 18:19; 2CH 32:10; ISA 36:4	EndOfVerse
-ISA	36	5	Rabshakeh			Implicit		2KI 18:20; ISA 36:5	
-ISA	36	6	Rabshakeh			Implicit		2KI 18:21; ISA 36:6	
-ISA	36	7	Rabshakeh			Implicit		2KI 18:22; 2CH 32:12; ISA 36:7	
-ISA	36	8	Rabshakeh			Implicit		2KI 18:23; ISA 36:8	
-ISA	36	9	Rabshakeh			Implicit		2KI 18:24; ISA 36:9	
-ISA	36	10	Rabshakeh			Implicit		2KI 18:25; ISA 36:10	
+ISA	36	5	Rabshakeh			Implicit		2KI 18:20; ISA 36:5	EntireVerse
+ISA	36	6	Rabshakeh			Implicit		2KI 18:21; ISA 36:6	EntireVerse
+ISA	36	7	Rabshakeh			Implicit		2KI 18:22; 2CH 32:12; ISA 36:7	EntireVerse
+ISA	36	8	Rabshakeh			Implicit		2KI 18:23; ISA 36:8	EntireVerse
+ISA	36	9	Rabshakeh			Implicit		2KI 18:24; ISA 36:9	EntireVerse
+ISA	36	10	Rabshakeh			Implicit		2KI 18:25; ISA 36:10	EntireVerse
 ISA	36	11	Eliakim/Shebna/Joah			Normal	Eliakim		EndOfVerse
 ISA	36	12	Rabshakeh			Normal		2KI 18:27; ISA 36:12	EndOfVerse
 ISA	36	13	Rabshakeh			Normal		2KI 18:28; ISA 36:13	EndOfVerse
-ISA	36	14	Rabshakeh			Implicit		2KI 18:29; ISA 36:14	
-ISA	36	15	Rabshakeh			Implicit		2KI 18:30; 2CH 32:11; ISA 36:15	
-ISA	36	16	Rabshakeh			Implicit		2KI 18:31; ISA 36:16	
-ISA	36	17	Rabshakeh			Implicit		2KI 18:32a; ISA 36:17	
-ISA	36	18	Rabshakeh			Implicit		2KI 18:32c-33; 2CH 32:13; ISA 36:18	
-ISA	36	19	Rabshakeh			Implicit		2KI 18:34; ISA 36:19	
-ISA	36	20	Rabshakeh			Implicit		2KI 18:35; 2CH 32:14; ISA 36:20	
+ISA	36	14	Rabshakeh			Implicit		2KI 18:29; ISA 36:14	EntireVerse
+ISA	36	15	Rabshakeh			Implicit		2KI 18:30; 2CH 32:11; ISA 36:15	EntireVerse
+ISA	36	16	Rabshakeh			Implicit		2KI 18:31; ISA 36:16	EntireVerse
+ISA	36	17	Rabshakeh			Implicit		2KI 18:32a; ISA 36:17	EntireVerse
+ISA	36	18	Rabshakeh			Implicit		2KI 18:32c-33; 2CH 32:13; ISA 36:18	EntireVerse
+ISA	36	19	Rabshakeh			Implicit		2KI 18:34; ISA 36:19	EntireVerse
+ISA	36	20	Rabshakeh			Implicit		2KI 18:35; 2CH 32:14; ISA 36:20	EntireVerse
 ISA	36	21	Hezekiah, king of Judah			Normal			Unspecified
 ISA	36	22	Rabshakeh			Quotation	narrator-ISA		Unspecified
 ISA	36	22	narrator-ISA			Quotation			Unspecified
 ISA	36	22	Needs Review			Rare			
 ISA	37	3	Eliakim/Shebna/chief priests			Normal	Eliakim		Unspecified
 ISA	37	3	Hezekiah, king of Judah			Alternate			
-ISA	37	4	Eliakim/Shebna/chief priests			Implicit	Eliakim		
+ISA	37	4	Eliakim/Shebna/chief priests			Implicit	Eliakim		EntireVerse
 ISA	37	4	Hezekiah, king of Judah			Alternate			
 ISA	37	6	Isaiah			Normal			EndOfVerse
 ISA	37	6	God		God (Yahweh)	Alternate			
-ISA	37	7	Isaiah			Implicit			
+ISA	37	7	Isaiah			Implicit			EntireVerse
 ISA	37	7	God		God (Yahweh)	Alternate			
 ISA	37	8	informer			Indirect			
 ISA	37	9	person who informed Rabshakeh			Normal			Unspecified
 ISA	37	10	Rabshakeh			Normal		2KI 19:10; ISA 37:10	Unspecified
-ISA	37	11	Rabshakeh			Implicit		2KI 19:11; ISA 37:11	
-ISA	37	12	Rabshakeh			Implicit		2KI 19:12; ISA 37:12	
-ISA	37	13	Rabshakeh			Implicit		2KI 19:13; ISA 37:13	
-ISA	37	16	Hezekiah, king of Judah			Implicit			
-ISA	37	17	Hezekiah, king of Judah			Implicit			
-ISA	37	18	Hezekiah, king of Judah			Implicit			
-ISA	37	19	Hezekiah, king of Judah			Implicit			
-ISA	37	20	Hezekiah, king of Judah			Implicit			
+ISA	37	11	Rabshakeh			Implicit		2KI 19:11; ISA 37:11	EntireVerse
+ISA	37	12	Rabshakeh			Implicit		2KI 19:12; ISA 37:12	EntireVerse
+ISA	37	13	Rabshakeh			Implicit		2KI 19:13; ISA 37:13	EntireVerse
+ISA	37	16	Hezekiah, king of Judah			Implicit			EntireVerse
+ISA	37	17	Hezekiah, king of Judah			Implicit			EntireVerse
+ISA	37	18	Hezekiah, king of Judah			Implicit			EntireVerse
+ISA	37	19	Hezekiah, king of Judah			Implicit			EntireVerse
+ISA	37	20	Hezekiah, king of Judah			Implicit			EntireVerse
 ISA	37	21	Isaiah			Normal			
 ISA	37	21	God		God (Yahweh)	Quotation			Unspecified
 ISA	37	22	Isaiah			Normal			
@@ -9923,25 +9923,25 @@ ISA	37	35	Isaiah			Normal
 ISA	37	35	God		God (Yahweh)	Quotation			Unspecified
 ISA	38	1	Isaiah			Normal			EndOfVerse
 ISA	38	3	Hezekiah, king of Judah			Normal			Unspecified
-ISA	38	5	God		God (Yahweh)	Implicit			
+ISA	38	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	38	5	Isaiah	Isaiah (Yahweh says)		Alternate			
-ISA	38	6	God		God (Yahweh)	Implicit			
+ISA	38	6	God		God (Yahweh)	Implicit			EntireVerse
 ISA	38	6	Isaiah	Isaiah (Yahweh says)		Alternate			
 ISA	38	7	Isaiah			Normal			
 ISA	38	7	God		God (Yahweh)	Normal			
 ISA	38	8	God		God (Yahweh)	Normal			StartOfVerse
 ISA	38	8	Isaiah	Isaiah (Yahweh says)		Alternate			
-ISA	38	10	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	11	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	12	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	13	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	14	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	15	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	16	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	17	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	18	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	19	Hezekiah, king of Judah	writing		Implicit			
-ISA	38	20	Hezekiah, king of Judah	writing		Implicit			
+ISA	38	10	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	11	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	12	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	13	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	14	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	15	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	16	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	17	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	18	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	19	Hezekiah, king of Judah	writing		Implicit			EntireVerse
+ISA	38	20	Hezekiah, king of Judah	writing		Implicit			EntireVerse
 ISA	38	21	Isaiah			Normal			
 ISA	38	21	narrator-ISA			Quotation			Unspecified
 ISA	38	22	Hezekiah, king of Judah			Normal			
@@ -9973,19 +9973,19 @@ ISA	40	6	God			Alternate
 ISA	40	6	Needs Review			Alternate			
 ISA	40	6	voice in reply (Isaiah?)			Normal			
 ISA	40	6	Isaiah			Normal			
-ISA	40	7	voice (God?)			Implicit			
+ISA	40	7	voice (God?)			Implicit			EntireVerse
 ISA	40	7	God			Alternate			
 ISA	40	7	Needs Review			Alternate			
-ISA	40	8	voice (God?)			Implicit			
+ISA	40	8	voice (God?)			Implicit			EntireVerse
 ISA	40	8	God			Alternate			
 ISA	40	8	Needs Review			Alternate			
 ISA	40	9	one who brings good news			Hypothetical			
 ISA	40	25	God		God (the Holy One)	Normal			
 ISA	40	27	Israel		Jacob (Israel)	Hypothetical			
-ISA	41	1	God		God (Yahweh)	Implicit			
-ISA	41	2	God		God (Yahweh)	Implicit			
-ISA	41	3	God		God (Yahweh)	Implicit			
-ISA	41	4	God		God (Yahweh)	Implicit			
+ISA	41	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	4	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	5	God		God (Yahweh)	Potential			
 ISA	41	5	Isaiah			Alternate			
 ISA	41	6	God		God (Yahweh)	Potential			
@@ -9994,49 +9994,49 @@ ISA	41	6	islanders		everyone (islanders or foreigners)	Hypothetical
 ISA	41	7	God		God (Yahweh)	Normal			
 ISA	41	7	craftsman			Hypothetical			
 ISA	41	7	Isaiah			Alternate			
-ISA	41	8	God		God (Yahweh)	Implicit			
+ISA	41	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	9	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 ISA	41	10	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
-ISA	41	11	God		God (Yahweh)	Implicit			
-ISA	41	12	God		God (Yahweh)	Implicit			
+ISA	41	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	12	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	13	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 ISA	41	14	God		God (Yahweh)	Normal			
 ISA	41	14	Isaiah			Potential			
-ISA	41	15	God		God (Yahweh)	Implicit			
-ISA	41	16	God		God (Yahweh)	Implicit			
-ISA	41	17	God		God (Yahweh)	Implicit			
-ISA	41	18	God		God (Yahweh)	Implicit			
-ISA	41	19	God		God (Yahweh)	Implicit			
-ISA	41	20	God		God (Yahweh)	Implicit			
+ISA	41	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	17	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	19	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	20	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	21	God		God (Yahweh)	Normal			
 ISA	41	21	Isaiah			Potential			
-ISA	41	22	God		God (Yahweh)	Implicit			
-ISA	41	23	God		God (Yahweh)	Implicit			
-ISA	41	24	God		God (Yahweh)	Implicit			
-ISA	41	25	God		God (Yahweh)	Implicit			
-ISA	41	26	Needs Review			Implicit			
+ISA	41	22	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	23	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	24	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	25	God		God (Yahweh)	Implicit			EntireVerse
+ISA	41	26	Needs Review			Implicit			EntireVerse
 ISA	41	26	God		God (Yahweh)	Alternate			
 ISA	41	26	Isaiah			Alternate			
 ISA	41	27	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
-ISA	41	28	God		God (Yahweh)	Implicit			
+ISA	41	28	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	28	Isaiah			Alternate			
-ISA	41	29	God		God (Yahweh)	Implicit			
+ISA	41	29	God		God (Yahweh)	Implicit			EntireVerse
 ISA	41	29	Isaiah			Alternate			
-ISA	42	1	God		God (Yahweh)	Implicit			
-ISA	42	2	God		God (Yahweh)	Implicit			
-ISA	42	3	God		God (Yahweh)	Implicit			
-ISA	42	4	God		God (Yahweh)	Implicit			
+ISA	42	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	4	God		God (Yahweh)	Implicit			EntireVerse
 ISA	42	5	God		God (Yahweh)	Potential			
-ISA	42	6	God		God (Yahweh)	Implicit			
-ISA	42	7	God		God (Yahweh)	Implicit			
-ISA	42	8	God		God (Yahweh)	Implicit			
-ISA	42	9	God		God (Yahweh)	Implicit			
-ISA	42	14	God		God (Yahweh)	Implicit			
-ISA	42	15	God		God (Yahweh)	Implicit			
-ISA	42	16	God		God (Yahweh)	Implicit			
-ISA	42	17	God		God (Yahweh)	Implicit			
-ISA	42	18	God		God (Yahweh)	Implicit			
-ISA	42	19	God		God (Yahweh)	Implicit			
+ISA	42	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	17	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	42	19	God		God (Yahweh)	Implicit			EntireVerse
 ISA	42	20	God		God (Yahweh)	Potential			
 ISA	42	20	Isaiah			Alternate			
 ISA	42	21	God		God (Yahweh)	Potential			
@@ -10051,42 +10051,42 @@ ISA	42	24	God		God (Yahweh)	Alternate
 ISA	42	25	Isaiah			Potential			
 ISA	42	25	God		God (Yahweh)	Alternate			
 ISA	43	1	God		God (Yahweh)	Normal			
-ISA	43	2	God		God (Yahweh)	Implicit			
-ISA	43	3	God		God (Yahweh)	Implicit			
-ISA	43	4	God		God (Yahweh)	Implicit			
-ISA	43	5	God		God (Yahweh)	Implicit			
-ISA	43	6	God		God (Yahweh)	Implicit			
-ISA	43	7	God		God (Yahweh)	Implicit			
+ISA	43	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	7	God		God (Yahweh)	Implicit			EntireVerse
 ISA	43	8	Isaiah			Potential			
 ISA	43	8	God		God (Yahweh)	Alternate			
 ISA	43	9	Isaiah			Potential			
 ISA	43	9	God		God (Yahweh)	Alternate			
 ISA	43	9	nations			Hypothetical			
 ISA	43	10	God		God (Yahweh)	Normal			
-ISA	43	11	God		God (Yahweh)	Implicit			
+ISA	43	11	God		God (Yahweh)	Implicit			EntireVerse
 ISA	43	12	God		God (Yahweh)	Normal			
-ISA	43	13	God		God (Yahweh)	Implicit			
+ISA	43	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	43	14	God		God (Yahweh)	Normal			
-ISA	43	15	God		God (Yahweh)	Implicit			
-ISA	43	18	God		God (Yahweh)	Implicit			
-ISA	43	19	God		God (Yahweh)	Implicit			
-ISA	43	20	God		God (Yahweh)	Implicit			
-ISA	43	21	God		God (Yahweh)	Implicit			
-ISA	43	22	God		God (Yahweh)	Implicit			
-ISA	43	23	God		God (Yahweh)	Implicit			
-ISA	43	24	God		God (Yahweh)	Implicit			
-ISA	43	25	God		God (Yahweh)	Implicit			
-ISA	43	26	God		God (Yahweh)	Implicit			
-ISA	43	27	God		God (Yahweh)	Implicit			
-ISA	43	28	God		God (Yahweh)	Implicit			
-ISA	44	1	God		God (Yahweh)	Implicit			
+ISA	43	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	19	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	20	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	22	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	23	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	24	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	25	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	26	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	27	God		God (Yahweh)	Implicit			EntireVerse
+ISA	43	28	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	1	God		God (Yahweh)	Implicit			EntireVerse
 ISA	44	2	God		God (Yahweh)	Normal			
-ISA	44	3	God		God (Yahweh)	Implicit			
-ISA	44	4	God		God (Yahweh)	Implicit			
-ISA	44	5	God		God (Yahweh)	Implicit			
+ISA	44	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	44	6	God		God (Yahweh)	Normal			
-ISA	44	7	God		God (Yahweh)	Implicit			
-ISA	44	8	God		God (Yahweh)	Implicit			
+ISA	44	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	44	9	God		God (Yahweh)	Potential			
 ISA	44	10	God		God (Yahweh)	Potential			
 ISA	44	11	God		God (Yahweh)	Potential			
@@ -10107,104 +10107,104 @@ ISA	44	20	God		God (Yahweh)	Potential
 # it may sound good to have him say this part also.
 ISA	44	20	craftsman			Hypothetical			
 ISA	44	20	narrator-ISA			Quotation			
-ISA	44	21	God		God (Yahweh)	Implicit			
-ISA	44	22	God		God (Yahweh)	Implicit			
+ISA	44	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	22	God		God (Yahweh)	Implicit			EntireVerse
 ISA	44	23	Isaiah			Potential			
 ISA	44	23	God		God (Yahweh)	Alternate			
 ISA	44	24	God		God (Yahweh)	Normal			
-ISA	44	25	God		God (Yahweh)	Implicit			
-ISA	44	26	God		God (Yahweh)	Implicit			
-ISA	44	27	God		God (Yahweh)	Implicit			
-ISA	44	28	God		God (Yahweh)	Implicit			
+ISA	44	25	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	26	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	27	God		God (Yahweh)	Implicit			EntireVerse
+ISA	44	28	God		God (Yahweh)	Implicit			EntireVerse
 # Not sure how to handle this. What we really want is: if we find a quote, then it can be unambiguously assigned
 # to God. But if we don't, then mark the verse for review to see if it should be split.
 ISA	45	1	God		God (Yahweh)	Normal			
-ISA	45	1	Needs Review			Implicit			
-ISA	45	2	God		God (Yahweh)	Implicit			
-ISA	45	3	God		God (Yahweh)	Implicit			
-ISA	45	4	God		God (Yahweh)	Implicit			
-ISA	45	5	God		God (Yahweh)	Implicit			
-ISA	45	6	God		God (Yahweh)	Implicit			
-ISA	45	7	God		God (Yahweh)	Implicit			
-ISA	45	8	God		God (Yahweh)	Implicit			
-ISA	45	9	God		God (Yahweh)	Implicit			
-ISA	45	10	God		God (Yahweh)	Implicit			
+ISA	45	1	Needs Review			Implicit			EntireVerse
+ISA	45	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	10	God		God (Yahweh)	Implicit			EntireVerse
 ISA	45	11	God		God (Yahweh)	Normal			
 ISA	45	12	God		God (Yahweh)	Normal			
 ISA	45	13	God		God (Yahweh)	Normal			
 ISA	45	14	God		God (Yahweh)	Normal			
 ISA	45	14	Egyptians/Ethiopians/Sabeans			Hypothetical			
-ISA	45	15	Needs Review			Implicit			
+ISA	45	15	Needs Review			Implicit			EntireVerse
 ISA	45	15	Isaiah			Potential			
 # If the text has the hypothetical speech by the Egyptians, Ethiopians and Sabeans continue through v. 15 and the
 # scripter wants to have God speak it, then He needs to be an option in this verse.
 ISA	45	15	God		God (Yahweh)	Potential			
 ISA	45	15	Egyptians/Ethiopians/Sabeans			Hypothetical			
 ISA	45	18	God		God (Yahweh)	Normal			
-ISA	45	19	God		God (Yahweh)	Implicit			
-ISA	45	20	God		God (Yahweh)	Implicit			
-ISA	45	21	God		God (Yahweh)	Implicit			
-ISA	45	22	God		God (Yahweh)	Implicit			
-ISA	45	23	God		God (Yahweh)	Implicit			
+ISA	45	19	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	20	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	22	God		God (Yahweh)	Implicit			EntireVerse
+ISA	45	23	God		God (Yahweh)	Implicit			EntireVerse
 ISA	45	24	God		God (Yahweh)	Normal			
 ISA	45	24	every tongue			Hypothetical			
 ISA	45	25	God		God (Yahweh)	Potential			
 ISA	46	1	God		God (Yahweh)	Potential			
-ISA	46	1	Needs Review			Implicit			
+ISA	46	1	Needs Review			Implicit			EntireVerse
 ISA	46	2	God		God (Yahweh)	Potential			
-ISA	46	2	Needs Review			Implicit			
-ISA	46	3	God		God (Yahweh)	Implicit			
-ISA	46	4	God		God (Yahweh)	Implicit			
-ISA	46	5	God		God (Yahweh)	Implicit			
-ISA	46	6	God		God (Yahweh)	Implicit			
-ISA	46	7	God		God (Yahweh)	Implicit			
-ISA	46	8	God		God (Yahweh)	Implicit			
-ISA	46	9	God		God (Yahweh)	Implicit			
-ISA	46	10	God		God (Yahweh)	Implicit			
-ISA	46	11	God		God (Yahweh)	Implicit			
-ISA	46	12	God		God (Yahweh)	Implicit			
-ISA	46	13	God		God (Yahweh)	Implicit			
-ISA	47	1	God		God (Yahweh)	Implicit			
-ISA	47	2	God		God (Yahweh)	Implicit			
-ISA	47	3	God		God (Yahweh)	Implicit			
-ISA	47	5	God		God (Yahweh)	Implicit			
-ISA	47	6	God		God (Yahweh)	Implicit			
+ISA	46	2	Needs Review			Implicit			EntireVerse
+ISA	46	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	46	13	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	6	God		God (Yahweh)	Implicit			EntireVerse
 ISA	47	7	God		God (Yahweh)	Normal			
 ISA	47	7	Babylon (personified as adulteress)			Hypothetical			
 ISA	47	8	God		God (Yahweh)	Normal			
 ISA	47	8	Babylon (personified as adulteress)			Hypothetical			
-ISA	47	9	God		God (Yahweh)	Implicit			
+ISA	47	9	God		God (Yahweh)	Implicit			EntireVerse
 ISA	47	10	God		God (Yahweh)	Normal			
 ISA	47	10	Babylon (personified as adulteress)			Hypothetical			
-ISA	47	11	God		God (Yahweh)	Implicit			
-ISA	47	12	God		God (Yahweh)	Implicit			
-ISA	47	13	God		God (Yahweh)	Implicit			
-ISA	47	14	God		God (Yahweh)	Implicit			
-ISA	47	15	God		God (Yahweh)	Implicit			
+ISA	47	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	13	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	47	15	God		God (Yahweh)	Implicit			EntireVerse
 ISA	48	1	God		God (Yahweh)	Potential			
 ISA	48	2	God		God (Yahweh)	Potential			
-ISA	48	3	God		God (Yahweh)	Implicit			
-ISA	48	4	God		God (Yahweh)	Implicit			
-ISA	48	5	God		God (Yahweh)	Implicit			
-ISA	48	6	God		God (Yahweh)	Implicit			
-ISA	48	7	God		God (Yahweh)	Implicit			
-ISA	48	8	God		God (Yahweh)	Implicit			
-ISA	48	9	God		God (Yahweh)	Implicit			
-ISA	48	10	God		God (Yahweh)	Implicit			
-ISA	48	11	God		God (Yahweh)	Implicit			
-ISA	48	12	God		God (Yahweh)	Implicit			
-ISA	48	13	God		God (Yahweh)	Implicit			
+ISA	48	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	48	14	God		God (Yahweh)	Potential			
-ISA	48	15	God		God (Yahweh)	Implicit			
-ISA	48	16	Needs Review			Implicit			
+ISA	48	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	16	Needs Review			Implicit			EntireVerse
 ISA	48	16	Jesus			Potential			
 ISA	48	16	God		God (Yahweh)	Potential			
 ISA	48	16	voice (Messiah?)			Potential			
 ISA	48	16	Cyrus, king of Persia			Potential			
 ISA	48	16	God's chosen (beloved) friend or ally			Potential			
 ISA	48	17	God		God (Yahweh)	Potential			
-ISA	48	18	God		God (Yahweh)	Implicit			
-ISA	48	19	God		God (Yahweh)	Implicit			
+ISA	48	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	48	19	God		God (Yahweh)	Implicit			EntireVerse
 ISA	48	20	God		God (Yahweh)	Potential			
 ISA	48	20	exiles			Hypothetical			
 ISA	48	21	God		God (Yahweh)	Potential			
@@ -10225,35 +10225,35 @@ ISA	49	7	God		God (Yahweh)	Normal
 ISA	49	7	Isaiah			Alternate			
 ISA	49	8	God		God (Yahweh)	Normal			
 ISA	49	8	Isaiah			Alternate			
-ISA	49	9	God		God (Yahweh)	Implicit			
-ISA	49	10	God		God (Yahweh)	Implicit			
-ISA	49	11	God		God (Yahweh)	Implicit			
-ISA	49	12	God		God (Yahweh)	Implicit			
+ISA	49	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	49	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	49	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	49	12	God		God (Yahweh)	Implicit			EntireVerse
 # Some translations consider that God continues to speak in v. 13-14
 ISA	49	13	God		God (Yahweh)	Potential			
 ISA	49	14	God		God (Yahweh)	Potential			
 ISA	49	14	Zion			Hypothetical			
-ISA	49	15	God		God (Yahweh)	Implicit			
-ISA	49	16	God		God (Yahweh)	Implicit			
-ISA	49	17	God		God (Yahweh)	Implicit			
+ISA	49	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	49	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	49	17	God		God (Yahweh)	Implicit			EntireVerse
 ISA	49	17	Isaiah			Alternate			
-ISA	49	18	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+ISA	49	18	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 ISA	49	18	Isaiah			Alternate			
-ISA	49	19	God		God (Yahweh)	Implicit			
+ISA	49	19	God		God (Yahweh)	Implicit			EntireVerse
 ISA	49	19	Isaiah			Alternate			
-ISA	49	20	God		God (Yahweh)	Implicit			
+ISA	49	20	God		God (Yahweh)	Implicit			EntireVerse
 ISA	49	20	Isaiah			Alternate			
 ISA	49	21	God		God (Yahweh)	Normal			
 ISA	49	21	Zion			Hypothetical			
 ISA	49	21	Isaiah			Alternate			
 ISA	49	22	God		God (Yahweh)	Normal			
-ISA	49	23	God		God (Yahweh)	Implicit			
+ISA	49	23	God		God (Yahweh)	Implicit			EntireVerse
 ISA	49	24	God		God (Yahweh)	Potential			
 ISA	49	25	God		God (Yahweh)	Normal			
-ISA	49	26	God		God (Yahweh)	Implicit			
+ISA	49	26	God		God (Yahweh)	Implicit			EntireVerse
 ISA	50	1	God		God (Yahweh)	Normal			
-ISA	50	2	God		God (Yahweh)	Implicit			
-ISA	50	3	God		God (Yahweh)	Implicit			
+ISA	50	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	50	3	God		God (Yahweh)	Implicit			EntireVerse
 ISA	50	4	Isaiah			Potential			
 ISA	50	5	Isaiah			Potential			
 ISA	50	6	Isaiah			Potential			
@@ -10262,25 +10262,25 @@ ISA	50	8	Isaiah			Potential
 ISA	50	9	Isaiah			Potential			
 ISA	50	10	Isaiah			Potential			
 ISA	50	11	Isaiah			Potential			
-ISA	51	1	God		God (Yahweh)	Implicit			
-ISA	51	2	God		God (Yahweh)	Implicit			
+ISA	51	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	2	God		God (Yahweh)	Implicit			EntireVerse
 ISA	51	3	Isaiah			Potential			
 ISA	51	3	God		God (Yahweh)	Alternate			
-ISA	51	4	God		God (Yahweh)	Implicit			
-ISA	51	5	God		God (Yahweh)	Implicit			
-ISA	51	6	God		God (Yahweh)	Implicit			
-ISA	51	7	God		God (Yahweh)	Implicit			
-ISA	51	8	God		God (Yahweh)	Implicit			
+ISA	51	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	51	9	Isaiah			Potential			
 ISA	51	10	Isaiah			Potential			
 ISA	51	11	Isaiah			Potential			
 ISA	51	11	God		God (Yahweh)	Potential			
-ISA	51	12	God		God (Yahweh)	Implicit			
-ISA	51	13	God		God (Yahweh)	Implicit			
-ISA	51	14	God		God (Yahweh)	Implicit			
-ISA	51	15	God		God (Yahweh)	Implicit			
+ISA	51	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	13	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	51	15	God		God (Yahweh)	Implicit			EntireVerse
 ISA	51	15	waves			Hypothetical			
-ISA	51	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+ISA	51	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 ISA	51	17	Isaiah			Potential			
 ISA	51	18	Isaiah			Potential			
 ISA	51	19	Isaiah			Potential			
@@ -10288,14 +10288,14 @@ ISA	51	20	Isaiah			Potential
 ISA	51	21	Isaiah			Potential			
 ISA	51	22	Isaiah			Potential			
 ISA	51	22	God		God (Yahweh)	Normal			
-ISA	51	23	God		God (Yahweh)	Implicit			
+ISA	51	23	God		God (Yahweh)	Implicit			EntireVerse
 ISA	51	23	those who afflict Jerusalem			Hypothetical			
 ISA	52	1	Isaiah			Potential			
 ISA	52	2	Isaiah			Potential			
 ISA	52	3	God		God (Yahweh)	Normal			
 ISA	52	4	God		God (Yahweh)	Normal			
 ISA	52	5	God		God (Yahweh)	Normal			
-ISA	52	6	God		God (Yahweh)	Implicit			
+ISA	52	6	God		God (Yahweh)	Implicit			EntireVerse
 ISA	52	7	one who brings good news			Hypothetical			
 ISA	52	7	Isaiah			Potential			
 ISA	52	7	God		God (Yahweh)	Potential			
@@ -10309,9 +10309,9 @@ ISA	52	11	God		God (Yahweh)	Potential
 ISA	52	11	Isaiah			Potential			
 ISA	52	12	God		God (Yahweh)	Potential			
 ISA	52	12	Isaiah			Potential			
-ISA	52	13	God		God (Yahweh)	Implicit			
-ISA	52	14	God		God (Yahweh)	Implicit			
-ISA	52	15	God		God (Yahweh)	Implicit			
+ISA	52	13	God		God (Yahweh)	Implicit			EntireVerse
+ISA	52	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	52	15	God		God (Yahweh)	Implicit			EntireVerse
 ISA	53	1	Isaiah			Potential			
 ISA	53	2	Isaiah			Potential			
 ISA	53	3	Isaiah			Potential			
@@ -10324,41 +10324,41 @@ ISA	53	9	Isaiah			Potential
 ISA	53	10	Isaiah			Potential			
 # If there is a quote (God) midway through v. 11, the preceding part should
 # be the narrator. Otherwise, the whole verse should be spoken by God.
-ISA	53	11	Needs Review			Implicit			
+ISA	53	11	Needs Review			Implicit			EntireVerse
 ISA	53	11	God		God (Yahweh)	Potential			
-ISA	53	12	God		God (Yahweh)	Implicit			
+ISA	53	12	God		God (Yahweh)	Implicit			EntireVerse
 ISA	54	1	God		God (Yahweh)	Normal			
 ISA	54	2	God		God (Yahweh)	Normal			
 ISA	54	3	God		God (Yahweh)	Normal			
 ISA	54	4	God		God (Yahweh)	Normal			
 ISA	54	5	God		God (Yahweh)	Normal			
 ISA	54	6	God		God (Yahweh)	Normal			
-ISA	54	7	God		God (Yahweh)	Implicit			
+ISA	54	7	God		God (Yahweh)	Implicit			EntireVerse
 ISA	54	8	God		God (Yahweh)	Normal			
-ISA	54	9	God		God (Yahweh)	Implicit			
+ISA	54	9	God		God (Yahweh)	Implicit			EntireVerse
 ISA	54	10	God		God (Yahweh)	Normal			
-ISA	54	11	God		God (Yahweh)	Implicit			
-ISA	54	12	God		God (Yahweh)	Implicit			
+ISA	54	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	54	12	God		God (Yahweh)	Implicit			EntireVerse
 ISA	54	13	God		God (Yahweh)	Potential			
 ISA	54	13	Isaiah			Potential			
 ISA	54	14	God		God (Yahweh)	Potential			
 ISA	54	14	Isaiah			Potential			
-ISA	54	15	God		God (Yahweh)	Implicit			
-ISA	54	16	God		God (Yahweh)	Implicit			
+ISA	54	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	54	16	God		God (Yahweh)	Implicit			EntireVerse
 ISA	54	17	God		God (Yahweh)	Normal			
-ISA	55	1	God		God (Yahweh)	Implicit			
-ISA	55	2	God		God (Yahweh)	Implicit			
-ISA	55	3	God		God (Yahweh)	Implicit			
-ISA	55	4	God		God (Yahweh)	Implicit			
-ISA	55	5	God		God (Yahweh)	Implicit			
+ISA	55	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	55	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	55	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	55	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	55	5	God		God (Yahweh)	Implicit			EntireVerse
 ISA	55	6	God		God (Yahweh)	Potential			
 ISA	55	6	Isaiah			Potential			
 ISA	55	7	God		God (Yahweh)	Potential			
 ISA	55	7	Isaiah			Potential			
 ISA	55	8	God		God (Yahweh)	Normal			
 ISA	55	9	God		God (Yahweh)	Normal			
-ISA	55	10	God		God (Yahweh)	Implicit			
-ISA	55	11	God		God (Yahweh)	Implicit			
+ISA	55	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	55	11	God		God (Yahweh)	Implicit			EntireVerse
 ISA	55	12	God		God (Yahweh)	Normal			
 ISA	55	12	Isaiah			Alternate			
 ISA	55	13	God		God (Yahweh)	Normal			
@@ -10369,9 +10369,9 @@ ISA	56	3	narrator-ISA			Quotation
 ISA	56	3	foreigner who has joined himself to Yahweh			Hypothetical			
 ISA	56	3	eunuch			Hypothetical			
 ISA	56	4	God		God (Yahweh)	Normal			
-ISA	56	5	God		God (Yahweh)	Implicit			
-ISA	56	6	God		God (Yahweh)	Implicit			
-ISA	56	7	God		God (Yahweh)	Implicit			
+ISA	56	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	56	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	56	7	God		God (Yahweh)	Implicit			EntireVerse
 ISA	56	8	God		God (Yahweh)	Normal			
 ISA	56	9	God		God (Yahweh)	Potential			
 ISA	56	10	God		God (Yahweh)	Potential			
@@ -10383,38 +10383,38 @@ ISA	57	2	God		God (Yahweh)	Potential
 ISA	57	3	God		God (Yahweh)	Normal			
 ISA	57	4	God		God (Yahweh)	Normal			
 ISA	57	5	God		God (Yahweh)	Normal			
-ISA	57	6	God		God (Yahweh)	Implicit			
-ISA	57	7	God		God (Yahweh)	Implicit			
-ISA	57	8	God		God (Yahweh)	Implicit			
-ISA	57	9	God		God (Yahweh)	Implicit			
-ISA	57	10	God		God (Yahweh)	Implicit			
-ISA	57	11	God		God (Yahweh)	Implicit			
-ISA	57	12	God		God (Yahweh)	Implicit			
-ISA	57	13	God		God (Yahweh)	Implicit			
+ISA	57	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	57	14	man (hypothetical)			Hypothetical			
 ISA	57	14	God		God (Yahweh)	Potential			
 ISA	57	15	God		God (Yahweh)	Normal			
-ISA	57	16	God		God (Yahweh)	Implicit			
-ISA	57	17	God		God (Yahweh)	Implicit			
-ISA	57	18	God		God (Yahweh)	Implicit			
+ISA	57	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	17	God		God (Yahweh)	Implicit			EntireVerse
+ISA	57	18	God		God (Yahweh)	Implicit			EntireVerse
 ISA	57	19	God		God (Yahweh)	Normal			
 ISA	57	20	God		God (Yahweh)	Potential			
 ISA	57	21	God		God (Yahweh)	Normal			
-ISA	58	1	God		God (Yahweh)	Implicit			
-ISA	58	2	God		God (Yahweh)	Implicit			
-ISA	58	3	God		God (Yahweh)	Implicit			
+ISA	58	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	3	God		God (Yahweh)	Implicit			EntireVerse
 # This hypothetical quote will normally be a 2nd-level quote, unless explicit 1st-level quotation marks are absent
 ISA	58	3	Israel, men of			Hypothetical			
-ISA	58	4	God		God (Yahweh)	Implicit			
-ISA	58	5	God		God (Yahweh)	Implicit			
-ISA	58	6	God		God (Yahweh)	Implicit			
-ISA	58	7	God		God (Yahweh)	Implicit			
-ISA	58	8	God		God (Yahweh)	Implicit			
-ISA	58	9	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
-ISA	58	10	God		God (Yahweh)	Implicit			
-ISA	58	11	God		God (Yahweh)	Implicit			
-ISA	58	12	God		God (Yahweh)	Implicit			
-ISA	58	13	God		God (Yahweh)	Implicit			
+ISA	58	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	6	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	9	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
+ISA	58	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	58	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	58	14	God		God (Yahweh)	Normal			
 ISA	59	20	God		God (Yahweh)	Potential			
 ISA	59	21	God		God (Yahweh)	Normal			
@@ -10424,22 +10424,22 @@ ISA	60	3	God		God (Yahweh)	Potential
 ISA	60	4	God		God (Yahweh)	Potential			
 ISA	60	5	God		God (Yahweh)	Potential			
 ISA	60	6	God		God (Yahweh)	Potential			
-ISA	60	7	God		God (Yahweh)	Implicit			
-ISA	60	8	God		God (Yahweh)	Implicit			
-ISA	60	9	God		God (Yahweh)	Implicit			
-ISA	60	10	God		God (Yahweh)	Implicit			
-ISA	60	11	God		God (Yahweh)	Implicit			
-ISA	60	12	God		God (Yahweh)	Implicit			
-ISA	60	13	God		God (Yahweh)	Implicit			
-ISA	60	14	God		God (Yahweh)	Implicit			
-ISA	60	15	God		God (Yahweh)	Implicit			
-ISA	60	16	God		God (Yahweh)	Implicit			
-ISA	60	17	God		God (Yahweh)	Implicit			
+ISA	60	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	8	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	12	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	13	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	17	God		God (Yahweh)	Implicit			EntireVerse
 ISA	60	18	God		God (Yahweh)	Potential			
 ISA	60	19	God		God (Yahweh)	Potential			
 ISA	60	20	God		God (Yahweh)	Potential			
-ISA	60	21	God		God (Yahweh)	Implicit			
-ISA	60	22	God		God (Yahweh)	Implicit			
+ISA	60	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	60	22	God		God (Yahweh)	Implicit			EntireVerse
 # ...called "Oaks of righteousness"...
 ISA	61	3	narrator-ISA			Quotation			
 # These two verses would be good candidates for making Implicit, but some translations appear to express this in the 3rd person.
@@ -10465,16 +10465,16 @@ ISA	63	2	Isaiah			Potential
 ISA	63	2	Jesus		Jesus (one with garments stained crimson)	Normal			
 ISA	63	2	God		God (one with dyed garments)	Normal			
 ISA	63	2	Needs Review			Normal			
-ISA	63	3	God		God (one with dyed garments)	Implicit			
+ISA	63	3	God		God (one with dyed garments)	Implicit			EntireVerse
 ISA	63	3	Jesus		Jesus (one with garments stained crimson)	Alternate			
 ISA	63	3	Needs Review			Alternate			
-ISA	63	4	God		God (one with dyed garments)	Implicit			
+ISA	63	4	God		God (one with dyed garments)	Implicit			EntireVerse
 ISA	63	4	Jesus		Jesus (one with garments stained crimson)	Alternate			
 ISA	63	4	Needs Review			Alternate			
-ISA	63	5	God		God (one with dyed garments)	Implicit			
+ISA	63	5	God		God (one with dyed garments)	Implicit			EntireVerse
 ISA	63	5	Jesus		Jesus (one with garments stained crimson)	Alternate			
 ISA	63	5	Needs Review			Alternate			
-ISA	63	6	God		God (one with dyed garments)	Implicit			
+ISA	63	6	God		God (one with dyed garments)	Implicit			EntireVerse
 ISA	63	6	Jesus		Jesus (one with garments stained crimson)	Alternate			
 ISA	63	6	Needs Review			Alternate			
 ISA	63	7	Isaiah			Potential			
@@ -10487,65 +10487,65 @@ ISA	63	13	narrator-ISA			Quotation
 ISA	63	13	people, God's			Quotation			
 ISA	63	14	narrator-ISA			Quotation			
 ISA	63	14	people, God's			Quotation			
-ISA	65	1	God		God (Yahweh)	Implicit			
-ISA	65	2	God		God (Yahweh)	Implicit			
-ISA	65	3	God		God (Yahweh)	Implicit			
-ISA	65	4	God		God (Yahweh)	Implicit			
-ISA	65	5	God		God (Yahweh)	Implicit			
-ISA	65	6	God		God (Yahweh)	Implicit			
+ISA	65	1	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	2	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	4	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	5	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	6	God		God (Yahweh)	Implicit			EntireVerse
 ISA	65	7	God		God (Yahweh)	Normal			
 ISA	65	8	God		God (Yahweh)	Normal			
-ISA	65	9	God		God (Yahweh)	Implicit			
-ISA	65	10	God		God (Yahweh)	Implicit			
-ISA	65	11	God		God (Yahweh)	Implicit			
-ISA	65	12	God		God (Yahweh)	Implicit			
+ISA	65	9	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	10	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	11	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	12	God		God (Yahweh)	Implicit			EntireVerse
 ISA	65	13	God		God (Yahweh)	Normal			
-ISA	65	14	God		God (Yahweh)	Implicit			
-ISA	65	15	God		God (Yahweh)	Implicit			
-ISA	65	16	God		God (Yahweh)	Implicit			
-ISA	65	17	God		God (Yahweh)	Implicit			
-ISA	65	18	God		God (Yahweh)	Implicit			
-ISA	65	19	God		God (Yahweh)	Implicit			
-ISA	65	20	God		God (Yahweh)	Implicit			
-ISA	65	21	God		God (Yahweh)	Implicit			
-ISA	65	22	God		God (Yahweh)	Implicit			
-ISA	65	23	God		God (Yahweh)	Implicit			
-ISA	65	24	God		God (Yahweh)	Implicit			
+ISA	65	14	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	15	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	16	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	17	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	19	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	20	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	21	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	22	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	23	God		God (Yahweh)	Implicit			EntireVerse
+ISA	65	24	God		God (Yahweh)	Implicit			EntireVerse
 ISA	65	25	God		God (Yahweh)	Normal			
 ISA	66	1	God		God (Yahweh)	Normal			
 ISA	66	2	God		God (Yahweh)	Normal			
-ISA	66	3	God		God (Yahweh)	Implicit			
-ISA	66	4	God		God (Yahweh)	Implicit			
+ISA	66	3	God		God (Yahweh)	Implicit			EntireVerse
+ISA	66	4	God		God (Yahweh)	Implicit			EntireVerse
 ISA	66	5	God		God (Yahweh)	Normal			
 ISA	66	5	brothers who hate you			Hypothetical			
 ISA	66	6	God		God (Yahweh)	Alternate			
 ISA	66	6	Isaiah			Potential			
-ISA	66	6	Needs Review			Implicit			
-ISA	66	7	God		God (Yahweh)	Implicit			
-ISA	66	8	God		God (Yahweh)	Implicit			
+ISA	66	6	Needs Review			Implicit			EntireVerse
+ISA	66	7	God		God (Yahweh)	Implicit			EntireVerse
+ISA	66	8	God		God (Yahweh)	Implicit			EntireVerse
 ISA	66	9	God		God (Yahweh)	Normal			
 ISA	66	10	God		God (Yahweh)	Potential			
 ISA	66	11	God		God (Yahweh)	Potential			
 ISA	66	12	God		God (Yahweh)	Normal			
-ISA	66	13	God		God (Yahweh)	Implicit			
+ISA	66	13	God		God (Yahweh)	Implicit			EntireVerse
 ISA	66	14	God		God (Yahweh)	Potential			
 ISA	66	15	God		God (Yahweh)	Potential			
 ISA	66	16	God		God (Yahweh)	Potential			
 ISA	66	17	God		God (Yahweh)	Normal			
-ISA	66	18	God		God (Yahweh)	Implicit			
-ISA	66	19	God		God (Yahweh)	Implicit			
+ISA	66	18	God		God (Yahweh)	Implicit			EntireVerse
+ISA	66	19	God		God (Yahweh)	Implicit			EntireVerse
 ISA	66	20	God		God (Yahweh)	Normal			
 ISA	66	21	God		God (Yahweh)	Normal			
 ISA	66	22	God		God (Yahweh)	Normal			
 ISA	66	23	God		God (Yahweh)	Normal			
-ISA	66	24	God		God (Yahweh)	Implicit			
-JER	1	5	God		God (Yahweh)	Implicit			
+ISA	66	24	God		God (Yahweh)	Implicit			EntireVerse
+JER	1	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	1	6	Jeremiah			Quotation			
 JER	1	7	God		God (Yahweh)	Normal			
 JER	1	7	Jeremiah			Quotation			
 JER	1	8	God		God (Yahweh)	Normal			
 JER	1	9	God		God (Yahweh)	Normal			
-JER	1	10	God		God (Yahweh)	Implicit			
+JER	1	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	1	11	God		God (Yahweh)	Normal			
 JER	1	11	Jeremiah			Potential			
 JER	1	12	God		God (Yahweh)	Normal			
@@ -10553,9 +10553,9 @@ JER	1	13	God		God (Yahweh)	Normal
 JER	1	13	Jeremiah			Potential			
 JER	1	14	God		God (Yahweh)	Normal			
 JER	1	15	God		God (Yahweh)	Normal			
-JER	1	16	God		God (Yahweh)	Implicit			
-JER	1	17	God		God (Yahweh)	Implicit			
-JER	1	18	God		God (Yahweh)	Implicit			
+JER	1	16	God		God (Yahweh)	Implicit			EntireVerse
+JER	1	17	God		God (Yahweh)	Implicit			EntireVerse
+JER	1	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	1	19	God		God (Yahweh)	Normal			
 JER	2	2	God		God (Yahweh)	Normal			
 JER	2	2	Jeremiah			Potential			
@@ -10564,55 +10564,55 @@ JER	2	4	God		God (Yahweh)	Potential
 JER	2	5	God		God (Yahweh)	Normal			
 JER	2	6	God		God (Yahweh)	Normal			
 JER	2	6	Israel, fathers of	didn't say		Hypothetical			
-JER	2	7	God		God (Yahweh)	Implicit			
+JER	2	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	8	God		God (Yahweh)	Normal			
 JER	2	8	priests	didn't say		Hypothetical			
 JER	2	9	God		God (Yahweh)	Normal			
-JER	2	10	God		God (Yahweh)	Implicit			
-JER	2	11	God		God (Yahweh)	Implicit			
+JER	2	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	12	God		God (Yahweh)	Normal			
-JER	2	13	God		God (Yahweh)	Implicit			
-JER	2	14	God		God (Yahweh)	Implicit			
-JER	2	15	God		God (Yahweh)	Implicit			
-JER	2	16	God		God (Yahweh)	Implicit			
-JER	2	17	God		God (Yahweh)	Implicit			
-JER	2	18	God		God (Yahweh)	Implicit			
+JER	2	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	14	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	15	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	16	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	17	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	19	God		God (Yahweh)	Normal			
-JER	2	20	God		God (Yahweh)	Implicit			
-JER	2	21	God		God (Yahweh)	Implicit			
+JER	2	20	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	21	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	22	God		God (Yahweh)	Normal			
 JER	2	23	God		God (Yahweh)	Normal			
 # Different hypotethical characters could be used here and in the following verses in this chapter and the next,
 # but for easier casting purposes and dramatic effect, it is probably best to use the same voice throughout.
 JER	2	23	you (hypothetical)			Hypothetical			
-JER	2	24	God		God (Yahweh)	Implicit			
-JER	2	25	God		God (Yahweh)	Implicit			
-JER	2	26	God		God (Yahweh)	Implicit			
+JER	2	24	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	25	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	26	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	27	God		God (Yahweh)	Normal			
 JER	2	27	you (hypothetical)		Israel, with their kings, princes, priests and prophets	Hypothetical			
-JER	2	28	God		God (Yahweh)	Implicit			
+JER	2	28	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	29	God		God (Yahweh)	Normal			
-JER	2	30	God		God (Yahweh)	Implicit			
+JER	2	30	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	31	God		God (Yahweh)	Normal			
 JER	2	31	you (hypothetical)		God's people (Israel)	Hypothetical			
-JER	2	32	God		God (Yahweh)	Implicit			
-JER	2	33	God		God (Yahweh)	Implicit			
-JER	2	34	God		God (Yahweh)	Implicit			
+JER	2	32	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	33	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	34	God		God (Yahweh)	Implicit			EntireVerse
 JER	2	35	God		God (Yahweh)	Normal			
 JER	2	35	you (hypothetical)			Hypothetical			
-JER	2	36	God		God (Yahweh)	Implicit			
-JER	2	37	God		God (Yahweh)	Implicit			
+JER	2	36	God		God (Yahweh)	Implicit			EntireVerse
+JER	2	37	God		God (Yahweh)	Implicit			EntireVerse
 JER	3	1	God		God (Yahweh)	Normal			
-JER	3	2	God		God (Yahweh)	Implicit			
-JER	3	3	God		God (Yahweh)	Implicit			
+JER	3	2	God		God (Yahweh)	Implicit			EntireVerse
+JER	3	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	3	4	God		God (Yahweh)	Normal			
 JER	3	4	you (hypothetical)			Hypothetical			
 JER	3	5	you (hypothetical)			Hypothetical			
 JER	3	5	God		God (Yahweh)	Normal			
 JER	3	6	God		God (Yahweh)	Normal			
-JER	3	7	God		God (Yahweh)	Implicit			
-JER	3	8	God		God (Yahweh)	Implicit			
-JER	3	9	God		God (Yahweh)	Implicit			
+JER	3	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	3	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	3	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	3	10	God		God (Yahweh)	Normal			
 JER	3	11	God		God (Yahweh)	Normal			
 JER	3	12	God		God (Yahweh)	Normal			
@@ -10624,9 +10624,9 @@ JER	3	16	God		God (Yahweh)	Normal
 JER	3	16	man (hypothetical)	won't say	they (future people of Israel)	Hypothetical			
 JER	3	16	you (hypothetical)			Hypothetical			
 # expression: "The throne of God"
-JER	3	17	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
-JER	3	18	God		God (Yahweh)	Implicit			
-JER	3	19	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+JER	3	17	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
+JER	3	18	God		God (Yahweh)	Implicit			EntireVerse
+JER	3	19	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 JER	3	19	you (hypothetical)			Hypothetical			
 JER	3	20	God		God (Yahweh)	Normal			
 JER	3	21	God		God (Yahweh)	Potential			
@@ -10639,24 +10639,24 @@ JER	3	22	Israel			Normal
 JER	3	22	Needs Review			Potential			
 JER	3	23	Jeremiah			Potential			
 JER	3	23	Israel			Normal			
-JER	3	23	Needs Review			Implicit			
+JER	3	23	Needs Review			Implicit			EntireVerse
 JER	3	24	Jeremiah			Potential			
 JER	3	24	Israel			Normal			
-JER	3	24	Needs Review			Implicit			
+JER	3	24	Needs Review			Implicit			EntireVerse
 JER	3	25	Jeremiah			Potential			
 JER	3	25	Israel			Normal			
-JER	3	25	Needs Review			Implicit			
+JER	3	25	Needs Review			Implicit			EntireVerse
 JER	4	1	God		God (Yahweh)	Normal			
 JER	4	2	God		God (Yahweh)	Normal			
 JER	4	2	Israel			Hypothetical			
 JER	4	3	God	commanding	God (Yahweh)	Normal			
-JER	4	4	God	commanding	God (Yahweh)	Implicit			
+JER	4	4	God	commanding	God (Yahweh)	Implicit			EntireVerse
 JER	4	5	God	commanding	God (Yahweh)	Normal			
 JER	4	5	people of Jerusalem	declaration of alarm		Hypothetical			
 JER	4	5	Jeremiah	declaration of alarm		Hypothetical			
 JER	4	5	Jeremiah	commanding		Potential			
 JER	4	5	Needs Review			Potential			
-JER	4	6	God	commanding	God (Yahweh)	Implicit			
+JER	4	6	God	commanding	God (Yahweh)	Implicit			EntireVerse
 JER	4	7	God		God (Yahweh)	Potential			
 JER	4	7	Jeremiah			Potential			
 JER	4	8	Jeremiah			Potential			
@@ -10666,7 +10666,7 @@ JER	4	10	Jeremiah			Quotation
 JER	4	10	God		God (Yahweh)	Quotation			
 JER	4	11	Jeremiah			Potential			
 JER	4	11	God		God (Yahweh)	Normal			
-JER	4	12	God		God (Yahweh)	Implicit			
+JER	4	12	God		God (Yahweh)	Implicit			EntireVerse
 JER	4	13	God		God (Yahweh)	Potential			
 JER	4	13	Jeremiah			Potential			
 JER	4	13	people of Jerusalem			Hypothetical			
@@ -10674,21 +10674,21 @@ JER	4	14	God		God (Yahweh)	Potential
 JER	4	15	God		God (Yahweh)	Potential			
 JER	4	16	God		God (Yahweh)	Normal			
 JER	4	17	God		God (Yahweh)	Normal			
-JER	4	18	God		God (Yahweh)	Implicit			
+JER	4	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	4	19	Jeremiah			Potential			
 JER	4	20	Jeremiah			Potential			
 JER	4	21	Jeremiah			Potential			
-JER	4	22	God		God (Yahweh)	Implicit			
+JER	4	22	God		God (Yahweh)	Implicit			EntireVerse
 JER	4	23	Jeremiah			Potential			
 JER	4	24	Jeremiah			Potential			
 JER	4	26	Jeremiah			Potential			
 JER	4	27	God		God (Yahweh)	Normal			
-JER	4	28	God		God (Yahweh)	Implicit			
+JER	4	28	God		God (Yahweh)	Implicit			EntireVerse
 JER	4	29	God		God (Yahweh)	Potential			
 JER	4	30	God		God (Yahweh)	Potential			
 JER	4	31	God		God (Yahweh)	Potential			
 JER	4	31	daughter of Zion			Hypothetical			
-JER	5	1	God		God (Yahweh)	Implicit			
+JER	5	1	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	2	God		God (Yahweh)	Normal			
 JER	5	2	people of Jerusalem			Hypothetical			
 JER	5	4	Jeremiah			Potential			
@@ -10698,40 +10698,40 @@ JER	5	5	Jeremiah			Potential
 JER	5	5	God		God (Yahweh)	Potential			
 JER	5	6	Jeremiah			Potential			
 JER	5	6	God		God (Yahweh)	Potential			
-JER	5	7	God		God (Yahweh)	Implicit			
-JER	5	8	God		God (Yahweh)	Implicit			
+JER	5	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	9	God		God (Yahweh)	Normal			
-JER	5	10	God		God (Yahweh)	Implicit			
+JER	5	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	11	God		God (Yahweh)	Normal			
 JER	5	12	God		God (Yahweh)	Potential			
 JER	5	12	Israel/Judah, people of		house of Israel/house of Judah	Quotation			
 JER	5	13	Israel/Judah, people of		house of Israel/house of Judah	Quotation			
 JER	5	14	God		God (Yahweh)	Normal			
 JER	5	15	God		God (Yahweh)	Normal			
-JER	5	16	God		God (Yahweh)	Implicit			
-JER	5	17	God		God (Yahweh)	Implicit			
+JER	5	16	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	17	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	18	God		God (Yahweh)	Normal			
 JER	5	19	God		God (Yahweh)	Normal			
 JER	5	19	you (hypothetical)			Hypothetical			
-JER	5	20	God		God (Yahweh)	Implicit			
+JER	5	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	21	God		God (Yahweh)	Normal			
 JER	5	21	Jeremiah			Alternate			
 JER	5	22	God		God (Yahweh)	Normal			
-JER	5	23	God		God (Yahweh)	Implicit			
+JER	5	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	24	God		God (Yahweh)	Normal			
 JER	5	24	you (hypothetical)	they do not say in their heart	God's people (Israel)	Hypothetical			
-JER	5	25	God		God (Yahweh)	Implicit			
-JER	5	26	God		God (Yahweh)	Implicit			
-JER	5	27	God		God (Yahweh)	Implicit			
-JER	5	28	God		God (Yahweh)	Implicit			
+JER	5	25	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	27	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	28	God		God (Yahweh)	Implicit			EntireVerse
 JER	5	29	God		God (Yahweh)	Normal			
-JER	5	30	God		God (Yahweh)	Implicit			
-JER	5	31	God		God (Yahweh)	Implicit			
-JER	6	1	God		God (Yahweh)	Implicit			
+JER	5	30	God		God (Yahweh)	Implicit			EntireVerse
+JER	5	31	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	1	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	1	Jeremiah			Alternate			
 JER	6	1	person warning people of Benjamin to flee			Alternate			
-JER	6	2	God		God (Yahweh)	Implicit			
-JER	6	3	God		God (Yahweh)	Implicit			
+JER	6	2	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	3	Jeremiah			Alternate			
 JER	6	4	God	saying what invaders will say	God (Yahweh)	Potential			
 JER	6	4	invaders		invaders (shepherds)	Hypothetical			
@@ -10740,15 +10740,15 @@ JER	6	5	God	saying what invaders will say	God (Yahweh)	Potential
 JER	6	5	invaders		invaders (shepherds)	Hypothetical			
 JER	6	5	Jeremiah			Alternate			
 JER	6	6	God		God (Yahweh)	Normal			
-JER	6	7	God		God (Yahweh)	Implicit			
-JER	6	8	God		God (Yahweh)	Implicit			
+JER	6	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	9	God		God (Yahweh)	Normal			
 JER	6	10	Jeremiah			Potential			
 JER	6	10	God		God (Yahweh)	Alternate			
 JER	6	11	Jeremiah			Potential			
 JER	6	11	God		God (Yahweh)	Normal			
 JER	6	12	God		God (Yahweh)	Normal			
-JER	6	13	God		God (Yahweh)	Implicit			
+JER	6	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	13	Jeremiah			Alternate			
 JER	6	14	God		God (Yahweh)	Normal			
 JER	6	14	everyone		everyone, from the prophets even to the priests	Hypothetical			
@@ -10760,18 +10760,18 @@ JER	6	16	everyone		people unwilling to walk in the good way	Hypothetical
 JER	6	17	God		God (Yahweh)	Normal			
 JER	6	17	watchman			Hypothetical			
 JER	6	17	everyone		people unwilling to listen	Hypothetical			
-JER	6	18	God		God (Yahweh)	Implicit			
-JER	6	19	God		God (Yahweh)	Implicit			
-JER	6	20	God		God (Yahweh)	Implicit			
+JER	6	18	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	19	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	21	God		God (Yahweh)	Normal			
 JER	6	22	God		God (Yahweh)	Normal			
-JER	6	23	God		God (Yahweh)	Implicit			
+JER	6	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	24	people of Jerusalem			Hypothetical			
 JER	6	25	people of Jerusalem			Hypothetical			
 JER	6	26	people of Jerusalem			Hypothetical			
-JER	6	27	God		God (Yahweh)	Implicit			
-JER	6	28	God		God (Yahweh)	Implicit			
-JER	6	29	God		God (Yahweh)	Implicit			
+JER	6	27	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	28	God		God (Yahweh)	Implicit			EntireVerse
+JER	6	29	God		God (Yahweh)	Implicit			EntireVerse
 JER	6	30	God		God (Yahweh)	Normal			
 JER	7	2	God		God (Yahweh)	Normal			
 JER	7	2	Jeremiah			Potential			
@@ -10779,56 +10779,56 @@ JER	7	3	God		God (Yahweh)	Normal
 JER	7	4	lying words			Hypothetical			
 JER	7	4	God		God (Yahweh)	Normal			
 JER	7	5	God		God (Yahweh)	Normal			
-JER	7	6	God		God (Yahweh)	Implicit			
-JER	7	7	God		God (Yahweh)	Implicit			
-JER	7	8	God		God (Yahweh)	Implicit			
-JER	7	9	God		God (Yahweh)	Implicit			
+JER	7	6	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	10	God		God (Yahweh)	Normal			
 JER	7	10	you (hypothetical)			Hypothetical			
 JER	7	11	God		God (Yahweh)	Normal			
 JER	7	11	Jeremiah			Potential			
 JER	7	12	God		God (Yahweh)	Normal			
-JER	7	13	God		God (Yahweh)	Implicit			
-JER	7	14	God		God (Yahweh)	Implicit			
-JER	7	15	God		God (Yahweh)	Implicit			
-JER	7	16	God		God (Yahweh)	Implicit			
-JER	7	17	God		God (Yahweh)	Implicit			
-JER	7	18	God		God (Yahweh)	Implicit			
+JER	7	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	14	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	15	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	16	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	17	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	19	God		God (Yahweh)	Normal			
 JER	7	19	Jeremiah			Potential			
 JER	7	20	God		God (Yahweh)	Normal			
 JER	7	20	Jeremiah			Potential			
 JER	7	21	Jeremiah			Potential			
 JER	7	21	God		God (Yahweh)	Normal			
-JER	7	22	God		God (Yahweh)	Implicit			
-JER	7	23	God		God (Yahweh)	Implicit			
-JER	7	24	God		God (Yahweh)	Implicit			
-JER	7	25	God		God (Yahweh)	Implicit			
-JER	7	26	God		God (Yahweh)	Implicit			
-JER	7	27	God		God (Yahweh)	Implicit			
+JER	7	22	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	23	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	24	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	25	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	7	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	28	Jeremiah			Normal			
 JER	7	28	God		God (Yahweh)	Alternate			
-JER	7	29	Jeremiah			Implicit			
+JER	7	29	Jeremiah			Implicit			EntireVerse
 JER	7	29	God		God (Yahweh)	Alternate			
 JER	7	30	God		God (Yahweh)	Normal			
 JER	7	30	Jeremiah			Potential			
-JER	7	31	God		God (Yahweh)	Implicit			
+JER	7	31	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	31	Jeremiah			Alternate			
 JER	7	32	God		God (Yahweh)	Normal			
 JER	7	32	Jeremiah			Potential			
-JER	7	33	God		God (Yahweh)	Implicit			
+JER	7	33	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	33	Jeremiah			Alternate			
-JER	7	34	God		God (Yahweh)	Implicit			
+JER	7	34	God		God (Yahweh)	Implicit			EntireVerse
 JER	7	34	Jeremiah			Alternate			
 JER	8	1	God		God (Yahweh)	Normal			
 JER	8	1	Jeremiah			Potential			
-JER	8	2	God		God (Yahweh)	Implicit			
+JER	8	2	God		God (Yahweh)	Implicit			EntireVerse
 JER	8	2	Jeremiah			Alternate			
 JER	8	3	God		God (Yahweh)	Normal			
 JER	8	3	Jeremiah			Potential			
 JER	8	4	God		God (Yahweh)	Normal			
 JER	8	4	Jeremiah			Potential			
-JER	8	5	God		God (Yahweh)	Implicit			
+JER	8	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	8	5	Jeremiah			Alternate			
 JER	8	6	God		God (Yahweh)	Normal			
 JER	8	6	no one			Hypothetical			
@@ -10839,7 +10839,7 @@ JER	8	8	you (hypothetical)			Hypothetical
 JER	8	8	God		God (Yahweh)	Alternate			
 JER	8	9	Jeremiah			Potential			
 JER	8	9	God		God (Yahweh)	Alternate			
-JER	8	10	God		God (Yahweh)	Implicit			
+JER	8	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	8	10	Jeremiah			Alternate			
 JER	8	11	God		God (Yahweh)	Normal			
 JER	8	11	everyone		everyone, from the prophets even to the priests	Hypothetical			
@@ -10865,35 +10865,35 @@ JER	8	19	people			Hypothetical
 JER	8	19	God		God (Yahweh)	Potential			
 JER	8	20	people			Hypothetical			
 JER	8	20	Jeremiah			Potential			
-JER	8	21	Jeremiah			Implicit			
-JER	8	22	Jeremiah			Implicit			
-JER	9	1	Jeremiah			Implicit			
-JER	9	2	Jeremiah			Implicit			
+JER	8	21	Jeremiah			Implicit			EntireVerse
+JER	8	22	Jeremiah			Implicit			EntireVerse
+JER	9	1	Jeremiah			Implicit			EntireVerse
+JER	9	2	Jeremiah			Implicit			EntireVerse
 JER	9	2	God		God (Yahweh)	Alternate			
 JER	9	3	God		God (Yahweh)	Normal			
 JER	9	3	Jeremiah			Potential			
-JER	9	4	God		God (Yahweh)	Implicit			
+JER	9	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	4	Jeremiah			Alternate			
-JER	9	5	God		God (Yahweh)	Implicit			
+JER	9	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	5	Jeremiah			Alternate			
 JER	9	6	God		God (Yahweh)	Normal			
 JER	9	6	Jeremiah			Potential			
 JER	9	7	Jeremiah			Potential			
 JER	9	7	God		God (Yahweh)	Normal			
-JER	9	8	God		God (Yahweh)	Implicit			
+JER	9	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	9	God		God (Yahweh)	Normal			
 JER	9	9	Jeremiah			Potential			
-JER	9	10	God		God (Yahweh)	Implicit			
+JER	9	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	10	Jeremiah			Alternate			
-JER	9	11	God		God (Yahweh)	Implicit			
+JER	9	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	11	Jeremiah			Alternate			
 JER	9	12	Jeremiah			Potential			
 JER	9	12	God			Potential			
 JER	9	13	God		God (Yahweh)	Normal			
-JER	9	14	God		God (Yahweh)	Implicit			
+JER	9	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	15	Jeremiah			Potential			
 JER	9	15	God		God (Yahweh)	Normal			
-JER	9	16	God		God (Yahweh)	Implicit			
+JER	9	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	9	17	Jeremiah			Potential			
 JER	9	17	God		God (Yahweh)	Normal			
 JER	9	18	God		God (Yahweh)	Normal			
@@ -10911,22 +10911,22 @@ JER	9	22	God		God (Yahweh)	Normal
 # Although FCBH has this verse broken out and assigned according to a reasonable interpretation of the quotation marks in te WEB,
 # most other translations appear to break it up differently. We can leave the reference text unambiguous, but rather than risk an
 # accidental match-up that doesn't really reflect the vernacular, lets have the parser merk this verse for review.
-JER	9	22	Needs Review			Implicit			
+JER	9	22	Needs Review			Implicit			EntireVerse
 JER	9	23	Jeremiah			Potential			
 JER	9	23	God		God (Yahweh)	Normal			
 JER	9	24	God		God (Yahweh)	Normal			
 JER	9	24	Jeremiah			Potential			
 JER	9	25	God		God (Yahweh)	Normal			
 JER	9	25	Jeremiah			Potential			
-JER	9	26	God		God (Yahweh)	Implicit			
+JER	9	26	God		God (Yahweh)	Implicit			EntireVerse
 JER	10	1	Jeremiah			Potential			
 JER	10	2	Jeremiah			Potential			
 JER	10	2	God		God (Yahweh)	Normal			
-JER	10	3	God		God (Yahweh)	Implicit			
+JER	10	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	10	3	Jeremiah			Alternate			
-JER	10	4	God		God (Yahweh)	Implicit			
+JER	10	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	10	4	Jeremiah			Alternate			
-JER	10	5	God		God (Yahweh)	Implicit			
+JER	10	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	10	5	Jeremiah			Alternate			
 JER	10	6	Jeremiah			Potential			
 JER	10	7	Jeremiah			Potential			
@@ -10935,45 +10935,45 @@ JER	10	9	Jeremiah			Potential
 JER	10	10	Jeremiah			Potential			
 JER	10	11	God		God (Yahweh)	Potential			
 JER	10	11	Jeremiah			Normal			
-JER	10	12	Jeremiah			Implicit			
+JER	10	12	Jeremiah			Implicit			EntireVerse
 JER	10	12	God		God (Yahweh)	Alternate			
-JER	10	13	Jeremiah			Implicit			
+JER	10	13	Jeremiah			Implicit			EntireVerse
 JER	10	13	God		God (Yahweh)	Alternate			
-JER	10	14	Jeremiah			Implicit			
+JER	10	14	Jeremiah			Implicit			EntireVerse
 JER	10	14	God		God (Yahweh)	Alternate			
-JER	10	15	Jeremiah			Implicit			
+JER	10	15	Jeremiah			Implicit			EntireVerse
 JER	10	15	God		God (Yahweh)	Alternate			
-JER	10	16	Jeremiah			Implicit			
+JER	10	16	Jeremiah			Implicit			EntireVerse
 JER	10	16	God		God (Yahweh)	Alternate			
-JER	10	17	Jeremiah			Implicit			
+JER	10	17	Jeremiah			Implicit			EntireVerse
 JER	10	17	God		God (Yahweh)	Alternate			
 JER	10	18	Jeremiah			Potential			
 JER	10	18	God		God (Yahweh)	Normal			
-JER	10	19	Jeremiah			Implicit			
-JER	10	20	Jeremiah			Implicit			
-JER	10	21	Jeremiah			Implicit			
-JER	10	22	Jeremiah			Implicit			
-JER	10	23	Jeremiah	prayer		Implicit			
-JER	10	24	Jeremiah	prayer		Implicit			
-JER	10	25	Jeremiah	prayer		Implicit			
-JER	11	2	God		God (Yahweh)	Implicit			
-JER	11	3	God		God (Yahweh)	Implicit			
-JER	11	4	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+JER	10	19	Jeremiah			Implicit			EntireVerse
+JER	10	20	Jeremiah			Implicit			EntireVerse
+JER	10	21	Jeremiah			Implicit			EntireVerse
+JER	10	22	Jeremiah			Implicit			EntireVerse
+JER	10	23	Jeremiah	prayer		Implicit			EntireVerse
+JER	10	24	Jeremiah	prayer		Implicit			EntireVerse
+JER	10	25	Jeremiah	prayer		Implicit			EntireVerse
+JER	11	2	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	3	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	4	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 JER	11	5	God		God (Yahweh)	Normal			
 JER	11	5	Jeremiah			Quotation			
 JER	11	6	Jeremiah			Potential			
 JER	11	6	God		God (Yahweh)	Normal			
-JER	11	7	God		God (Yahweh)	Implicit			
-JER	11	8	God		God (Yahweh)	Implicit			
+JER	11	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	11	9	Jeremiah			Potential			
 JER	11	9	God		God (Yahweh)	Normal			
-JER	11	10	God		God (Yahweh)	Implicit			
+JER	11	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	11	11	Jeremiah			Potential			
 JER	11	11	God		God (Yahweh)	Normal			
-JER	11	12	God		God (Yahweh)	Implicit			
-JER	11	13	God		God (Yahweh)	Implicit			
-JER	11	14	God		God (Yahweh)	Implicit			
-JER	11	15	God		God (Yahweh)	Implicit			
+JER	11	12	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	14	God		God (Yahweh)	Implicit			EntireVerse
+JER	11	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	11	16	Jeremiah			Potential			
 JER	11	17	Jeremiah			Potential			
 JER	11	18	Jeremiah			Potential			
@@ -10985,35 +10985,35 @@ JER	11	21	God		God (Yahweh)	Normal
 JER	11	21	men of Anathoth			Hypothetical			
 JER	11	22	Jeremiah			Potential			
 JER	11	22	God		God (Yahweh)	Normal			
-JER	11	23	God		God (Yahweh)	Implicit			
+JER	11	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	12	1	Jeremiah			Potential			
 JER	12	2	Jeremiah			Potential			
 JER	12	3	Jeremiah			Potential			
 JER	12	4	Jeremiah	lament		Potential			
 JER	12	4	Jeremiah	quoting the wicked who live in the land		Hypothetical			
 JER	12	4	wicked, the			Hypothetical			
-JER	12	5	God		God (Yahweh)	Implicit			
-JER	12	6	God		God (Yahweh)	Implicit			
-JER	12	7	God		God (Yahweh)	Implicit			
-JER	12	8	God		God (Yahweh)	Implicit			
-JER	12	9	God		God (Yahweh)	Implicit			
-JER	12	10	God		God (Yahweh)	Implicit			
-JER	12	11	God		God (Yahweh)	Implicit			
-JER	12	12	God		God (Yahweh)	Implicit			
-JER	12	13	God		God (Yahweh)	Implicit			
+JER	12	5	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	6	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	11	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	12	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	12	14	Jeremiah			Potential			
 JER	12	14	God		God (Yahweh)	Normal			
-JER	12	15	God		God (Yahweh)	Implicit			
-JER	12	16	God		God (Yahweh)	Implicit			
+JER	12	15	God		God (Yahweh)	Implicit			EntireVerse
+JER	12	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	12	17	God		God (Yahweh)	Normal			
 JER	12	17	Jeremiah			Potential			
 JER	13	1	God		God (Yahweh)	Normal			
 JER	13	2	God		God (Yahweh)	Indirect			
 JER	13	4	God		God (Yahweh)	Normal			
 JER	13	6	God		God (Yahweh)	Normal			
-JER	13	9	God		God (Yahweh)	Implicit			
-JER	13	10	God		God (Yahweh)	Implicit			
-JER	13	11	God		God (Yahweh)	Implicit			
+JER	13	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	13	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	13	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	13	12	God		God (Yahweh)	Normal			
 JER	13	12	Jeremiah			Normal			
 JER	13	12	Israel, all/Judah, all		whole house of Israel/whole house of Judah	Hypothetical			
@@ -11044,11 +11044,11 @@ JER	13	22	Jeremiah			Potential
 JER	13	22	God		God (Yahweh)	Potential			
 JER	13	22	Judah, all	say in your heart	you (Judah)	Hypothetical			
 JER	13	23	God		God (Yahweh)	Potential			
-JER	13	24	God		God (Yahweh)	Implicit			
+JER	13	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	13	25	God		God (Yahweh)	Normal			
 JER	13	25	Jeremiah			Potential			
-JER	13	26	God		God (Yahweh)	Implicit			
-JER	13	27	God		God (Yahweh)	Implicit			
+JER	13	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	13	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	14	2	God		God (Yahweh)	Alternate			
 JER	14	2	Jeremiah			Potential			
 JER	14	3	God		God (Yahweh)	Alternate			
@@ -11061,51 +11061,51 @@ JER	14	6	God		God (Yahweh)	Alternate
 JER	14	6	Jeremiah			Potential			
 JER	14	7	Jeremiah			Potential			
 JER	14	7	people, repentant			Potential			
-JER	14	7	Needs Review			Implicit			
+JER	14	7	Needs Review			Implicit			EntireVerse
 JER	14	8	Jeremiah			Potential			
 JER	14	8	people, repentant			Potential			
-JER	14	8	Needs Review			Implicit			
+JER	14	8	Needs Review			Implicit			EntireVerse
 JER	14	9	Jeremiah			Potential			
 JER	14	9	people, repentant			Potential			
-JER	14	9	Needs Review			Implicit			
+JER	14	9	Needs Review			Implicit			EntireVerse
 JER	14	10	God		God (Yahweh)	Normal			
 JER	14	11	God		God (Yahweh)	Normal			
-JER	14	12	God		God (Yahweh)	Implicit			
+JER	14	12	God		God (Yahweh)	Implicit			EntireVerse
 JER	14	13	Jeremiah			Potential			
 JER	14	13	false prophets			Hypothetical			
 JER	14	14	Jeremiah			Potential			
 JER	14	14	God		God (Yahweh)	Normal			
 JER	14	15	God		God (Yahweh)	Normal			
 JER	14	15	false prophets			Hypothetical			
-JER	14	16	God		God (Yahweh)	Implicit			
+JER	14	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	14	17	God		God (Yahweh)	Normal			
 JER	14	17	Jeremiah			Normal			
 JER	14	18	God		God (Yahweh)	Potential			
-JER	14	19	Jeremiah			Implicit			
+JER	14	19	Jeremiah			Implicit			EntireVerse
 JER	14	19	people, repentant			Alternate			
-JER	14	20	Jeremiah			Implicit			
+JER	14	20	Jeremiah			Implicit			EntireVerse
 JER	14	20	people, repentant			Alternate			
-JER	14	21	Jeremiah			Implicit			
+JER	14	21	Jeremiah			Implicit			EntireVerse
 JER	14	21	people, repentant			Alternate			
-JER	14	22	Jeremiah			Implicit			
+JER	14	22	Jeremiah			Implicit			EntireVerse
 JER	14	22	people, repentant			Alternate			
 JER	15	1	God		God (Yahweh)	Normal			
 JER	15	2	God		God (Yahweh)	Normal			
 JER	15	2	people			Hypothetical			
 JER	15	3	God		God (Yahweh)	Normal			
-JER	15	4	God		God (Yahweh)	Implicit			
-JER	15	5	God		God (Yahweh)	Implicit			
+JER	15	4	God		God (Yahweh)	Implicit			EntireVerse
+JER	15	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	15	6	God		God (Yahweh)	Normal			
 JER	15	6	Jeremiah			Potential			
-JER	15	7	God		God (Yahweh)	Implicit			
-JER	15	8	God		God (Yahweh)	Implicit			
+JER	15	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	15	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	15	9	God		God (Yahweh)	Normal			
 JER	15	9	Jeremiah			Potential			
 JER	15	10	Jeremiah			Potential			
 JER	15	11	God		God (Yahweh)	Normal			
-JER	15	12	God		God (Yahweh)	Implicit			
-JER	15	13	God		God (Yahweh)	Implicit			
-JER	15	14	God		God (Yahweh)	Implicit			
+JER	15	12	God		God (Yahweh)	Implicit			EntireVerse
+JER	15	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	15	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	15	15	Jeremiah			Potential			
 JER	15	16	Jeremiah			Potential			
 JER	15	17	Jeremiah			Potential			
@@ -11113,7 +11113,7 @@ JER	15	18	Jeremiah			Potential
 JER	15	19	God		God (Yahweh)	Normal			
 JER	15	20	God		God (Yahweh)	Normal			
 JER	15	20	Jeremiah			Potential			
-JER	15	21	God		God (Yahweh)	Implicit			
+JER	15	21	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	2	God		God (Yahweh)	Normal			
 JER	16	3	Jeremiah			Potential			
 JER	16	3	God		God (Yahweh)	Alternate			
@@ -11121,21 +11121,21 @@ JER	16	4	Jeremiah			Alternate
 JER	16	4	God		God (Yahweh)	Normal			
 JER	16	5	Jeremiah			Potential			
 JER	16	5	God		God (Yahweh)	Normal			
-JER	16	6	God		God (Yahweh)	Implicit			
+JER	16	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	6	Jeremiah			Alternate			
-JER	16	7	God		God (Yahweh)	Implicit			
+JER	16	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	7	Jeremiah			Alternate			
-JER	16	8	God		God (Yahweh)	Implicit			
+JER	16	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	8	Jeremiah			Alternate			
 JER	16	9	Jeremiah			Potential			
 JER	16	9	God		God (Yahweh)	Normal			
 JER	16	10	God		God (Yahweh)	Normal			
 JER	16	10	people			Hypothetical			
-JER	16	11	God		God (Yahweh)	Implicit			
+JER	16	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	11	Jeremiah			Alternate			
-JER	16	12	God		God (Yahweh)	Implicit			
+JER	16	12	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	12	Jeremiah			Alternate			
-JER	16	13	God		God (Yahweh)	Implicit			
+JER	16	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	13	Jeremiah			Alternate			
 JER	16	14	God		God (Yahweh)	Normal			
 JER	16	14	Jeremiah			Potential			
@@ -11144,33 +11144,33 @@ JER	16	15	God		God (Yahweh)	Normal
 JER	16	15	saying about God's deliverance			Hypothetical		JER 16.15;JER 23.8	
 JER	16	16	God		God (Yahweh)	Normal			
 JER	16	16	Jeremiah			Potential			
-JER	16	17	God		God (Yahweh)	Implicit			
-JER	16	18	God		God (Yahweh)	Implicit			
+JER	16	17	God		God (Yahweh)	Implicit			EntireVerse
+JER	16	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	16	19	nations			Hypothetical			
 JER	16	19	Jeremiah			Alternate			
 JER	16	20	nations			Hypothetical			
 JER	16	20	Needs Review			Potential			
 JER	16	20	Jeremiah			Potential			
 JER	16	20	God		God (Yahweh)	Alternate			
-JER	16	21	God		God (Yahweh)	Implicit			
-JER	17	1	God		God (Yahweh)	Implicit			
+JER	16	21	God		God (Yahweh)	Implicit			EntireVerse
+JER	17	1	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	1	Jeremiah			Alternate			
-JER	17	2	God		God (Yahweh)	Implicit			
+JER	17	2	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	2	Jeremiah			Alternate			
-JER	17	3	God		God (Yahweh)	Implicit			
+JER	17	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	3	Jeremiah			Alternate			
-JER	17	4	God		God (Yahweh)	Implicit			
+JER	17	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	4	Jeremiah			Alternate			
 JER	17	5	Jeremiah			Potential			
 JER	17	5	God		God (Yahweh)	Normal			
-JER	17	6	God		God (Yahweh)	Implicit			
+JER	17	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	6	Jeremiah			Alternate			
-JER	17	7	God		God (Yahweh)	Implicit			
+JER	17	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	7	Jeremiah			Alternate			
-JER	17	8	God		God (Yahweh)	Implicit			
+JER	17	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	8	Jeremiah			Alternate			
-JER	17	9	God		God (Yahweh)	Implicit			
-JER	17	10	God		God (Yahweh)	Implicit			
+JER	17	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	17	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	11	God		God (Yahweh)	Potential			
 JER	17	13	Jeremiah			Potential			
 JER	17	14	Jeremiah			Potential			
@@ -11182,54 +11182,54 @@ JER	17	18	Jeremiah			Potential
 JER	17	19	God		God (Yahweh)	Normal			
 JER	17	20	God		God (Yahweh)	Normal			
 JER	17	21	God		God (Yahweh)	Normal			
-JER	17	22	God		God (Yahweh)	Implicit			
-JER	17	23	God		God (Yahweh)	Implicit			
+JER	17	22	God		God (Yahweh)	Implicit			EntireVerse
+JER	17	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	17	24	God		God (Yahweh)	Normal			
-JER	17	25	God		God (Yahweh)	Implicit			
-JER	17	26	God		God (Yahweh)	Implicit			
-JER	17	27	God		God (Yahweh)	Implicit			
-JER	18	2	God		God (Yahweh)	Implicit			
+JER	17	25	God		God (Yahweh)	Implicit			EntireVerse
+JER	17	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	17	27	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	2	God		God (Yahweh)	Implicit			EntireVerse
 JER	18	6	God		God (Yahweh)	Normal			
 JER	18	6	Jeremiah			Potential			
-JER	18	7	God		God (Yahweh)	Implicit			
-JER	18	8	God		God (Yahweh)	Implicit			
-JER	18	9	God		God (Yahweh)	Implicit			
-JER	18	10	God		God (Yahweh)	Implicit			
+JER	18	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	18	11	God		God (Yahweh)	Normal			
 JER	18	11	Jeremiah			Potential			
 JER	18	12	Jeremiah			Potential			
 JER	18	12	God		God (Yahweh)	Potential			
 JER	18	12	Judah, men of/people of Jerusalem			Hypothetical			
 JER	18	13	God		God (Yahweh)	Normal			
-JER	18	14	God		God (Yahweh)	Implicit			
-JER	18	15	God		God (Yahweh)	Implicit			
-JER	18	16	God		God (Yahweh)	Implicit			
-JER	18	17	God		God (Yahweh)	Implicit			
+JER	18	14	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	15	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	16	God		God (Yahweh)	Implicit			EntireVerse
+JER	18	17	God		God (Yahweh)	Implicit			EntireVerse
 JER	18	18	Jeremiah's enemies			Normal			
 JER	18	19	Jeremiah			Potential			
 JER	18	20	Jeremiah			Potential			
 JER	18	21	Jeremiah			Potential			
 JER	18	22	Jeremiah			Potential			
 JER	18	23	Jeremiah			Potential			
-JER	19	1	God		God (Yahweh)	Implicit			
-JER	19	2	God		God (Yahweh)	Implicit			
+JER	19	1	God		God (Yahweh)	Implicit			EntireVerse
+JER	19	2	God		God (Yahweh)	Implicit			EntireVerse
 JER	19	3	God		God (Yahweh)	Normal			
 JER	19	3	Jeremiah			Normal			
-JER	19	4	God		God (Yahweh)	Implicit			
+JER	19	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	19	4	Jeremiah			Alternate			
-JER	19	5	God		God (Yahweh)	Implicit			
+JER	19	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	19	5	Jeremiah			Alternate			
 JER	19	6	God		God (Yahweh)	Normal			
 JER	19	6	Jeremiah			Potential			
-JER	19	7	God		God (Yahweh)	Implicit			
-JER	19	8	God		God (Yahweh)	Implicit			
-JER	19	9	God		God (Yahweh)	Implicit			
-JER	19	10	God		God (Yahweh)	Implicit			
+JER	19	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	19	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	19	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	19	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	19	11	God		God (Yahweh)	Normal			
 JER	19	11	Jeremiah			Potential			
 JER	19	12	God		God (Yahweh)	Normal			
 JER	19	12	Jeremiah			Potential			
-JER	19	13	God		God (Yahweh)	Implicit			
+JER	19	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	19	15	Jeremiah			Normal			
 JER	19	15	God		God (Yahweh)	Normal			
 JER	20	3	Jeremiah			Normal			EndOfVerse
@@ -11249,7 +11249,7 @@ JER	20	9	narrator-JER			Quotation
 JER	20	10	Jeremiah			Potential			
 JER	20	10	Jeremiah's enemies			Hypothetical			
 JER	20	10	Jeremiah's friends (bad)			Hypothetical			
-JER	20	10	Needs Review			Implicit			
+JER	20	10	Needs Review			Implicit			EntireVerse
 JER	20	11	Jeremiah			Potential			
 JER	20	12	Jeremiah			Potential			
 JER	20	13	Jeremiah			Potential			
@@ -11264,15 +11264,15 @@ JER	21	3	Jeremiah			Normal			Unspecified
 JER	21	4	Jeremiah			Normal			
 JER	21	4	God		God (Yahweh)	Normal			
 JER	21	5	Jeremiah			Alternate			
-JER	21	5	God		God (Yahweh)	Implicit			
+JER	21	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	21	6	Jeremiah			Alternate			
-JER	21	6	God		God (Yahweh)	Implicit			
+JER	21	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	21	7	Jeremiah			Normal			
 JER	21	7	God		God (Yahweh)	Normal			
 JER	21	8	Jeremiah			Normal			
 JER	21	8	God		God (Yahweh)	Normal			
 JER	21	9	Jeremiah			Alternate			
-JER	21	9	God		God (Yahweh)	Implicit			
+JER	21	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	21	10	Jeremiah			Normal			
 JER	21	10	God		God (Yahweh)	Normal			
 JER	21	11	Jeremiah			Normal			
@@ -11289,13 +11289,13 @@ JER	22	2	God		God (Yahweh)	Normal
 JER	22	2	Jeremiah			Normal			
 JER	22	3	Jeremiah			Normal			
 JER	22	3	God		God (Yahweh)	Normal			
-JER	22	4	God		God (Yahweh)	Implicit			
+JER	22	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	4	Jeremiah			Alternate			
 JER	22	5	God		God (Yahweh)	Normal			
 JER	22	5	Jeremiah			Normal			
 JER	22	6	Jeremiah			Normal			
 JER	22	6	God		God (Yahweh)	Normal			
-JER	22	7	God		God (Yahweh)	Implicit			
+JER	22	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	7	Jeremiah			Alternate			
 JER	22	8	God		God (Yahweh)	Normal			
 JER	22	8	nations			Hypothetical			
@@ -11307,28 +11307,28 @@ JER	22	10	Jeremiah			Potential
 JER	22	11	Jeremiah			Potential			
 JER	22	11	God		God (Yahweh)	Normal			
 JER	22	12	God		God (Yahweh)	Normal			
-JER	22	13	God		God (Yahweh)	Implicit			
+JER	22	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	13	Jeremiah			Alternate			
 JER	22	14	God		God (Yahweh)	Normal			
 JER	22	14	Jeremiah			Alternate			
 JER	22	14	man who builds his house by unrighteousness			Hypothetical			
-JER	22	15	God		God (Yahweh)	Implicit			
+JER	22	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	16	God		God (Yahweh)	Normal			
 JER	22	16	Jeremiah			Potential			
 JER	22	17	God		God (Yahweh)	Potential			
 JER	22	18	God		God (Yahweh)	Normal			
 JER	22	18	no one	lament		Hypothetical			
-JER	22	19	God		God (Yahweh)	Implicit			
-JER	22	20	God		God (Yahweh)	Implicit			
+JER	22	19	God		God (Yahweh)	Implicit			EntireVerse
+JER	22	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	21	God		God (Yahweh)	Normal			
 JER	22	21	you (hypothetical)			Hypothetical			
-JER	22	22	God		God (Yahweh)	Implicit			
-JER	22	23	God		God (Yahweh)	Implicit			
+JER	22	22	God		God (Yahweh)	Implicit			EntireVerse
+JER	22	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	24	God		God (Yahweh)	Normal			
 JER	22	24	Jeremiah			Potential			
-JER	22	25	God		God (Yahweh)	Implicit			
-JER	22	26	God		God (Yahweh)	Implicit			
-JER	22	27	God		God (Yahweh)	Implicit			
+JER	22	25	God		God (Yahweh)	Implicit			EntireVerse
+JER	22	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	22	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	22	28	God		God (Yahweh)	Potential			
 JER	22	28	Jeremiah			Potential			
 JER	22	29	Jeremiah			Potential			
@@ -11336,12 +11336,12 @@ JER	22	30	Jeremiah			Potential
 JER	22	30	God		God (Yahweh)	Normal			
 JER	23	1	God		God (Yahweh)	Normal			
 JER	23	2	God		God (Yahweh)	Normal			
-JER	23	3	God		God (Yahweh)	Implicit			
+JER	23	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	23	4	God		God (Yahweh)	Normal			
 JER	23	4	Jeremiah			Potential			
 JER	23	5	God		God (Yahweh)	Normal			
 JER	23	5	Jeremiah			Potential			
-JER	23	6	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+JER	23	6	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 JER	23	7	God		God (Yahweh)	Normal			
 JER	23	7	Jeremiah			Potential			
 JER	23	7	saying about God's deliverance	no more be said		Hypothetical		JER 16.14;JER 23.7	
@@ -11350,13 +11350,13 @@ JER	23	8	saying about God's deliverance			Hypothetical		JER 16.15;JER 23.8
 JER	23	9	Jeremiah			Potential			
 JER	23	10	Jeremiah			Potential			
 JER	23	10	God		God (Yahweh)	Potential			
-JER	23	10	Needs Review			Implicit			
+JER	23	10	Needs Review			Implicit			EntireVerse
 JER	23	11	God		God (Yahweh)	Normal			
 JER	23	11	Jeremiah			Rare			
 JER	23	11	Needs Review			Rare			
 JER	23	12	God		God (Yahweh)	Normal			
-JER	23	13	God		God (Yahweh)	Implicit			
-JER	23	14	God		God (Yahweh)	Implicit			
+JER	23	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	23	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	23	15	God		God (Yahweh)	Normal			
 JER	23	16	God		God (Yahweh)	Normal			
 JER	23	17	God		God (Yahweh)	Normal			
@@ -11367,16 +11367,16 @@ JER	23	19	God		God (Yahweh)	Potential
 JER	23	19	Jeremiah			Potential			
 JER	23	20	God		God (Yahweh)	Potential			
 JER	23	20	Jeremiah			Potential			
-JER	23	21	God		God (Yahweh)	Implicit			
-JER	23	22	God		God (Yahweh)	Implicit			
+JER	23	21	God		God (Yahweh)	Implicit			EntireVerse
+JER	23	22	God		God (Yahweh)	Implicit			EntireVerse
 JER	23	23	God		God (Yahweh)	Normal			
 JER	23	23	Jeremiah			Potential			
 JER	23	24	God		God (Yahweh)	Normal			
 JER	23	24	Jeremiah			Potential			
 JER	23	25	God		God (Yahweh)	Normal			
 JER	23	25	false prophets			Quotation			
-JER	23	26	God		God (Yahweh)	Implicit			
-JER	23	27	God		God (Yahweh)	Implicit			
+JER	23	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	23	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	23	28	God		God (Yahweh)	Normal			
 JER	23	28	Jeremiah			Potential			
 JER	23	29	God		God (Yahweh)	Normal			
@@ -11400,16 +11400,16 @@ JER	23	37	God		God (Yahweh)	Normal
 JER	23	37	you (hypothetical)			Hypothetical			
 JER	23	38	God		God (Yahweh)	Normal			
 JER	23	38	you (hypothetical)			Hypothetical			
-JER	23	39	God		God (Yahweh)	Implicit			
-JER	23	40	God		God (Yahweh)	Implicit			
+JER	23	39	God		God (Yahweh)	Implicit			EntireVerse
+JER	23	40	God		God (Yahweh)	Implicit			EntireVerse
 JER	24	3	God		God (Yahweh)	Normal			
 JER	24	3	Jeremiah			Quotation			
-JER	24	5	God		God (Yahweh)	Implicit			
-JER	24	6	God		God (Yahweh)	Implicit			
-JER	24	7	God		God (Yahweh)	Implicit			
+JER	24	5	God		God (Yahweh)	Implicit			EntireVerse
+JER	24	6	God		God (Yahweh)	Implicit			EntireVerse
+JER	24	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	24	8	God		God (Yahweh)	Normal			
-JER	24	9	God		God (Yahweh)	Implicit			
-JER	24	10	God		God (Yahweh)	Implicit			
+JER	24	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	24	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	25	3	Jeremiah			Potential			
 JER	25	4	Jeremiah			Potential			
 JER	25	5	Jeremiah		Jeremiah quoting the prophets	Normal			
@@ -11421,13 +11421,13 @@ JER	25	6	prophets			Quotation
 JER	25	7	God		God (Yahweh)	Normal			
 JER	25	8	God		God (Yahweh)	Normal			
 JER	25	9	God		God (Yahweh)	Normal			
-JER	25	10	God		God (Yahweh)	Implicit			
-JER	25	11	God		God (Yahweh)	Implicit			
+JER	25	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	25	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	25	12	God		God (Yahweh)	Normal			
-JER	25	13	God		God (Yahweh)	Implicit			
-JER	25	14	God		God (Yahweh)	Implicit			
+JER	25	13	God		God (Yahweh)	Implicit			EntireVerse
+JER	25	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	25	15	God		God (Yahweh)	Normal			
-JER	25	16	God		God (Yahweh)	Implicit			
+JER	25	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	25	27	God		God (Yahweh)	Normal			
 JER	25	27	Jeremiah			Potential			
 JER	25	28	God		God (Yahweh)	Normal			
@@ -11453,7 +11453,7 @@ JER	25	37	God		God (Yahweh)	Potential
 JER	25	38	Jeremiah			Potential			
 JER	25	38	God		God (Yahweh)	Potential			
 JER	26	2	God		God (Yahweh)	Normal			
-JER	26	3	God		God (Yahweh)	Implicit			
+JER	26	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	26	4	God		God (Yahweh)	Normal			
 JER	26	4	Jeremiah			Normal			
 JER	26	5	Jeremiah			Normal			Unspecified
@@ -11465,13 +11465,13 @@ JER	26	8	priests/Levites		priests/prophets/all the people	Normal			Unspecified
 JER	26	9	priests/Levites		priests/prophets/all the people	Normal			Unspecified
 JER	26	11	priests/Levites		priests/prophets	Normal			EndOfVerse
 JER	26	12	Jeremiah			Normal			Unspecified
-JER	26	13	Jeremiah			Implicit			
-JER	26	14	Jeremiah			Implicit			
-JER	26	15	Jeremiah			Implicit			
+JER	26	13	Jeremiah			Implicit			EntireVerse
+JER	26	14	Jeremiah			Implicit			EntireVerse
+JER	26	15	Jeremiah			Implicit			EntireVerse
 JER	26	16	officials/people, all the			Normal			EndOfVerse
 JER	26	18	elders of the land			Normal			
 JER	26	18	Micah, prophet			Quotation			Unspecified
-JER	26	19	elders of the land			Implicit			
+JER	26	19	elders of the land			Implicit			EntireVerse
 # Most translations (including WEB) do not have vv. 20-23 in quotes. It is a commentary by the narrator (some make it parenthetical).
 JER	26	20	elders of the land			Potential			
 JER	26	20	Needs Review			Potential			
@@ -11483,25 +11483,25 @@ JER	26	23	elders of the land			Potential
 JER	26	23	Needs Review			Potential			
 JER	27	2	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	2	God		God (Yahweh)	Normal			
-JER	27	3	God		God (Yahweh)	Implicit			
+JER	27	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	4	God		God (Yahweh)	Normal			
 JER	27	4	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	27	5	God		God (Yahweh)	Implicit			
+JER	27	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	5	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	27	5	messenger			Hypothetical			
-JER	27	6	God		God (Yahweh)	Implicit			
+JER	27	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	6	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	27	6	messenger			Hypothetical			
-JER	27	7	God		God (Yahweh)	Implicit			
+JER	27	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	7	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	27	7	messenger			Hypothetical			
 JER	27	8	God		God (Yahweh)	Normal			
 JER	27	8	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	27	8	messenger			Hypothetical			
-JER	27	9	God		God (Yahweh)	Implicit			
+JER	27	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	9	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	27	9	messenger			Hypothetical			
-JER	27	10	God		God (Yahweh)	Implicit			
+JER	27	10	God		God (Yahweh)	Implicit			EntireVerse
 JER	27	10	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	27	10	messenger			Hypothetical			
 JER	27	11	God		God (Yahweh)	Normal			
@@ -11512,47 +11512,47 @@ JER	27	12	God		God (Yahweh)	Alternate
 JER	27	12	Needs Review			Normal			
 JER	27	13	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	13	God		God (Yahweh)	Alternate			
-JER	27	13	Needs Review			Implicit			
+JER	27	13	Needs Review			Implicit			EntireVerse
 JER	27	14	God		God (Yahweh)	Normal			
 JER	27	14	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	27	14	Needs Review			Implicit			
+JER	27	14	Needs Review			Implicit			EntireVerse
 JER	27	14	false prophets			Quotation			
 JER	27	15	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	15	God		God (Yahweh)	Normal			
-JER	27	15	Needs Review			Implicit			
+JER	27	15	Needs Review			Implicit			EntireVerse
 JER	27	16	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	16	God		God (Yahweh)	Alternate			
 JER	27	16	false prophets			Quotation			
 JER	27	16	Needs Review			Normal			
 JER	27	17	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	17	God		God (Yahweh)	Normal			
-JER	27	17	Needs Review			Implicit			
+JER	27	17	Needs Review			Implicit			EntireVerse
 JER	27	18	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	18	God		God (Yahweh)	Normal			
-JER	27	18	Needs Review			Implicit			
+JER	27	18	Needs Review			Implicit			EntireVerse
 JER	27	19	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	19	God		God (Yahweh)	Normal			
-JER	27	19	Needs Review			Implicit			
+JER	27	19	Needs Review			Implicit			EntireVerse
 JER	27	20	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	20	God		God (Yahweh)	Normal			
-JER	27	20	Needs Review			Implicit			
+JER	27	20	Needs Review			Implicit			EntireVerse
 JER	27	21	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	27	21	God		God (Yahweh)	Normal			
-JER	27	21	Needs Review			Implicit			
+JER	27	21	Needs Review			Implicit			EntireVerse
 JER	27	22	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	27	22	God		God (Yahweh)	Normal			
-JER	27	22	Needs Review			Implicit			
-JER	28	2	Hananiah, false prophet			Implicit			
-JER	28	3	Hananiah, false prophet			Implicit			
-JER	28	4	Hananiah, false prophet			Implicit			
+JER	27	22	Needs Review			Implicit			EntireVerse
+JER	28	2	Hananiah, false prophet			Implicit			EntireVerse
+JER	28	3	Hananiah, false prophet			Implicit			EntireVerse
+JER	28	4	Hananiah, false prophet			Implicit			EntireVerse
 JER	28	6	Jeremiah			Normal			Unspecified
-JER	28	7	Jeremiah			Implicit			
-JER	28	8	Jeremiah			Implicit			
-JER	28	9	Jeremiah			Implicit			
+JER	28	7	Jeremiah			Implicit			EntireVerse
+JER	28	8	Jeremiah			Implicit			EntireVerse
+JER	28	9	Jeremiah			Implicit			EntireVerse
 JER	28	11	Hananiah, false prophet			Normal			ContainedWithinVerse
 JER	28	13	God		God (Yahweh)	Normal			Unspecified
 JER	28	13	Jeremiah			Alternate			
-JER	28	14	God		God (Yahweh)	Implicit			
+JER	28	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	28	14	Jeremiah			Alternate			
 JER	28	15	Jeremiah			Normal			Unspecified
 JER	28	16	Jeremiah		Jeremiah (Yahweh says)	Normal			
@@ -11566,7 +11566,7 @@ JER	29	4-23	Jeremiah	letter	Jeremiah (Yahweh says)	ImplicitWithPotentialSelfQuot
 JER	29	4-23	Elasah, son of Shaphan/Gemariah, son of Hilkiah	letter		Alternate			
 JER	29	4-23	God		God (Yahweh)	Alternate			
 JER	29	24	God		God (Yahweh)	Potential			
-JER	29	24	Needs Review			Implicit			
+JER	29	24	Needs Review			Implicit			EntireVerse
 JER	29	25	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	29	25	God		God (Yahweh)	Normal			
 JER	29	26	Shemaiah the Nehelamite			Quotation			
@@ -11588,13 +11588,13 @@ JER	30	3	God		God (Yahweh)	Normal
 JER	30	3	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	30	5	God		God (Yahweh)	Normal			
 JER	30	5	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	30	6	God		God (Yahweh)	Implicit			
+JER	30	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	6	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	7	God		God (Yahweh)	Implicit			
+JER	30	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	7	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	30	8	God		God (Yahweh)	Normal			
 JER	30	8	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	30	9	God		God (Yahweh)	Implicit			
+JER	30	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	9	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	30	10	God		God (Yahweh)	Normal			
 JER	30	10	Jeremiah		Jeremiah (Yahweh says)	Normal			
@@ -11602,25 +11602,25 @@ JER	30	11	God		God (Yahweh)	Normal
 JER	30	11	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	30	12	God		God (Yahweh)	Normal			
 JER	30	12	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	30	13	God		God (Yahweh)	Implicit			
+JER	30	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	13	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	14	God		God (Yahweh)	Implicit			
+JER	30	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	14	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	15	God		God (Yahweh)	Implicit			
+JER	30	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	15	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	16	God		God (Yahweh)	Implicit			
+JER	30	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	16	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	30	17	God		God (Yahweh)	Normal			
 JER	30	17	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	30	18	God		God (Yahweh)	Normal			
 JER	30	18	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	30	19	God		God (Yahweh)	Implicit			
+JER	30	19	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	19	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	20	God		God (Yahweh)	Implicit			
+JER	30	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	20	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	21	God		God (Yahweh)	Implicit			
+JER	30	21	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	21	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	30	22	God		God (Yahweh)	Implicit			
+JER	30	22	God		God (Yahweh)	Implicit			EntireVerse
 JER	30	22	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	30	23	God		God (Yahweh)	Potential			
 JER	30	24	God		God (Yahweh)	Potential			
@@ -11629,22 +11629,22 @@ JER	31	1	Jeremiah		Jeremiah (Yahweh says)	Potential
 JER	31	2	God		God (Yahweh)	Normal			
 JER	31	2	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	31	3	God		God (Yahweh)	Normal			
-JER	31	4	God		God (Yahweh)	Implicit			
-JER	31	5	God		God (Yahweh)	Implicit			
+JER	31	4	God		God (Yahweh)	Implicit			EntireVerse
+JER	31	5	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	6	God		God (Yahweh)	Normal			
 JER	31	6	watchman		watchman on the hills of Ephraim	Hypothetical			
 JER	31	7	God		God (Yahweh)	Normal			
 JER	31	7	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	31	7	you (people of Zion, restored)			Hypothetical			
-JER	31	8	God		God (Yahweh)	Implicit			
+JER	31	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	8	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	31	9	God		God (Yahweh)	Implicit			
+JER	31	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	9	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	31	10	God		God (Yahweh)	Potential			
 JER	31	10	nations			Hypothetical			
 JER	31	11	God		God (Yahweh)	Potential			
 JER	31	12	God		God (Yahweh)	Potential			
-JER	31	13	God		God (Yahweh)	Implicit			
+JER	31	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	13	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	31	14	God		God (Yahweh)	Normal			
 JER	31	14	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -11668,9 +11668,9 @@ JER	31	22	Jeremiah			Potential
 JER	31	23	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	31	23	God		God (Yahweh)	Normal			
 JER	31	23	Judah, people of			Hypothetical			
-JER	31	24	God		God (Yahweh)	Implicit			
+JER	31	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	24	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	31	25	God		God (Yahweh)	Implicit			
+JER	31	25	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	25	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	31	26	God		God (Yahweh)	Potential			
 JER	31	26	Jeremiah			Potential			
@@ -11680,9 +11680,9 @@ JER	31	27	God		God (Yahweh)	Normal
 JER	31	27	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	31	28	God		God (Yahweh)	Normal			
 JER	31	28	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	31	29	God		God (Yahweh)	Implicit			
+JER	31	29	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	29	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	31	30	God		God (Yahweh)	Implicit			
+JER	31	30	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	30	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	31	31	God		God (Yahweh)	Normal			
 JER	31	31	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -11700,15 +11700,15 @@ JER	31	37	God		God (Yahweh)	Normal
 JER	31	37	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	31	38	God		God (Yahweh)	Normal			
 JER	31	38	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	31	39	God		God (Yahweh)	Implicit			
+JER	31	39	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	39	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	31	40	God		God (Yahweh)	Implicit			
+JER	31	40	God		God (Yahweh)	Implicit			EntireVerse
 JER	31	40	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	3	Zedekiah, king of Judah			Normal			EndOfVerse
-JER	32	4	Zedekiah, king of Judah			Implicit			
-JER	32	5	Zedekiah, king of Judah			Implicit			
+JER	32	4	Zedekiah, king of Judah			Implicit			EntireVerse
+JER	32	5	Zedekiah, king of Judah			Implicit			EntireVerse
 JER	32	6	Jeremiah			Normal			Unspecified
-JER	32	7	God		God (Yahweh)	Implicit			
+JER	32	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	7	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	8	Jeremiah			Potential			
 JER	32	8	Hanamel (Jeremiah's cousin)			Quotation			
@@ -11731,35 +11731,35 @@ JER	32	22	Jeremiah	praying		Potential
 JER	32	23	Jeremiah	praying		Potential			
 JER	32	24	Jeremiah	praying		Potential			
 JER	32	25	Jeremiah	praying		Potential			
-JER	32	27	God		God (Yahweh)	Implicit			
+JER	32	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	27	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	28	Jeremiah			Potential			
 JER	32	28	God		God (Yahweh)	Normal			
-JER	32	29	God		God (Yahweh)	Implicit			
+JER	32	29	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	29	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	30	God		God (Yahweh)	Normal			
 JER	32	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	32	31	God		God (Yahweh)	Implicit			
-JER	32	32	God		God (Yahweh)	Implicit			
-JER	32	33	God		God (Yahweh)	Implicit			
-JER	32	34	God		God (Yahweh)	Implicit			
-JER	32	35	God		God (Yahweh)	Implicit			
+JER	32	31	God		God (Yahweh)	Implicit			EntireVerse
+JER	32	32	God		God (Yahweh)	Implicit			EntireVerse
+JER	32	33	God		God (Yahweh)	Implicit			EntireVerse
+JER	32	34	God		God (Yahweh)	Implicit			EntireVerse
+JER	32	35	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	36	God		God (Yahweh)	Normal			
 JER	32	36	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	32	36	you (hypothetical)			Hypothetical			
-JER	32	37	God		God (Yahweh)	Implicit			
+JER	32	37	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	37	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	32	38	God		God (Yahweh)	Implicit			
+JER	32	38	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	38	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	32	39	God		God (Yahweh)	Implicit			
+JER	32	39	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	39	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	32	40	God		God (Yahweh)	Implicit			
+JER	32	40	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	40	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	32	41	God		God (Yahweh)	Implicit			
+JER	32	41	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	41	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	42	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	32	42	God		God (Yahweh)	Normal			
-JER	32	43	God		God (Yahweh)	Implicit			
+JER	32	43	God		God (Yahweh)	Implicit			EntireVerse
 JER	32	43	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	32	44	God		God (Yahweh)	Normal			
 JER	32	44	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -11791,13 +11791,13 @@ JER	33	13	God		God (Yahweh)	Normal
 JER	33	13	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	33	14	God		God (Yahweh)	Normal			
 JER	33	14	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	33	15	God		God (Yahweh)	Implicit			
+JER	33	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	33	15	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	33	16	God		God (Yahweh)	Implicit			
+JER	33	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	33	16	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	33	17	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	33	17	God		God (Yahweh)	Normal			
-JER	33	18	God		God (Yahweh)	Implicit			
+JER	33	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	33	18	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	33	20	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	33	20	God		God (Yahweh)	Normal			
@@ -11805,11 +11805,11 @@ JER	33	21	God		God (Yahweh)	Normal
 JER	33	21	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	33	22	God		God (Yahweh)	Normal			
 JER	33	22	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	33	24	God		God (Yahweh)	Implicit			
+JER	33	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	33	24	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	33	25	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	33	25	God		God (Yahweh)	Normal			
-JER	33	26	God		God (Yahweh)	Implicit			
+JER	33	26	God		God (Yahweh)	Implicit			EntireVerse
 JER	33	26	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	34	2	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	34	2	God		God (Yahweh)	Normal			
@@ -11833,24 +11833,24 @@ JER	34	16	God		God (Yahweh)	Normal
 JER	34	16	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	34	17	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	34	17	God		God (Yahweh)	Normal			
-JER	34	18	God		God (Yahweh)	Implicit			
+JER	34	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	34	18	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	34	19	God		God (Yahweh)	Implicit			
+JER	34	19	God		God (Yahweh)	Implicit			EntireVerse
 JER	34	19	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	34	20	God		God (Yahweh)	Implicit			
+JER	34	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	34	20	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	34	21	God		God (Yahweh)	Implicit			
+JER	34	21	God		God (Yahweh)	Implicit			EntireVerse
 JER	34	21	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	34	22	God		God (Yahweh)	Normal			
 JER	34	22	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	35	2	God		God (Yahweh)	Implicit			
+JER	35	2	God		God (Yahweh)	Implicit			EntireVerse
 JER	35	5	Jeremiah			Quotation			
 JER	35	6	Rechabite family, men of			Normal			
-JER	35	7	Rechabite family, men of			Implicit			
-JER	35	8	Rechabite family, men of			Implicit			
-JER	35	9	Rechabite family, men of			Implicit			
-JER	35	10	Rechabite family, men of			Implicit			
-JER	35	11	Rechabite family, men of			Implicit			
+JER	35	7	Rechabite family, men of			Implicit			EntireVerse
+JER	35	8	Rechabite family, men of			Implicit			EntireVerse
+JER	35	9	Rechabite family, men of			Implicit			EntireVerse
+JER	35	10	Rechabite family, men of			Implicit			EntireVerse
+JER	35	11	Rechabite family, men of			Implicit			EntireVerse
 JER	35	13	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	35	13	God		God (Yahweh)	Normal			
 JER	35	14	God		God (Yahweh)	Normal			
@@ -11865,11 +11865,11 @@ JER	35	18	Jeremiah		Jeremiah (Yahweh says)	Normal
 JER	35	18	God		God (Yahweh)	Normal			
 JER	35	19	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	35	19	God		God (Yahweh)	Normal			
-JER	36	2	God		God (Yahweh)	Implicit			
-JER	36	3	God		God (Yahweh)	Implicit			
+JER	36	2	God		God (Yahweh)	Implicit			EntireVerse
+JER	36	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	36	5	Jeremiah			Normal			EndOfVerse
-JER	36	6	Jeremiah			Implicit			
-JER	36	7	Jeremiah			Implicit			
+JER	36	6	Jeremiah			Implicit			EntireVerse
+JER	36	7	Jeremiah			Implicit			EntireVerse
 JER	36	14	Jehudi			Normal			ContainedWithinVerse
 JER	36	15	Elishama/Delaiah/Elnathan/Gemariah, son of Shaphan/Zedekiah, son of Hananiah/officials		Elishama/Delaiah/Elnathan/Gemariah/Zedekiah/officials	Normal			ContainedWithinVerse
 JER	36	16	Elishama/Delaiah/Elnathan/Gemariah, son of Shaphan/Zedekiah, son of Hananiah/officials		Elishama/Delaiah/Elnathan/Gemariah/Zedekiah/officials	Normal			Unspecified
@@ -11878,12 +11878,12 @@ JER	36	18	Baruch			Normal			Unspecified
 JER	36	19	Elishama/Delaiah/Elnathan/Gemariah, son of Shaphan/Zedekiah, son of Hananiah/officials		Elishama/Delaiah/Elnathan/Gemariah/Zedekiah/officials	Normal			EndOfVerse
 JER	36	25	Elnathan/Delaiah/Gemariah, son of Shaphan		Elnathan/Delaiah/Gemariah	Indirect			
 JER	36	26	Zedekiah, king of Judah			Indirect			
-JER	36	28	God		God (Yahweh)	Implicit			
+JER	36	28	God		God (Yahweh)	Implicit			EntireVerse
 JER	36	29	God		God (Yahweh)	Normal			
 JER	36	29	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	36	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	36	30	God		God (Yahweh)	Normal			
-JER	36	31	God		God (Yahweh)	Implicit			
+JER	36	31	God		God (Yahweh)	Implicit			EntireVerse
 JER	36	31	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	37	3	Jehucal/Zephaniah, priest			Normal			EndOfVerse
 JER	37	3	Zedekiah, king of Judah			Alternate			
@@ -11901,8 +11901,8 @@ JER	37	14	Jeremiah			Normal			Unspecified
 JER	37	17	Jeremiah			Normal			
 JER	37	17	Zedekiah, king of Judah			Normal			
 JER	37	18	Jeremiah			Normal			EndOfVerse
-JER	37	19	Jeremiah			Implicit			
-JER	37	20	Jeremiah			Implicit			
+JER	37	19	Jeremiah			Implicit			EntireVerse
+JER	37	20	Jeremiah			Implicit			EntireVerse
 JER	37	21	Zedekiah, king of Judah			Indirect			
 JER	38	2	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	38	2	God		God (Yahweh)	Normal			
@@ -11910,7 +11910,7 @@ JER	38	3	Jeremiah		Jeremiah (Yahweh says)	Potential
 JER	38	3	God		God (Yahweh)	Normal			
 JER	38	4	Shephatiah/Gedaliah, son of Pashur/Jehucal/Pashur		officials (Shephatiah, Gedaliah, Jehucal, and Pashur)	Normal			EndOfVerse
 JER	38	5	Zedekiah, king of Judah			Normal			EndOfVerse
-JER	38	9	Ebed-Melech (official of king of Judea)			Implicit			
+JER	38	9	Ebed-Melech (official of king of Judea)			Implicit			EntireVerse
 JER	38	10	Zedekiah, king of Judah			Normal			EndOfVerse
 JER	38	12	Ebed-Melech (official of king of Judea)			Normal			ContainedWithinVerse
 JER	38	14	Zedekiah, king of Judah			Normal			EndOfVerse
@@ -11922,14 +11922,14 @@ JER	38	18	God		God (Yahweh)	Normal
 JER	38	18	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	38	19	Zedekiah, king of Judah			Normal			EndOfVerse
 JER	38	20	Jeremiah			Normal			EndOfVerse
-JER	38	21	Jeremiah			Implicit			
+JER	38	21	Jeremiah			Implicit			EntireVerse
 JER	38	22	God		God (Yahweh)	Alternate			
-JER	38	22	Jeremiah		Jeremiah (Yahweh says)	Implicit			
+JER	38	22	Jeremiah		Jeremiah (Yahweh says)	Implicit			EntireVerse
 JER	38	22	women, remnant of the king of Judah's house			Hypothetical			Unspecified
 JER	38	23	God		God (Yahweh)	Alternate			
-JER	38	23	Jeremiah		Jeremiah (Yahweh says)	Implicit			
+JER	38	23	Jeremiah		Jeremiah (Yahweh says)	Implicit			EntireVerse
 JER	38	24	Zedekiah, king of Judah			Normal			EndOfVerse
-JER	38	25	Zedekiah, king of Judah			Implicit			
+JER	38	25	Zedekiah, king of Judah			Implicit			EntireVerse
 JER	38	25	Shephatiah/Gedaliah, son of Pashur/Jehucal/Pashur		officials (Shephatiah, Gedaliah, Jehucal, and Pashur)	Hypothetical			Unspecified
 JER	38	26	Zedekiah, king of Judah			Normal			EntireVerse
 JER	38	27	Jeremiah		Jeremiah (Yahweh says)	Indirect			
@@ -11943,23 +11943,23 @@ JER	39	17	Jeremiah		Jeremiah (Yahweh says)	Potential
 JER	39	18	God		God (Yahweh)	Normal			
 JER	39	18	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	40	2	Nebuzaradan			Normal			EndOfVerse
-JER	40	3	Nebuzaradan			Implicit			
-JER	40	4	Nebuzaradan			Implicit			
+JER	40	3	Nebuzaradan			Implicit			EntireVerse
+JER	40	4	Nebuzaradan			Implicit			EntireVerse
 JER	40	5	Nebuzaradan			Normal			Unspecified
 JER	40	9	Gedaliah, governor of Judah			Normal			EndOfVerse
-JER	40	10	Gedaliah, governor of Judah			Implicit			
+JER	40	10	Gedaliah, governor of Judah			Implicit			EntireVerse
 JER	40	14	Johanan/army officers			Normal	Johanan		ContainedWithinVerse
 JER	40	15	Johanan			Normal			EndOfVerse
 JER	40	16	Gedaliah, governor of Judah			Normal			EndOfVerse
 JER	41	6	Ishmael, son of Nethaniah (murderer)			Normal			Unspecified
 JER	41	8	men in mourning, ten of eighty			Normal			Unspecified
 JER	42	2	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Normal	Johanan		EndOfVerse
-JER	42	3	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Implicit	Johanan		
+JER	42	3	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Implicit	Johanan		EntireVerse
 JER	42	4	Jeremiah			Normal			Unspecified
 JER	42	5	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Normal	Johanan		EndOfVerse
-JER	42	6	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Implicit	Johanan		
+JER	42	6	Johanan/army officers/people, all the		all the army officers, including Johanan and Jezaniah/all the people	Implicit	Johanan		EntireVerse
 JER	42	9	Jeremiah		Jeremiah (Yahweh says)	Normal			EndOfVerse
-JER	42	10	Jeremiah		Jeremiah (Yahweh says)	Implicit			
+JER	42	10	Jeremiah		Jeremiah (Yahweh says)	Implicit			EntireVerse
 JER	42	10	God		God (Yahweh)	Alternate			
 JER	42	11	God		God (Yahweh)	Normal			
 JER	42	11	Jeremiah		Jeremiah (Yahweh says)	Normal			
@@ -11985,15 +11985,15 @@ JER	42	20	Judah, remnant of			Quotation
 JER	42	21	Jeremiah			Normal			
 JER	42	22	Jeremiah			Normal			
 JER	43	2	Azariah, son of Hoshaiah/Johanan/arrogant men		Azariah, Johanan and all the arrogant men	Normal			EndOfVerse
-JER	43	3	Azariah, son of Hoshaiah/Johanan/arrogant men		Azariah, Johanan and all the arrogant men	Implicit			
-JER	43	9	God		God (Yahweh)	Implicit			
+JER	43	3	Azariah, son of Hoshaiah/Johanan/arrogant men		Azariah, Johanan and all the arrogant men	Implicit			EntireVerse
+JER	43	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	43	10	God		God (Yahweh)	Normal			
 JER	43	10	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	43	11	God		God (Yahweh)	Implicit			
+JER	43	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	43	11	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	43	12	God		God (Yahweh)	Implicit			
+JER	43	12	God		God (Yahweh)	Implicit			EntireVerse
 JER	43	12	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	43	13	God		God (Yahweh)	Implicit			
+JER	43	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	43	13	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	44	2	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	44	2	God		God (Yahweh)	Normal			
@@ -12022,13 +12022,13 @@ JER	44	13	God		God (Yahweh)	Normal
 JER	44	13	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	44	14	God		God (Yahweh)	Normal			
 JER	44	14	Jeremiah		Jeremiah (Yahweh says)	Normal			
-JER	44	16	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		
-JER	44	17	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		
-JER	44	18	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		
+JER	44	16	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		EntireVerse
+JER	44	17	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		EntireVerse
+JER	44	18	idolaters from Judah (men)/idolaters from Judah (women)			Implicit	idolaters from Judah (men)		EntireVerse
 JER	44	19	idolaters from Judah (women)			Normal			EndOfVerse
-JER	44	21	Jeremiah			Implicit			
-JER	44	22	Jeremiah			Implicit			
-JER	44	23	Jeremiah			Implicit			
+JER	44	21	Jeremiah			Implicit			EntireVerse
+JER	44	22	Jeremiah			Implicit			EntireVerse
+JER	44	23	Jeremiah			Implicit			EntireVerse
 JER	44	24	Jeremiah			Normal			
 JER	44	25	Jeremiah			Normal			
 JER	44	25	God		God (Yahweh)	Normal			
@@ -12044,7 +12044,7 @@ JER	44	29	God		God (Yahweh)	Normal
 JER	44	30	Jeremiah			Normal			
 JER	44	30	God		God (Yahweh)	Normal			
 JER	45	2	Jeremiah			Normal			
-JER	45	3	God		God (Yahweh)	Implicit			
+JER	45	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	45	3	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	45	4	God		God (Yahweh)	Normal			
 JER	45	4	Jeremiah		Jeremiah (Yahweh says)	Alternate			
@@ -12052,9 +12052,9 @@ JER	45	5	God		God (Yahweh)	Normal
 JER	45	5	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	46	2	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	46	2	God		God (Yahweh)	Potential			
-JER	46	3	God		God (Yahweh)	Implicit			
+JER	46	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	3	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	46	4	God		God (Yahweh)	Implicit			
+JER	46	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	4	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	46	5	God		God (Yahweh)	Normal			
 JER	46	5	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12084,123 +12084,123 @@ JER	46	17	Jeremiah		Jeremiah (Yahweh says)	Potential
 JER	46	17	God		God (Yahweh)	Alternate			
 JER	46	18	God		God (Yahweh)	Normal			
 JER	46	18	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	46	19	God		God (Yahweh)	Implicit			
+JER	46	19	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	19	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	46	20	God		God (Yahweh)	Implicit			
+JER	46	20	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	20	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	46	21	God		God (Yahweh)	Implicit			
+JER	46	21	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	21	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	46	22	God		God (Yahweh)	Implicit			
+JER	46	22	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	22	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	46	23	God		God (Yahweh)	Normal			
 JER	46	23	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	46	24	God		God (Yahweh)	Implicit			
+JER	46	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	24	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	46	25	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	46	25	God		God (Yahweh)	Normal			
 JER	46	26	God		God (Yahweh)	Normal			
 JER	46	26	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	46	27	God		God (Yahweh)	Implicit			
+JER	46	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	27	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	46	28	God		God (Yahweh)	Implicit			
+JER	46	28	God		God (Yahweh)	Implicit			EntireVerse
 JER	46	28	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	47	2	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	47	2	God		God (Yahweh)	Normal			
-JER	47	3	God		God (Yahweh)	Implicit			
-JER	47	4	God		God (Yahweh)	Implicit			
-JER	47	5	God		God (Yahweh)	Implicit			
-JER	47	6	God		God (Yahweh)	Implicit			
-JER	47	7	God		God (Yahweh)	Implicit			
+JER	47	3	God		God (Yahweh)	Implicit			EntireVerse
+JER	47	4	God		God (Yahweh)	Implicit			EntireVerse
+JER	47	5	God		God (Yahweh)	Implicit			EntireVerse
+JER	47	6	God		God (Yahweh)	Implicit			EntireVerse
+JER	47	7	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	1	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	48	1	God		God (Yahweh)	Normal			
 JER	48	2	God		God (Yahweh)	Normal			
 JER	48	2	Heshbon, people of			Normal			
-JER	48	3	God		God (Yahweh)	Implicit			
-JER	48	4	God		God (Yahweh)	Implicit			
-JER	48	5	God		God (Yahweh)	Implicit			
-JER	48	6	God		God (Yahweh)	Implicit			
-JER	48	7	God		God (Yahweh)	Implicit			
-JER	48	8	God		God (Yahweh)	Implicit			
-JER	48	9	God		God (Yahweh)	Implicit			
-JER	48	10	God		God (Yahweh)	Implicit			
-JER	48	11	God		God (Yahweh)	Implicit			
+JER	48	3	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	4	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	5	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	6	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	7	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	12	God		God (Yahweh)	Normal			
 JER	48	12	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	13	God		God (Yahweh)	Implicit			
+JER	48	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	14	God		God (Yahweh)	Normal			
 JER	48	14	Moabites			Hypothetical			
 JER	48	15	God		God (Yahweh)	Normal			
 JER	48	15	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	16	God		God (Yahweh)	Implicit			
+JER	48	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	17	God		God (Yahweh)	Normal			
 JER	48	17	neighboring nations around Moab			Hypothetical			
-JER	48	18	God		God (Yahweh)	Implicit			
+JER	48	18	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	19	God		God (Yahweh)	Normal			
 JER	48	19	Aroer, inhabitant of			Hypothetical			
-JER	48	20	God		God (Yahweh)	Implicit			
-JER	48	21	God		God (Yahweh)	Implicit			
-JER	48	22	God		God (Yahweh)	Implicit			
-JER	48	23	God		God (Yahweh)	Implicit			
-JER	48	24	God		God (Yahweh)	Implicit			
+JER	48	20	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	21	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	22	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	23	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	25	God		God (Yahweh)	Normal			
 JER	48	25	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	26	God		God (Yahweh)	Implicit			
-JER	48	27	God		God (Yahweh)	Implicit			
-JER	48	28	God		God (Yahweh)	Implicit			
-JER	48	29	God		God (Yahweh)	Implicit			
+JER	48	26	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	27	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	28	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	29	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	30	God		God (Yahweh)	Normal			
 JER	48	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	31	God		God (Yahweh)	Implicit			
-JER	48	32	God		God (Yahweh)	Implicit			
-JER	48	33	God		God (Yahweh)	Implicit			
-JER	48	34	God		God (Yahweh)	Implicit			
+JER	48	31	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	32	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	33	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	34	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	35	God		God (Yahweh)	Normal			
 JER	48	35	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	36	God		God (Yahweh)	Implicit			
-JER	48	37	God		God (Yahweh)	Implicit			
+JER	48	36	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	37	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	38	God		God (Yahweh)	Normal			
 JER	48	38	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	39	God		God (Yahweh)	Implicit			
-JER	48	40	God		God (Yahweh)	Implicit			
-JER	48	41	God		God (Yahweh)	Implicit			
-JER	48	42	God		God (Yahweh)	Implicit			
+JER	48	39	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	40	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	41	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	42	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	43	God		God (Yahweh)	Normal			
 JER	48	43	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	48	44	God		God (Yahweh)	Normal			
 JER	48	44	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	48	45	God		God (Yahweh)	Implicit			
-JER	48	46	God		God (Yahweh)	Implicit			
+JER	48	45	God		God (Yahweh)	Implicit			EntireVerse
+JER	48	46	God		God (Yahweh)	Implicit			EntireVerse
 JER	48	47	God		God (Yahweh)	Normal			
 JER	48	47	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	1	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	1	God		God (Yahweh)	Normal			
 JER	49	2	God		God (Yahweh)	Normal			
 JER	49	2	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	3	God		God (Yahweh)	Implicit			
-JER	49	4	God		God (Yahweh)	Implicit			
+JER	49	3	God		God (Yahweh)	Implicit			EntireVerse
+JER	49	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	5	God		God (Yahweh)	Normal			
 JER	49	5	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	6	God		God (Yahweh)	Normal			
 JER	49	6	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	7	God		God (Yahweh)	Normal			
 JER	49	7	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	8	God		God (Yahweh)	Implicit			
-JER	49	9	God		God (Yahweh)	Implicit			
-JER	49	10	God		God (Yahweh)	Implicit			
-JER	49	11	God		God (Yahweh)	Implicit			
+JER	49	8	God		God (Yahweh)	Implicit			EntireVerse
+JER	49	9	God		God (Yahweh)	Implicit			EntireVerse
+JER	49	10	God		God (Yahweh)	Implicit			EntireVerse
+JER	49	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	12	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	12	God		God (Yahweh)	Normal			
 JER	49	13	God		God (Yahweh)	Normal			
 JER	49	13	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	14	God		God (Yahweh)	Normal			
 JER	49	14	ambassador			Hypothetical			
-JER	49	15	God		God (Yahweh)	Implicit			
+JER	49	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	16	God		God (Yahweh)	Normal			
 JER	49	16	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	17	God		God (Yahweh)	Implicit			
+JER	49	17	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	18	God		God (Yahweh)	Normal			
 JER	49	18	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	19	God		God (Yahweh)	Implicit			
+JER	49	19	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	20	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	20	God		God (Yahweh)	Normal			
 JER	49	21	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12208,21 +12208,21 @@ JER	49	21	God		God (Yahweh)	Normal
 JER	49	22	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	22	God		God (Yahweh)	Normal			
 JER	49	23	God		God (Yahweh)	Normal			
-JER	49	24	God		God (Yahweh)	Implicit			
-JER	49	25	God		God (Yahweh)	Implicit			
+JER	49	24	God		God (Yahweh)	Implicit			EntireVerse
+JER	49	25	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	26	God		God (Yahweh)	Normal			
 JER	49	26	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	27	God		God (Yahweh)	Implicit			
+JER	49	27	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	28	God		God (Yahweh)	Normal			
 JER	49	28	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	29	God		God (Yahweh)	Implicit			
+JER	49	29	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	30	God		God (Yahweh)	Normal			
 JER	49	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	31	God		God (Yahweh)	Normal			
 JER	49	31	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	49	32	God		God (Yahweh)	Normal			
 JER	49	32	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	49	33	God		God (Yahweh)	Implicit			
+JER	49	33	God		God (Yahweh)	Implicit			EntireVerse
 JER	49	33	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	49	35	Jeremiah		Jeremiah (Yahweh says)	Normal			
 JER	49	35	God		God (Yahweh)	Normal			
@@ -12236,51 +12236,51 @@ JER	49	39	God		God (Yahweh)	Normal
 JER	49	39	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	2	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	2	God		God (Yahweh)	Normal			
-JER	50	3	God		God (Yahweh)	Implicit			
+JER	50	3	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	3	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	4	God		God (Yahweh)	Normal			
 JER	50	4	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	5	God		God (Yahweh)	Normal			
 JER	50	5	Israel, men of/Judah, people of		children of Israel/children of Judah	Hypothetical			
 JER	50	5	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	6	God		God (Yahweh)	Implicit			
+JER	50	6	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	6	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	7	God		God (Yahweh)	Normal			
 JER	50	7	enemies of Israel		adversaries of God's people	Hypothetical			
 JER	50	7	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	8	God		God (Yahweh)	Implicit			
+JER	50	8	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	8	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	9	God		God (Yahweh)	Implicit			
+JER	50	9	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	9	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	10	God		God (Yahweh)	Normal			
 JER	50	10	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	11	God		God (Yahweh)	Implicit			
+JER	50	11	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	11	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	12	God		God (Yahweh)	Implicit			
+JER	50	12	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	12	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	13	God		God (Yahweh)	Implicit			
+JER	50	13	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	13	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	14	God		God (Yahweh)	Implicit			
+JER	50	14	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	14	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	15	God		God (Yahweh)	Implicit			
+JER	50	15	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	15	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	16	God		God (Yahweh)	Implicit			
+JER	50	16	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	16	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	17	God		God (Yahweh)	Implicit			
+JER	50	17	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	17	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	18	God		God (Yahweh)	Normal			
 JER	50	18	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	19	God		God (Yahweh)	Implicit			
+JER	50	19	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	19	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	20	God		God (Yahweh)	Normal			
 JER	50	20	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	21	God		God (Yahweh)	Normal			
 JER	50	21	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	22	God		God (Yahweh)	Implicit			
+JER	50	22	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	22	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	23	God		God (Yahweh)	Implicit			
+JER	50	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	23	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	24	God		God (Yahweh)	Implicit			
+JER	50	24	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	24	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	25	God		God (Yahweh)	Potential			
 JER	50	25	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12296,7 +12296,7 @@ JER	50	30	God		God (Yahweh)	Normal
 JER	50	30	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	31	God		God (Yahweh)	Normal			
 JER	50	31	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	32	God		God (Yahweh)	Implicit			
+JER	50	32	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	32	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	33	God		God (Yahweh)	Normal			
 JER	50	33	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12304,23 +12304,23 @@ JER	50	34	God		God (Yahweh)	Potential
 JER	50	34	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	50	35	God		God (Yahweh)	Normal			
 JER	50	35	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	36	God		God (Yahweh)	Implicit			
+JER	50	36	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	36	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	37	God		God (Yahweh)	Implicit			
+JER	50	37	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	37	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	38	God		God (Yahweh)	Implicit			
+JER	50	38	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	38	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	39	God		God (Yahweh)	Implicit			
+JER	50	39	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	39	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	40	God		God (Yahweh)	Normal			
 JER	50	40	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	50	41	God		God (Yahweh)	Implicit			
+JER	50	41	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	41	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	42	God		God (Yahweh)	Implicit			
+JER	50	42	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	42	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	43	God		God (Yahweh)	Implicit			
+JER	50	43	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	43	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	50	44	God		God (Yahweh)	Implicit			
+JER	50	44	God		God (Yahweh)	Implicit			EntireVerse
 JER	50	44	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	50	45	God		God (Yahweh)	Potential			
 JER	50	45	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12328,9 +12328,9 @@ JER	50	46	God		God (Yahweh)	Potential
 JER	50	46	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	1	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	1	God		God (Yahweh)	Normal			
-JER	51	2	God		God (Yahweh)	Implicit			
-JER	51	3	God		God (Yahweh)	Implicit			
-JER	51	4	God		God (Yahweh)	Implicit			
+JER	51	2	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	3	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	4	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	5	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	5	God		God (Yahweh)	Potential			
 JER	51	6	Jeremiah		Jeremiah (Yahweh says)	Potential			
@@ -12356,10 +12356,10 @@ JER	51	16	God		God (Yahweh)	Potential
 JER	51	17	God		God (Yahweh)	Potential			
 JER	51	18	God		God (Yahweh)	Potential			
 JER	51	19	God		God (Yahweh)	Potential			
-JER	51	20	God		God (Yahweh)	Implicit			
-JER	51	21	God		God (Yahweh)	Implicit			
-JER	51	22	God		God (Yahweh)	Implicit			
-JER	51	23	God		God (Yahweh)	Implicit			
+JER	51	20	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	21	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	22	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	23	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	24	God		God (Yahweh)	Normal			
 JER	51	24	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	25	God		God (Yahweh)	Normal			
@@ -12382,20 +12382,20 @@ JER	51	35	Jerusalem (personified)			Hypothetical
 JER	51	35	God		God (Yahweh)	Normal			
 JER	51	35	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	36	God		God (Yahweh)	Normal			
-JER	51	37	God		God (Yahweh)	Implicit			
+JER	51	37	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	37	Jeremiah		Jeremiah (Yahweh says)	Alternate			
-JER	51	38	God		God (Yahweh)	Implicit			
+JER	51	38	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	38	Jeremiah		Jeremiah (Yahweh says)	Alternate			
 JER	51	39	God		God (Yahweh)	Normal			
 JER	51	39	Jeremiah		Jeremiah (Yahweh says)	Potential			
-JER	51	40	God		God (Yahweh)	Implicit			
-JER	51	41	God		God (Yahweh)	Implicit			
-JER	51	42	God		God (Yahweh)	Implicit			
-JER	51	43	God		God (Yahweh)	Implicit			
-JER	51	44	God		God (Yahweh)	Implicit			
+JER	51	40	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	41	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	42	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	43	God		God (Yahweh)	Implicit			EntireVerse
+JER	51	44	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	45	God		God (Yahweh)	Potential			
 JER	51	46	God		God (Yahweh)	Potential			
-JER	51	47	God		God (Yahweh)	Implicit			
+JER	51	47	God		God (Yahweh)	Implicit			EntireVerse
 JER	51	48	God		God (Yahweh)	Normal			
 JER	51	48	Jeremiah		Jeremiah (Yahweh says)	Potential			
 JER	51	49	God		God (Yahweh)	Potential			
@@ -12428,27 +12428,27 @@ JER	51	64	Seraiah			Hypothetical			Unspecified
 LAM	1	9	daughter of Zion		daughter of Zion (Jerusalem)	Potential			
 LAM	1	10	God		you (God)	Indirect			
 LAM	1	11	daughter of Zion			Potential			
-LAM	1	12	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	13	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	14	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	15	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	16	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
+LAM	1	12	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	13	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	14	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	15	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	16	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
 # A loose translation (e.g., GNT) could turn the first part of v. 17 into direct speech
 LAM	1	17	daughter of Zion			Potential			
 LAM	1	17	God		God (Yahweh)	Indirect			
-LAM	1	18	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	19	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	20	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	21	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	1	22	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
+LAM	1	18	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	19	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	20	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	21	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	1	22	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
 LAM	2	12	children of Zion (Jerusalem)			Hypothetical			
 LAM	2	15	passers by			Hypothetical			
 LAM	2	16	enemies of God		enemies (scoffing)	Hypothetical			
 LAM	2	18	daughter of Zion		daughter of Zion (Jerusalem)	Potential			
 LAM	2	18	Needs Review			Potential			
-LAM	2	20	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	2	21	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
-LAM	2	22	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			
+LAM	2	20	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	2	21	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
+LAM	2	22	daughter of Zion		daughter of Zion (Jerusalem)	Implicit			EntireVerse
 LAM	3	18	narrator-LAM			Quotation			
 LAM	3	24	narrator-LAM			Quotation			
 LAM	3	42	Jeremiah			Potential			
@@ -12483,27 +12483,27 @@ LAM	4	15	nations		people among the nations	Quotation
 LAM	4	20	narrator-LAM			Quotation			
 EZK	2	1	God		God (voice of one speaking, in vision)	Normal			
 EZK	2	3	God		God (voice of one speaking, in vision)	Normal			
-EZK	2	4	God		God (voice of one speaking, in vision)	Implicit			
-EZK	2	5	God		God (voice of one speaking, in vision)	Implicit			
-EZK	2	6	God		God (voice of one speaking, in vision)	Implicit			
-EZK	2	7	God		God (voice of one speaking, in vision)	Implicit			
-EZK	2	8	God		God (voice of one speaking, in vision)	Implicit			
+EZK	2	4	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	2	5	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	2	6	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	2	7	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	2	8	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
 EZK	3	1	God		God (voice of one speaking, in vision)	Normal			
 EZK	3	3	God		God (voice of one speaking, in vision)	Normal			
 EZK	3	4	God		God (voice of one speaking, in vision)	Normal			
-EZK	3	5	God		God (voice of one speaking, in vision)	Implicit			
-EZK	3	6	God		God (voice of one speaking, in vision)	Implicit			
-EZK	3	7	God		God (voice of one speaking, in vision)	Implicit			
-EZK	3	8	God		God (voice of one speaking, in vision)	Implicit			
-EZK	3	9	God		God (voice of one speaking, in vision)	Implicit			
+EZK	3	5	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	3	6	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	3	7	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	3	8	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
+EZK	3	9	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
 EZK	3	10	God		God (voice of one speaking, in vision)	Normal			
-EZK	3	11	God		God (voice of one speaking, in vision)	Implicit			
+EZK	3	11	God		God (voice of one speaking, in vision)	Implicit			EntireVerse
 EZK	3	12	rumbling sound	loud (thundering)		Potential			
-EZK	3	17	God		God (Yahweh)	Implicit			
-EZK	3	18	God		God (Yahweh)	Implicit			
-EZK	3	19	God		God (Yahweh)	Implicit			
-EZK	3	20	God		God (Yahweh)	Implicit			
-EZK	3	21	God		God (Yahweh)	Implicit			
+EZK	3	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	3	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	3	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	3	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	3	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	3	22	God		God (Yahweh)	Normal			
 # The text in v. 24 indicates that the Spirit is speaking, but in the subsequent verses
 # it transitions back to having God speak. Although a voice change is in one sense warranted,
@@ -12512,120 +12512,120 @@ EZK	3	22	God		God (Yahweh)	Normal
 EZK	3	24	Holy Spirit, the			Alternate			
 EZK	3	24	God		God (the Spirit)	Normal			
 EZK	3	24	Needs Review			Normal			
-EZK	3	25	Needs Review			Implicit			
+EZK	3	25	Needs Review			Implicit			EntireVerse
 EZK	3	25	Holy Spirit, the			Alternate			
 EZK	3	25	God		God (the Lord Yahweh)	Alternate			
-EZK	3	26	Needs Review			Implicit			
+EZK	3	26	Needs Review			Implicit			EntireVerse
 EZK	3	26	Holy Spirit, the			Alternate			
 EZK	3	26	God		God (the Lord Yahweh)	Alternate			
-EZK	3	27	Needs Review			Implicit			
+EZK	3	27	Needs Review			Implicit			EntireVerse
 EZK	3	27	Holy Spirit, the			Alternate			
 EZK	3	27	God		God (the Lord Yahweh)	Alternate			
 EZK	3	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	4	1	God		God (Yahweh)	Implicit			
+EZK	4	1	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	1	Holy Spirit, the			Alternate			
-EZK	4	2	God		God (Yahweh)	Implicit			
+EZK	4	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	2	Holy Spirit, the			Alternate			
-EZK	4	3	God		God (Yahweh)	Implicit			
+EZK	4	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	3	Holy Spirit, the			Alternate			
-EZK	4	4	God		God (Yahweh)	Implicit			
+EZK	4	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	4	Holy Spirit, the			Alternate			
-EZK	4	5	God		God (Yahweh)	Implicit			
+EZK	4	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	5	Holy Spirit, the			Alternate			
-EZK	4	6	God		God (Yahweh)	Implicit			
+EZK	4	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	6	Holy Spirit, the			Alternate			
-EZK	4	7	God		God (Yahweh)	Implicit			
+EZK	4	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	7	Holy Spirit, the			Alternate			
-EZK	4	8	God		God (Yahweh)	Implicit			
+EZK	4	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	8	Holy Spirit, the			Alternate			
-EZK	4	9	God		God (Yahweh)	Implicit			
+EZK	4	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	9	Holy Spirit, the			Alternate			
-EZK	4	10	God		God (Yahweh)	Implicit			
+EZK	4	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	10	Holy Spirit, the			Alternate			
-EZK	4	11	God		God (Yahweh)	Implicit			
+EZK	4	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	11	Holy Spirit, the			Alternate			
-EZK	4	12	God		God (Yahweh)	Implicit			
+EZK	4	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	4	12	Holy Spirit, the			Alternate			
 EZK	4	13	God		God (Yahweh)	Normal			
 EZK	4	14	narrator-EZK			Quotation			
 EZK	4	15	God		God (Yahweh)	Normal			
 EZK	4	16	God		God (Yahweh)	Normal			
-EZK	4	17	God		God (Yahweh)	Implicit			
-EZK	5	1	God		God (Yahweh)	Implicit			
-EZK	5	2	God		God (Yahweh)	Implicit			
-EZK	5	3	God		God (Yahweh)	Implicit			
-EZK	5	4	God		God (Yahweh)	Implicit			
+EZK	4	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	1	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	2	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	5	5	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	5	5	God		God (Yahweh)	Normal			
-EZK	5	6	God		God (Yahweh)	Implicit			
+EZK	5	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	5	7	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	5	7	God		God (Yahweh)	Normal			
 EZK	5	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	5	8	God		God (Yahweh)	Normal			
-EZK	5	9	God		God (Yahweh)	Implicit			
-EZK	5	10	God		God (Yahweh)	Implicit			
+EZK	5	9	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	5	11	God		God (Yahweh)	Normal			
 EZK	5	11	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	5	12	God		God (Yahweh)	Implicit			
-EZK	5	13	God		God (Yahweh)	Implicit			
-EZK	5	14	God		God (Yahweh)	Implicit			
-EZK	5	15	God		God (Yahweh)	Implicit			
-EZK	5	16	God		God (Yahweh)	Implicit			
-EZK	5	17	God		God (Yahweh)	Implicit			
-EZK	6	2	God		God (Yahweh)	Implicit			
+EZK	5	12	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	5	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	6	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	6	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	6	3	God		God (Yahweh)	Normal			
-EZK	6	4	God		God (Yahweh)	Implicit			
+EZK	6	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	5	God		God (Yahweh)	Implicit			
+EZK	6	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	6	God		God (Yahweh)	Implicit			
+EZK	6	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	7	God		God (Yahweh)	Implicit			
+EZK	6	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	8	God		God (Yahweh)	Implicit			
+EZK	6	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	9	God		God (Yahweh)	Implicit			
+EZK	6	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	10	God		God (Yahweh)	Implicit			
+EZK	6	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	6	11	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	6	11	God		God (Yahweh)	Normal			
-EZK	6	12	God		God (Yahweh)	Implicit			
+EZK	6	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	13	God		God (Yahweh)	Implicit			
+EZK	6	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	6	14	God		God (Yahweh)	Implicit			
+EZK	6	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	6	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	7	2	God		God (Yahweh)	Implicit			
+EZK	7	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	7	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	7	3	God		God (Yahweh)	Implicit			
-EZK	7	4	God		God (Yahweh)	Implicit			
+EZK	7	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	7	5	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	7	5	God		God (Yahweh)	Normal			
-EZK	7	6	God		God (Yahweh)	Implicit			
-EZK	7	7	God		God (Yahweh)	Implicit			
-EZK	7	8	God		God (Yahweh)	Implicit			
-EZK	7	9	God		God (Yahweh)	Implicit			
-EZK	7	10	God		God (Yahweh)	Implicit			
-EZK	7	11	God		God (Yahweh)	Implicit			
-EZK	7	12	God		God (Yahweh)	Implicit			
-EZK	7	13	God		God (Yahweh)	Implicit			
-EZK	7	14	God		God (Yahweh)	Implicit			
-EZK	7	15	God		God (Yahweh)	Implicit			
-EZK	7	16	God		God (Yahweh)	Implicit			
-EZK	7	17	God		God (Yahweh)	Implicit			
-EZK	7	18	God		God (Yahweh)	Implicit			
-EZK	7	19	God		God (Yahweh)	Implicit			
-EZK	7	20	God		God (Yahweh)	Implicit			
-EZK	7	21	God		God (Yahweh)	Implicit			
-EZK	7	22	God		God (Yahweh)	Implicit			
-EZK	7	23	God		God (Yahweh)	Implicit			
-EZK	7	24	God		God (Yahweh)	Implicit			
-EZK	7	25	God		God (Yahweh)	Implicit			
-EZK	7	26	God		God (Yahweh)	Implicit			
-EZK	7	27	God		God (Yahweh)	Implicit			
+EZK	7	6	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	8	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	9	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	10	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	11	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	12	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	21	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	22	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	23	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	24	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	25	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	26	God		God (Yahweh)	Implicit			EntireVerse
+EZK	7	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	8	5	figure like that of a man (in vision)			Normal	Jesus		
 EZK	8	5	God		God (Yahweh) (in vision)	Normal			
 EZK	8	5	Holy Spirit, the		Holy Spirit, the (in vision)	Normal			
@@ -12659,7 +12659,7 @@ EZK	8	17	God		God (Yahweh) (in vision)	Normal
 EZK	8	17	Holy Spirit, the		Holy Spirit, the (in vision)	Normal			
 EZK	8	17	Needs Review			Normal			
 EZK	8	18	figure like that of a man (in vision)			Alternate	Jesus		
-EZK	8	18	God		God (Yahweh) (in vision)	Implicit			
+EZK	8	18	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	8	18	Holy Spirit, the		Holy Spirit, the (in vision)	Alternate			
 EZK	8	18	Needs Review			Alternate			
 EZK	9	1	figure like that of a man (in vision)	loud voice		Normal	Jesus		
@@ -12672,7 +12672,7 @@ EZK	9	6	God		God (Yahweh) (in vision)	Normal
 EZK	9	7	God		God (Yahweh) (in vision)	Normal			
 EZK	9	8	narrator-EZK			Quotation			
 EZK	9	9	God		God (Yahweh) (in vision)	Normal			
-EZK	9	10	God		God (Yahweh) (in vision)	Implicit			
+EZK	9	10	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	9	11	man in linen with writing kit (in vision)			Normal			
 EZK	10	2	God		God (Yahweh) (in vision)	Normal			
 EZK	10	6	God		God (Yahweh) (in vision)	Normal			
@@ -12682,41 +12682,41 @@ EZK	10	13	Needs Review			Potential
 EZK	11	2	God		God (Yahweh) (in vision)	Normal			
 EZK	11	2	Holy Spirit, the		Holy Spirit, the (in vision)	Normal			
 EZK	11	2	Needs Review			Normal			
-EZK	11	3	God		God (Yahweh) (in vision)	Implicit			
+EZK	11	3	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	11	3	Holy Spirit, the		Holy Spirit, the (in vision)	Alternate			
 EZK	11	3	Needs Review			Alternate			
-EZK	11	4	God		God (Yahweh) (in vision)	Implicit			
+EZK	11	4	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	11	4	Holy Spirit, the		Holy Spirit, the (in vision)	Alternate			
 EZK	11	4	Needs Review			Alternate			
 EZK	11	5	God		God (Yahweh) (in vision)	Normal			
 EZK	11	5	Holy Spirit, the		Holy Spirit, the (in vision)	Normal			
 EZK	11	5	Needs Review			Alternate			
-EZK	11	6	God		God (Yahweh) (in vision)	Implicit			
+EZK	11	6	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	11	6	Holy Spirit, the		Holy Spirit, the (in vision)	Alternate			
 EZK	11	7	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	11	7	God		God (Yahweh) (in vision)	Normal			
 EZK	11	8	God		God (Yahweh) (in vision)	Normal			
 EZK	11	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	11	9	God		God (Yahweh)	Implicit			
-EZK	11	10	God		God (Yahweh)	Implicit			
-EZK	11	11	God		God (Yahweh)	Implicit			
-EZK	11	12	God		God (Yahweh)	Implicit			
+EZK	11	9	God		God (Yahweh)	Implicit			EntireVerse
+EZK	11	10	God		God (Yahweh)	Implicit			EntireVerse
+EZK	11	11	God		God (Yahweh)	Implicit			EntireVerse
+EZK	11	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	11	13	narrator-EZK			Quotation			
-EZK	11	15	God		God (Yahweh)	Implicit			
+EZK	11	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	11	16	God		God (Yahweh)	Normal			
 EZK	11	16	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	11	17	God		God (Yahweh)	Normal			
 EZK	11	17	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	11	18	God		God (Yahweh)	Implicit			
-EZK	11	19	God		God (Yahweh)	Implicit			
-EZK	11	20	God		God (Yahweh)	Implicit			
+EZK	11	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	11	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	11	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	11	21	God		God (Yahweh)	Normal			
 EZK	11	21	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	12	2	God		God (Yahweh)	Implicit			
-EZK	12	3	God		God (Yahweh)	Implicit			
-EZK	12	4	God		God (Yahweh)	Implicit			
-EZK	12	5	God		God (Yahweh)	Implicit			
-EZK	12	6	God		God (Yahweh)	Implicit			
+EZK	12	2	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	5	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	12	9	God		God (Yahweh)	Normal			
 EZK	12	9	Israel, men of		house of Israel (rebellious)	Quotation			
 EZK	12	10	God		God (Yahweh)	Normal			
@@ -12725,19 +12725,19 @@ EZK	12	11	God		God (Yahweh)	Normal
 EZK	12	11	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	12	12	God		God (Yahweh)	Normal			
 EZK	12	12	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	12	13	God		God (Yahweh)	Implicit			
-EZK	12	14	God		God (Yahweh)	Implicit			
-EZK	12	15	God		God (Yahweh)	Implicit			
-EZK	12	16	God		God (Yahweh)	Implicit			
-EZK	12	18	God		God (Yahweh)	Implicit			
+EZK	12	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	12	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	12	19	God		God (Yahweh)	Normal			
 EZK	12	19	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	12	20	God		God (Yahweh)	Implicit			
+EZK	12	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	12	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	12	22	God		God (Yahweh)	Implicit			
+EZK	12	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	12	23	God		God (Yahweh)	Normal			
 EZK	12	23	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	12	24	God		God (Yahweh)	Implicit			
+EZK	12	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	12	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	12	25	God		God (Yahweh)	Normal			
 EZK	12	25	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -12748,269 +12748,269 @@ EZK	12	28	Ezekiel		Ezekiel (Yahweh says)	Normal
 EZK	13	2	God		God (Yahweh)	Normal			
 EZK	13	3	God		God (Yahweh)	Normal			
 EZK	13	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	13	4	God		God (Yahweh)	Implicit			
+EZK	13	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	5	God		God (Yahweh)	Implicit			
+EZK	13	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	6	God		God (Yahweh)	Implicit			
+EZK	13	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	7	God		God (Yahweh)	Implicit			
+EZK	13	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	13	8	God		God (Yahweh)	Normal			
 EZK	13	8	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	13	9	God		God (Yahweh)	Implicit			
+EZK	13	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	10	God		God (Yahweh)	Implicit			
+EZK	13	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	11	God		God (Yahweh)	Implicit			
+EZK	13	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	12	God		God (Yahweh)	Implicit			
+EZK	13	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	13	13	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	13	13	God		God (Yahweh)	Normal			
-EZK	13	14	God		God (Yahweh)	Implicit			
+EZK	13	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	15	God		God (Yahweh)	Implicit			
+EZK	13	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	13	16	God		God (Yahweh)	Normal			
 EZK	13	16	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	13	17	God		God (Yahweh)	Implicit			
+EZK	13	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	18	God		God (Yahweh)	Normal			
 EZK	13	18	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	13	19	God		God (Yahweh)	Implicit			
+EZK	13	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	13	20	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	13	20	God		God (Yahweh)	Normal			
-EZK	13	21	God		God (Yahweh)	Implicit			
+EZK	13	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	22	God		God (Yahweh)	Implicit			
+EZK	13	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	13	23	God		God (Yahweh)	Implicit			
+EZK	13	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	13	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	14	3	God		God (Yahweh)	Implicit			
+EZK	14	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	4	God		God (Yahweh)	Normal			
 EZK	14	4	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	14	5	God		God (Yahweh)	Implicit			
+EZK	14	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	14	6	God		God (Yahweh)	Normal			
 EZK	14	6	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	14	7	God		God (Yahweh)	Implicit			
+EZK	14	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	14	8	God		God (Yahweh)	Implicit			
+EZK	14	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	14	9	God		God (Yahweh)	Implicit			
+EZK	14	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	14	10	God		God (Yahweh)	Implicit			
+EZK	14	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	14	11	God		God (Yahweh)	Normal			
 EZK	14	11	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	14	13	God		God (Yahweh)	Implicit			
+EZK	14	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	14	God		God (Yahweh)	Normal			
 EZK	14	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	14	15	God		God (Yahweh)	Implicit			
+EZK	14	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	16	God		God (Yahweh)	Normal			
 EZK	14	16	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	14	17	God		God (Yahweh)	Implicit			
+EZK	14	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	18	God		God (Yahweh)	Normal			
 EZK	14	18	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	14	19	God		God (Yahweh)	Implicit			
+EZK	14	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	20	God		God (Yahweh)	Normal			
 EZK	14	20	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	14	21	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	14	21	God		God (Yahweh)	Normal			
-EZK	14	22	God		God (Yahweh)	Implicit			
+EZK	14	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	14	23	God		God (Yahweh)	Normal			
 EZK	14	23	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	15	2	God		God (Yahweh)	Implicit			
-EZK	15	3	God		God (Yahweh)	Implicit			
-EZK	15	4	God		God (Yahweh)	Implicit			
-EZK	15	5	God		God (Yahweh)	Implicit			
+EZK	15	2	God		God (Yahweh)	Implicit			EntireVerse
+EZK	15	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	15	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	15	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	15	6	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	15	6	God		God (Yahweh)	Normal			
-EZK	15	7	God		God (Yahweh)	Implicit			
+EZK	15	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	15	8	God		God (Yahweh)	Normal			
 EZK	15	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	2	God		God (Yahweh)	Implicit			
+EZK	16	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	3	God		God (Yahweh)	Normal			
 EZK	16	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	16	4	God		God (Yahweh)	Implicit			
+EZK	16	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	5	God		God (Yahweh)	Implicit			
+EZK	16	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	6	God		God (Yahweh)	Implicit			
+EZK	16	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	7	God		God (Yahweh)	Implicit			
+EZK	16	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	8	God		God (Yahweh)	Normal			
 EZK	16	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	9	God		God (Yahweh)	Implicit			
+EZK	16	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	10	God		God (Yahweh)	Implicit			
+EZK	16	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	11	God		God (Yahweh)	Implicit			
+EZK	16	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	12	God		God (Yahweh)	Implicit			
+EZK	16	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	13	God		God (Yahweh)	Implicit			
+EZK	16	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	14	God		God (Yahweh)	Normal			
 EZK	16	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	15	God		God (Yahweh)	Implicit			
+EZK	16	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	16	God		God (Yahweh)	Implicit			
+EZK	16	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	17	God		God (Yahweh)	Implicit			
+EZK	16	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	18	God		God (Yahweh)	Implicit			
+EZK	16	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	18	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	19	God		God (Yahweh)	Normal			
 EZK	16	19	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	20	God		God (Yahweh)	Implicit			
+EZK	16	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	21	God		God (Yahweh)	Implicit			
+EZK	16	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	22	God		God (Yahweh)	Implicit			
+EZK	16	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	23	God		God (Yahweh)	Normal			
 EZK	16	23	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	24	God		God (Yahweh)	Implicit			
+EZK	16	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	25	God		God (Yahweh)	Implicit			
+EZK	16	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	26	God		God (Yahweh)	Implicit			
+EZK	16	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	27	God		God (Yahweh)	Implicit			
+EZK	16	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	28	God		God (Yahweh)	Implicit			
+EZK	16	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	29	God		God (Yahweh)	Implicit			
+EZK	16	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	30	God		God (Yahweh)	Normal			
 EZK	16	30	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	31	God		God (Yahweh)	Implicit			
+EZK	16	31	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	31	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	32	God		God (Yahweh)	Implicit			
+EZK	16	32	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	32	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	33	God		God (Yahweh)	Implicit			
+EZK	16	33	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	33	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	34	God		God (Yahweh)	Implicit			
+EZK	16	34	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	34	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	35	God		God (Yahweh)	Potential			
 EZK	16	35	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	16	36	God		God (Yahweh)	Normal			
 EZK	16	36	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	37	God		God (Yahweh)	Implicit			
+EZK	16	37	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	37	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	38	God		God (Yahweh)	Implicit			
+EZK	16	38	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	38	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	39	God		God (Yahweh)	Implicit			
+EZK	16	39	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	39	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	40	God		God (Yahweh)	Implicit			
+EZK	16	40	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	40	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	41	God		God (Yahweh)	Implicit			
+EZK	16	41	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	41	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	42	God		God (Yahweh)	Implicit			
+EZK	16	42	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	42	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	43	God		God (Yahweh)	Normal			
 EZK	16	43	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	44	God		God (Yahweh)	Implicit			
+EZK	16	44	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	44	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	45	God		God (Yahweh)	Implicit			
+EZK	16	45	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	45	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	46	God		God (Yahweh)	Implicit			
+EZK	16	46	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	47	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	47	God		God (Yahweh)	Implicit			
+EZK	16	47	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	48	God		God (Yahweh)	Normal			
 EZK	16	48	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	16	49	God		God (Yahweh)	Implicit			
+EZK	16	49	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	49	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	50	God		God (Yahweh)	Implicit			
+EZK	16	50	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	50	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	51	God		God (Yahweh)	Implicit			
+EZK	16	51	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	51	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	52	God		God (Yahweh)	Implicit			
+EZK	16	52	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	52	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	53	God		God (Yahweh)	Implicit			
+EZK	16	53	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	53	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	54	God		God (Yahweh)	Implicit			
+EZK	16	54	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	54	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	55	God		God (Yahweh)	Implicit			
+EZK	16	55	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	55	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	56	God		God (Yahweh)	Implicit			
+EZK	16	56	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	56	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	57	God		God (Yahweh)	Implicit			
+EZK	16	57	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	57	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	58	God		God (Yahweh)	Normal			
 EZK	16	58	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	16	59	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	16	59	God		God (Yahweh)	Normal			
-EZK	16	60	God		God (Yahweh)	Implicit			
+EZK	16	60	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	60	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	61	God		God (Yahweh)	Implicit			
+EZK	16	61	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	61	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	16	62	God		God (Yahweh)	Implicit			
+EZK	16	62	God		God (Yahweh)	Implicit			EntireVerse
 EZK	16	62	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	16	63	God		God (Yahweh)	Normal			
 EZK	16	63	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	17	2	God		God (Yahweh)	Implicit			
+EZK	17	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	3	God		God (Yahweh)	Normal			
 EZK	17	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	17	4	God		God (Yahweh)	Implicit			
-EZK	17	5	God		God (Yahweh)	Implicit			
-EZK	17	6	God		God (Yahweh)	Implicit			
-EZK	17	7	God		God (Yahweh)	Implicit			
-EZK	17	8	God		God (Yahweh)	Implicit			
+EZK	17	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	5	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	6	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	9	God		God (Yahweh)	Normal			
 EZK	17	9	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	17	10	God		God (Yahweh)	Implicit			
+EZK	17	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	12	God		God (Yahweh)	Normal			
 EZK	17	12	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	17	13	God		God (Yahweh)	Implicit			
+EZK	17	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	17	14	God		God (Yahweh)	Implicit			
+EZK	17	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	17	15	God		God (Yahweh)	Implicit			
+EZK	17	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	17	16	God		God (Yahweh)	Normal			
 EZK	17	16	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	17	17	God		God (Yahweh)	Implicit			
-EZK	17	18	God		God (Yahweh)	Implicit			
+EZK	17	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	19	God		God (Yahweh)	Normal			
 EZK	17	19	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	17	20	God		God (Yahweh)	Implicit			
-EZK	17	21	God		God (Yahweh)	Implicit			
+EZK	17	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	17	22	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	17	22	God		God (Yahweh)	Normal			
-EZK	17	23	God		God (Yahweh)	Implicit			
-EZK	17	24	God		God (Yahweh)	Implicit			
-EZK	18	2	God		God (Yahweh)	Implicit			
+EZK	17	23	God		God (Yahweh)	Implicit			EntireVerse
+EZK	17	24	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	2	saying (proverb) about sour grapes			Hypothetical			
 EZK	18	3	God		God (Yahweh)	Normal			
 EZK	18	3	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	18	4	God		God (Yahweh)	Implicit			
-EZK	18	5	God		God (Yahweh)	Implicit			
-EZK	18	6	God		God (Yahweh)	Implicit			
-EZK	18	7	God		God (Yahweh)	Implicit			
-EZK	18	8	God		God (Yahweh)	Implicit			
+EZK	18	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	5	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	6	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	9	God		God (Yahweh)	Normal			
 EZK	18	9	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	18	10	God		God (Yahweh)	Implicit			
-EZK	18	11	God		God (Yahweh)	Implicit			
-EZK	18	12	God		God (Yahweh)	Implicit			
-EZK	18	13	God		God (Yahweh)	Implicit			
-EZK	18	14	God		God (Yahweh)	Implicit			
-EZK	18	15	God		God (Yahweh)	Implicit			
-EZK	18	16	God		God (Yahweh)	Implicit			
-EZK	18	17	God		God (Yahweh)	Implicit			
-EZK	18	18	God		God (Yahweh)	Implicit			
+EZK	18	10	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	11	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	12	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	19	God		God (Yahweh)	Normal			
 EZK	18	19	you (hypothetical)			Hypothetical			
-EZK	18	20	God		God (Yahweh)	Implicit			
-EZK	18	21	God		God (Yahweh)	Implicit			
-EZK	18	22	God		God (Yahweh)	Implicit			
+EZK	18	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	21	God		God (Yahweh)	Implicit			EntireVerse
+EZK	18	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	23	God		God (Yahweh)	Normal			
 EZK	18	23	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	18	24	God		God (Yahweh)	Implicit			
+EZK	18	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	25	God		God (Yahweh)	Normal			
 EZK	18	25	you (hypothetical)			Hypothetical			
 EZK	18	25	Israel		you (Israel - see v. 29)	Hypothetical			
@@ -13021,96 +13021,96 @@ EZK	18	29	God		God (Yahweh)	Normal
 EZK	18	29	Israel		house of Israel	Hypothetical			
 EZK	18	30	God		God (Yahweh)	Normal			
 EZK	18	30	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	18	31	God		God (Yahweh)	Implicit			
+EZK	18	31	God		God (Yahweh)	Implicit			EntireVerse
 EZK	18	32	God		God (Yahweh)	Normal			
 EZK	18	32	Ezekiel		Ezekiel (Yahweh says)	Potential			
 # 19:1 is implicitly attributed to God, regardless of whether there is an opening quote. From verse 2b-14b, it could be either God or
 # Ezekiel speaking the words of the lament. FCBH has God speaak it and also includes the "This is a lament" line at the end of 19:14.
 # However, some translations clearly treat it more as a parenthetical aside or scribal note, in which case it should more properly be
 # spoken by the narrator.
-EZK	19	1	God		God (Yahweh)	Implicit			
-EZK	19	2	God	lament	God (Yahweh)	Implicit			
+EZK	19	1	God		God (Yahweh)	Implicit			EntireVerse
+EZK	19	2	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	2	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	3	God	lament	God (Yahweh)	Implicit			
+EZK	19	3	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	3	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	4	God	lament	God (Yahweh)	Implicit			
+EZK	19	4	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	4	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	5	God	lament	God (Yahweh)	Implicit			
+EZK	19	5	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	5	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	6	God	lament	God (Yahweh)	Implicit			
+EZK	19	6	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	6	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	7	God	lament	God (Yahweh)	Implicit			
+EZK	19	7	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	7	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	8	God	lament	God (Yahweh)	Implicit			
+EZK	19	8	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	8	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	9	God	lament	God (Yahweh)	Implicit			
+EZK	19	9	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	9	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	10	God	lament	God (Yahweh)	Implicit			
+EZK	19	10	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	10	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	11	God	lament	God (Yahweh)	Implicit			
+EZK	19	11	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	11	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	12	God	lament	God (Yahweh)	Implicit			
+EZK	19	12	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	12	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	19	13	God	lament	God (Yahweh)	Implicit			
+EZK	19	13	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	19	13	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
 EZK	19	14	God	lament	God (Yahweh)	Potential			
 EZK	19	14	God	instructing	God (Yahweh)	Potential			
 EZK	19	14	Ezekiel	lament	Ezekiel (Yahweh says)	Potential			
 EZK	19	14	Ezekiel	instructing	Ezekiel (Yahweh says)	Potential			
-EZK	19	14	Needs Review			Implicit			
+EZK	19	14	Needs Review			Implicit			EntireVerse
 EZK	20	3	God		God (Yahweh)	Normal			
 EZK	20	3	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	4	God		God (Yahweh)	Implicit			
+EZK	20	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	5	God		God (Yahweh)	Normal			
 EZK	20	5	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	6	God		God (Yahweh)	Implicit			
+EZK	20	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	7	God		God (Yahweh)	Implicit			
+EZK	20	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	8	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	20	8	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	20	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	9	God		God (Yahweh)	Implicit			
+EZK	20	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	10	God		God (Yahweh)	Implicit			
+EZK	20	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	11	God		God (Yahweh)	Implicit			
+EZK	20	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	12	God		God (Yahweh)	Implicit			
+EZK	20	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	13	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	20	13	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	20	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	14	God		God (Yahweh)	Implicit			
+EZK	20	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	15	God		God (Yahweh)	Implicit			
+EZK	20	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	16	God		God (Yahweh)	Implicit			
+EZK	20	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	17	God		God (Yahweh)	Implicit			
+EZK	20	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	18	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	20	18	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	20	18	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	19	God		God (Yahweh)	Implicit			
+EZK	20	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	20	God		God (Yahweh)	Implicit			
+EZK	20	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	21	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	20	21	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	20	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	22	God		God (Yahweh)	Implicit			
+EZK	20	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	23	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	20	23	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	20	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	24	God		God (Yahweh)	Implicit			
+EZK	20	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	25	God		God (Yahweh)	Implicit			
+EZK	20	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	26	God		God (Yahweh)	Implicit			
+EZK	20	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	27	God		God (Yahweh)	Normal			
 EZK	20	27	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	28	God		God (Yahweh)	Implicit			
+EZK	20	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	29	God		God (Yahweh)	Implicit			
+EZK	20	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	30	God		God (Yahweh)	Normal			
 EZK	20	30	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -13120,220 +13120,220 @@ EZK	20	32	God		God (Yahweh)	Normal
 EZK	20	32	you (hypothetical)			Hypothetical			
 EZK	20	33	God		God (Yahweh)	Normal			
 EZK	20	33	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	34	God		God (Yahweh)	Implicit			
+EZK	20	34	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	34	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	35	God		God (Yahweh)	Implicit			
+EZK	20	35	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	35	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	36	God		God (Yahweh)	Normal			
 EZK	20	36	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	37	God		God (Yahweh)	Implicit			
+EZK	20	37	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	37	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	38	God		God (Yahweh)	Implicit			
+EZK	20	38	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	38	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	39	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	20	39	God		God (Yahweh)	Normal			
 EZK	20	40	God		God (Yahweh)	Normal			
 EZK	20	40	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	41	God		God (Yahweh)	Implicit			
+EZK	20	41	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	41	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	42	God		God (Yahweh)	Implicit			
+EZK	20	42	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	42	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	20	43	God		God (Yahweh)	Implicit			
+EZK	20	43	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	43	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	20	44	God		God (Yahweh)	Normal			
 EZK	20	44	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	20	46	God		God (Yahweh)	Implicit			
+EZK	20	46	God		God (Yahweh)	Implicit			EntireVerse
 EZK	20	47	God		God (Yahweh)	Normal			
 EZK	20	47	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	20	48	God		God (Yahweh)	Normal			
 EZK	20	49	narrator-EZK			Quotation			
 EZK	20	49	Israel		they	Hypothetical			
-EZK	21	2	God		God (Yahweh)	Implicit			
+EZK	21	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	3	God		God (Yahweh)	Normal			
 EZK	21	3	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	21	4	God		God (Yahweh)	Implicit			
+EZK	21	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	5	God		God (Yahweh)	Implicit			
+EZK	21	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	6	God		God (Yahweh)	Implicit			
+EZK	21	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	7	God		God (Yahweh)	Normal			
 EZK	21	7	Israel		they	Hypothetical			
 EZK	21	7	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	21	9	God		God (Yahweh)	Normal			
 EZK	21	9	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	21	10	God		God (Yahweh)	Implicit			
+EZK	21	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	11	God		God (Yahweh)	Implicit			
+EZK	21	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	12	God		God (Yahweh)	Implicit			
+EZK	21	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	21	13	God		God (Yahweh)	Normal			
 EZK	21	13	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	21	14	God		God (Yahweh)	Implicit			
-EZK	21	15	God		God (Yahweh)	Implicit			
-EZK	21	16	God		God (Yahweh)	Implicit			
-EZK	21	17	God		God (Yahweh)	Implicit			
-EZK	21	19	God		God (Yahweh)	Implicit			
-EZK	21	20	God		God (Yahweh)	Implicit			
-EZK	21	21	God		God (Yahweh)	Implicit			
-EZK	21	22	God		God (Yahweh)	Implicit			
-EZK	21	23	God		God (Yahweh)	Implicit			
+EZK	21	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	21	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	22	God		God (Yahweh)	Implicit			EntireVerse
+EZK	21	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	24	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	21	24	God		God (Yahweh)	Normal			
-EZK	21	25	God		God (Yahweh)	Implicit			
+EZK	21	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	21	26	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	21	26	God		God (Yahweh)	Normal			
-EZK	21	27	God		God (Yahweh)	Implicit			
+EZK	21	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	21	28	God		God (Yahweh)	Normal			
 EZK	21	28	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	21	29	God		God (Yahweh)	Implicit			
+EZK	21	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	30	God		God (Yahweh)	Implicit			
+EZK	21	30	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	30	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	31	God		God (Yahweh)	Implicit			
+EZK	21	31	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	31	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	21	32	God		God (Yahweh)	Implicit			
+EZK	21	32	God		God (Yahweh)	Implicit			EntireVerse
 EZK	21	32	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	2	God		God (Yahweh)	Implicit			
+EZK	22	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	3	God		God (Yahweh)	Normal			
 EZK	22	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	22	4	God		God (Yahweh)	Implicit			
+EZK	22	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	5	God		God (Yahweh)	Implicit			
+EZK	22	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	6	God		God (Yahweh)	Implicit			
+EZK	22	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	7	God		God (Yahweh)	Implicit			
+EZK	22	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	8	God		God (Yahweh)	Implicit			
+EZK	22	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	9	God		God (Yahweh)	Implicit			
+EZK	22	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	10	God		God (Yahweh)	Implicit			
+EZK	22	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	11	God		God (Yahweh)	Implicit			
+EZK	22	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	22	12	God		God (Yahweh)	Normal			
 EZK	22	12	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	22	13	God		God (Yahweh)	Implicit			
-EZK	22	14	God		God (Yahweh)	Implicit			
-EZK	22	15	God		God (Yahweh)	Implicit			
-EZK	22	16	God		God (Yahweh)	Implicit			
-EZK	22	18	God		God (Yahweh)	Implicit			
+EZK	22	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	22	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	22	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	22	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	22	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	19	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	22	19	God		God (Yahweh)	Normal			
-EZK	22	20	God		God (Yahweh)	Implicit			
+EZK	22	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	21	God		God (Yahweh)	Implicit			
+EZK	22	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	22	God		God (Yahweh)	Implicit			
+EZK	22	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	22	24	God		God (Yahweh)	Normal			
 EZK	22	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	25	God		God (Yahweh)	Implicit			
+EZK	22	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	26	God		God (Yahweh)	Implicit			
+EZK	22	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	27	God		God (Yahweh)	Implicit			
+EZK	22	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	28	God		God (Yahweh)	Implicit			
+EZK	22	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	22	28	false prophets			Hypothetical			
-EZK	22	29	God		God (Yahweh)	Implicit			
+EZK	22	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	22	30	God		God (Yahweh)	Implicit			
+EZK	22	30	God		God (Yahweh)	Implicit			EntireVerse
 EZK	22	30	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	22	31	God		God (Yahweh)	Normal			
-EZK	23	2	God		God (Yahweh)	Implicit			
-EZK	23	3	God		God (Yahweh)	Implicit			
-EZK	23	4	God		God (Yahweh)	Implicit			
-EZK	23	5	God		God (Yahweh)	Implicit			
-EZK	23	6	God		God (Yahweh)	Implicit			
-EZK	23	7	God		God (Yahweh)	Implicit			
-EZK	23	8	God		God (Yahweh)	Implicit			
-EZK	23	9	God		God (Yahweh)	Implicit			
-EZK	23	10	God		God (Yahweh)	Implicit			
-EZK	23	11	God		God (Yahweh)	Implicit			
-EZK	23	12	God		God (Yahweh)	Implicit			
-EZK	23	13	God		God (Yahweh)	Implicit			
-EZK	23	14	God		God (Yahweh)	Implicit			
-EZK	23	15	God		God (Yahweh)	Implicit			
-EZK	23	16	God		God (Yahweh)	Implicit			
-EZK	23	17	God		God (Yahweh)	Implicit			
-EZK	23	18	God		God (Yahweh)	Implicit			
-EZK	23	19	God		God (Yahweh)	Implicit			
-EZK	23	20	God		God (Yahweh)	Implicit			
-EZK	23	21	God		God (Yahweh)	Implicit			
+EZK	23	2	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	5	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	6	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	8	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	9	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	10	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	11	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	12	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	22	God		God (Yahweh)	Normal			
 EZK	23	22	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	23	23	God		God (Yahweh)	Implicit			
+EZK	23	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	24	God		God (Yahweh)	Implicit			
+EZK	23	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	25	God		God (Yahweh)	Implicit			
+EZK	23	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	26	God		God (Yahweh)	Implicit			
+EZK	23	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	27	God		God (Yahweh)	Implicit			
+EZK	23	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	23	28	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	23	28	God		God (Yahweh)	Normal			
-EZK	23	29	God		God (Yahweh)	Implicit			
+EZK	23	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	30	God		God (Yahweh)	Implicit			
+EZK	23	30	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	30	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	23	31	God		God (Yahweh)	Implicit			
+EZK	23	31	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	31	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	23	32	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	23	32	God		God (Yahweh)	Normal			
-EZK	23	33	God		God (Yahweh)	Implicit			
+EZK	23	33	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	33	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	23	34	God		God (Yahweh)	Normal			
 EZK	23	34	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	23	35	God		God (Yahweh)	Normal			
 EZK	23	36	God		God (Yahweh)	Normal			
-EZK	23	37	God		God (Yahweh)	Implicit			
-EZK	23	38	God		God (Yahweh)	Implicit			
-EZK	23	39	God		God (Yahweh)	Implicit			
-EZK	23	40	God		God (Yahweh)	Implicit			
-EZK	23	41	God		God (Yahweh)	Implicit			
-EZK	23	42	God		God (Yahweh)	Implicit			
-EZK	23	43	God		God (Yahweh)	Implicit			
-EZK	23	44	God		God (Yahweh)	Implicit			
-EZK	23	45	God		God (Yahweh)	Implicit			
+EZK	23	37	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	38	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	39	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	40	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	41	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	42	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	43	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	44	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	45	God		God (Yahweh)	Implicit			EntireVerse
 EZK	23	46	God		God (Yahweh)	Normal			
-EZK	23	47	God		God (Yahweh)	Implicit			
-EZK	23	48	God		God (Yahweh)	Implicit			
-EZK	23	49	God		God (Yahweh)	Implicit			
-EZK	24	2	God		God (Yahweh)	Implicit			
+EZK	23	47	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	48	God		God (Yahweh)	Implicit			EntireVerse
+EZK	23	49	God		God (Yahweh)	Implicit			EntireVerse
+EZK	24	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	3	God		God (Yahweh)	Normal			
 EZK	24	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	24	4	God		God (Yahweh)	Implicit			
+EZK	24	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	5	God		God (Yahweh)	Implicit			
+EZK	24	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	24	6	God		God (Yahweh)	Normal			
 EZK	24	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	7	God		God (Yahweh)	Implicit			
+EZK	24	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	8	God		God (Yahweh)	Implicit			
+EZK	24	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	24	9	God		God (Yahweh)	Normal			
 EZK	24	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	10	God		God (Yahweh)	Implicit			
+EZK	24	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	11	God		God (Yahweh)	Implicit			
+EZK	24	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	12	God		God (Yahweh)	Implicit			
+EZK	24	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	24	13	God		God (Yahweh)	Implicit			
+EZK	24	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	24	14	God		God (Yahweh)	Normal			
 EZK	24	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	24	16	God		God (Yahweh)	Implicit			
-EZK	24	17	God		God (Yahweh)	Implicit			
+EZK	24	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	24	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	24	19	people			Normal			
 EZK	24	20	Ezekiel			Quotation			
 EZK	24	21	Ezekiel			Normal			
@@ -13344,27 +13344,27 @@ EZK	24	23	God		God (Yahweh)	Quotation
 EZK	24	23	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	24	24	God		God (Yahweh)	Quotation			
 EZK	24	24	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	24	25	God		God (Yahweh)	Implicit			
-EZK	24	26	God		God (Yahweh)	Implicit			
-EZK	24	27	God		God (Yahweh)	Implicit			
-EZK	25	2	God		God (Yahweh)	Implicit			
+EZK	24	25	God		God (Yahweh)	Implicit			EntireVerse
+EZK	24	26	God		God (Yahweh)	Implicit			EntireVerse
+EZK	24	27	God		God (Yahweh)	Implicit			EntireVerse
+EZK	25	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	3	God		God (Yahweh)	Normal			
 EZK	25	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	25	3	Ammonites			Hypothetical			
-EZK	25	4	God		God (Yahweh)	Implicit			
+EZK	25	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	25	5	God		God (Yahweh)	Implicit			
+EZK	25	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	25	6	God		God (Yahweh)	Normal			
-EZK	25	7	God		God (Yahweh)	Implicit			
+EZK	25	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	25	8	Moabites/Seir (personified)		Moab and Seir	Hypothetical			
 EZK	25	8	God		God (Yahweh)	Normal			
-EZK	25	9	God		God (Yahweh)	Implicit			
+EZK	25	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	25	10	God		God (Yahweh)	Implicit			
+EZK	25	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	25	11	God		God (Yahweh)	Implicit			
+EZK	25	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	25	12	God		God (Yahweh)	Normal			
 EZK	25	13	God		God (Yahweh)	Normal			
@@ -13373,143 +13373,143 @@ EZK	25	14	Ezekiel		Ezekiel (Yahweh says)	Potential
 EZK	25	15	God		God (Yahweh)	Normal			
 EZK	25	16	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	25	16	God		God (Yahweh)	Normal			
-EZK	25	17	God		God (Yahweh)	Implicit			
+EZK	25	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	25	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	2	God		God (Yahweh)	Normal			
 EZK	26	2	Tyre (personified)			Hypothetical			
 EZK	26	3	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	26	3	God		God (Yahweh)	Normal			
-EZK	26	4	God		God (Yahweh)	Implicit			
+EZK	26	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	5	God		God (Yahweh)	Normal			
 EZK	26	5	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	26	6	God		God (Yahweh)	Implicit			
+EZK	26	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	7	God		God (Yahweh)	Normal			
 EZK	26	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	8	God		God (Yahweh)	Implicit			
+EZK	26	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	9	God		God (Yahweh)	Implicit			
+EZK	26	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	10	God		God (Yahweh)	Implicit			
+EZK	26	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	11	God		God (Yahweh)	Implicit			
+EZK	26	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	12	God		God (Yahweh)	Implicit			
+EZK	26	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	13	God		God (Yahweh)	Implicit			
+EZK	26	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	14	God		God (Yahweh)	Normal			
 EZK	26	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	26	15	God		God (Yahweh)	Normal			
 EZK	26	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	16	God		God (Yahweh)	Implicit			
+EZK	26	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	26	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	17	God	prophecy	God (Yahweh)	Normal			
 EZK	26	17	God	lament	God (Yahweh)	Quotation			
 EZK	26	17	princes of the sea	lament		Hypothetical			
 EZK	26	17	Ezekiel	prophecy	Ezekiel (Yahweh says)	Alternate			
 EZK	26	17	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	26	18	God	lament	God (Yahweh)	Implicit			
+EZK	26	18	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	26	18	princes of the sea	lament		Hypothetical			
 EZK	26	18	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
 EZK	26	19	God	prophecy	God (Yahweh)	Normal			
 EZK	26	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	26	20	God	prophecy	God (Yahweh)	Implicit			
+EZK	26	20	God	prophecy	God (Yahweh)	Implicit			EntireVerse
 EZK	26	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	26	21	God	prophecy	God (Yahweh)	Normal			
 EZK	26	21	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	27	2	God	commanding	God (Yahweh)	Implicit			
+EZK	27	2	God	commanding	God (Yahweh)	Implicit			EntireVerse
 EZK	27	3	God	commanding	God (Yahweh)	Normal			
 EZK	27	3	Ezekiel	lament	Ezekiel (Yahweh says)	Normal			
 EZK	27	3	God	lament	God (Yahweh)	Normal			
-EZK	27	4	God	lament	God (Yahweh)	Implicit			
+EZK	27	4	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	4	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	5	God	lament	God (Yahweh)	Implicit			
+EZK	27	5	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	5	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	6	God	lament	God (Yahweh)	Implicit			
+EZK	27	6	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	6	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	7	God	lament	God (Yahweh)	Implicit			
+EZK	27	7	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	7	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	8	God	lament	God (Yahweh)	Implicit			
+EZK	27	8	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	8	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	9	God	lament	God (Yahweh)	Implicit			
+EZK	27	9	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	9	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	10	God	lament	God (Yahweh)	Implicit			
+EZK	27	10	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	10	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	11	God	lament	God (Yahweh)	Implicit			
+EZK	27	11	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	11	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	12	God	lament	God (Yahweh)	Implicit			
+EZK	27	12	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	12	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	13	God	lament	God (Yahweh)	Implicit			
+EZK	27	13	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	13	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	14	God	lament	God (Yahweh)	Implicit			
+EZK	27	14	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	14	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	15	God	lament	God (Yahweh)	Implicit			
+EZK	27	15	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	15	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	16	God	lament	God (Yahweh)	Implicit			
+EZK	27	16	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	16	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	17	God	lament	God (Yahweh)	Implicit			
+EZK	27	17	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	17	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	18	God	lament	God (Yahweh)	Implicit			
+EZK	27	18	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	18	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	19	God	lament	God (Yahweh)	Implicit			
+EZK	27	19	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	19	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	20	God	lament	God (Yahweh)	Implicit			
+EZK	27	20	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	20	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	21	God	lament	God (Yahweh)	Implicit			
+EZK	27	21	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	21	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	22	God	lament	God (Yahweh)	Implicit			
+EZK	27	22	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	22	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	23	God	lament	God (Yahweh)	Implicit			
+EZK	27	23	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	23	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	24	God	lament	God (Yahweh)	Implicit			
+EZK	27	24	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	24	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	25	God	lament	God (Yahweh)	Implicit			
+EZK	27	25	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	25	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	26	God	lament	God (Yahweh)	Implicit			
+EZK	27	26	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	26	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	27	God	lament	God (Yahweh)	Implicit			
+EZK	27	27	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	27	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	28	God	lament	God (Yahweh)	Implicit			
+EZK	27	28	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	28	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	29	God	lament	God (Yahweh)	Implicit			
+EZK	27	29	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	29	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	30	God	lament	God (Yahweh)	Implicit			
+EZK	27	30	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	30	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	31	God	lament	God (Yahweh)	Implicit			
+EZK	27	31	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	31	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
 EZK	27	32	God	lament	God (Yahweh)	Normal			
 EZK	27	32	oarsmen, mariners, pilots of the sea	lament		Hypothetical			
 EZK	27	32	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	33	God	lament	God (Yahweh)	Implicit			
+EZK	27	33	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	33	oarsmen, mariners, pilots of the sea	lament		Hypothetical			
 EZK	27	33	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	34	God	lament	God (Yahweh)	Implicit			
+EZK	27	34	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	34	oarsmen, mariners, pilots of the sea	lament		Hypothetical			
 EZK	27	34	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	35	God	lament	God (Yahweh)	Implicit			
+EZK	27	35	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	35	oarsmen, mariners, pilots of the sea	lament		Hypothetical			
 EZK	27	35	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
-EZK	27	36	God	lament	God (Yahweh)	Implicit			
+EZK	27	36	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	27	36	oarsmen, mariners, pilots of the sea	lament		Hypothetical			
 EZK	27	36	Ezekiel	lament	Ezekiel (Yahweh says)	Alternate			
 EZK	28	2	God		God (Yahweh)	Normal			
 EZK	28	2	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	28	2	prince of Tyre	boasting		Hypothetical			
-EZK	28	3	God		God (Yahweh)	Implicit			
+EZK	28	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	4	God		God (Yahweh)	Implicit			
+EZK	28	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	5	God		God (Yahweh)	Implicit			
+EZK	28	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	28	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	28	6	God		God (Yahweh)	Normal			
-EZK	28	7	God		God (Yahweh)	Implicit			
+EZK	28	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	8	God		God (Yahweh)	Implicit			
+EZK	28	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	9	God		God (Yahweh)	Implicit			
+EZK	28	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	28	9	prince of Tyre			Hypothetical			
 EZK	28	10	God		God (Yahweh)	Normal			
@@ -13517,147 +13517,147 @@ EZK	28	10	Ezekiel		Ezekiel (Yahweh says)	Potential
 EZK	28	12	God	commanding	God (Yahweh)	Normal			
 EZK	28	12	Ezekiel	lament	Ezekiel (Yahweh says)	Normal			
 EZK	28	12	God	lament	God (Yahweh)	Normal			
-EZK	28	13	God	lament	God (Yahweh)	Implicit			
+EZK	28	13	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	14	God	lament	God (Yahweh)	Implicit			
+EZK	28	14	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	15	God	lament	God (Yahweh)	Implicit			
+EZK	28	15	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	16	God	lament	God (Yahweh)	Implicit			
+EZK	28	16	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	17	God	lament	God (Yahweh)	Implicit			
+EZK	28	17	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	18	God	lament	God (Yahweh)	Implicit			
+EZK	28	18	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	18	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	19	God	lament	God (Yahweh)	Implicit			
+EZK	28	19	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	28	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	21	God		God (Yahweh)	Implicit			
+EZK	28	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	22	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	28	22	God		God (Yahweh)	Normal			
-EZK	28	23	God		God (Yahweh)	Implicit			
+EZK	28	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	28	24	God		God (Yahweh)	Implicit			
+EZK	28	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	28	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	28	25	God		God (Yahweh)	Normal			
-EZK	28	26	God		God (Yahweh)	Implicit			
+EZK	28	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	28	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	2	God		God (Yahweh)	Implicit			
+EZK	29	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	3	God		God (Yahweh)	Normal			
 EZK	29	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	29	3	Pharaoh (Apries)		Pharaoh king of Egypt	Hypothetical			
-EZK	29	4	God		God (Yahweh)	Implicit			
+EZK	29	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	5	God		God (Yahweh)	Implicit			
+EZK	29	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	6	God		God (Yahweh)	Implicit			
+EZK	29	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	7	God		God (Yahweh)	Implicit			
+EZK	29	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	8	God		God (Yahweh)	Normal			
-EZK	29	9	God		God (Yahweh)	Implicit			
+EZK	29	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	9	Pharaoh (Apries)		Pharaoh king of Egypt	Hypothetical			
-EZK	29	10	God		God (Yahweh)	Implicit			
+EZK	29	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	11	God		God (Yahweh)	Implicit			
+EZK	29	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	12	God		God (Yahweh)	Implicit			
+EZK	29	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	13	God		God (Yahweh)	Normal			
-EZK	29	14	God		God (Yahweh)	Implicit			
+EZK	29	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	15	God		God (Yahweh)	Implicit			
+EZK	29	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	16	God		God (Yahweh)	Implicit			
+EZK	29	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	18	God		God (Yahweh)	Implicit			
+EZK	29	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	29	19	God		God (Yahweh)	Normal			
-EZK	29	20	God		God (Yahweh)	Implicit			
+EZK	29	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	29	21	God		God (Yahweh)	Implicit			
+EZK	29	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	29	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	2	God		God (Yahweh)	Normal			
 EZK	30	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	3	God		God (Yahweh)	Implicit			
+EZK	30	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	4	God		God (Yahweh)	Implicit			
+EZK	30	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	5	God		God (Yahweh)	Implicit			
+EZK	30	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	6	God		God (Yahweh)	Normal			
 EZK	30	6	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	30	7	God		God (Yahweh)	Implicit			
+EZK	30	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	8	God		God (Yahweh)	Implicit			
+EZK	30	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	9	God		God (Yahweh)	Implicit			
+EZK	30	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	10	God		God (Yahweh)	Normal			
-EZK	30	11	God		God (Yahweh)	Implicit			
+EZK	30	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	12	God		God (Yahweh)	Implicit			
+EZK	30	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	13	God		God (Yahweh)	Normal			
-EZK	30	14	God		God (Yahweh)	Implicit			
+EZK	30	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	15	God		God (Yahweh)	Implicit			
+EZK	30	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	16	God		God (Yahweh)	Implicit			
+EZK	30	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	17	God		God (Yahweh)	Implicit			
+EZK	30	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	18	God		God (Yahweh)	Implicit			
+EZK	30	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	18	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	19	God		God (Yahweh)	Implicit			
+EZK	30	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	21	God		God (Yahweh)	Implicit			
+EZK	30	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	30	22	God		God (Yahweh)	Normal			
-EZK	30	23	God		God (Yahweh)	Implicit			
+EZK	30	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	24	God		God (Yahweh)	Implicit			
+EZK	30	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	25	God		God (Yahweh)	Implicit			
+EZK	30	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	30	26	God		God (Yahweh)	Implicit			
+EZK	30	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	30	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	2	God		God (Yahweh)	Implicit			
+EZK	31	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	3	God		God (Yahweh)	Implicit			
+EZK	31	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	4	God		God (Yahweh)	Implicit			
+EZK	31	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	5	God		God (Yahweh)	Implicit			
+EZK	31	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	6	God		God (Yahweh)	Implicit			
+EZK	31	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	7	God		God (Yahweh)	Implicit			
+EZK	31	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	8	God		God (Yahweh)	Implicit			
+EZK	31	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	9	God		God (Yahweh)	Implicit			
+EZK	31	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	31	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	31	10	God		God (Yahweh)	Normal			
-EZK	31	11	God		God (Yahweh)	Implicit			
+EZK	31	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	12	God		God (Yahweh)	Implicit			
+EZK	31	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	13	God		God (Yahweh)	Implicit			
+EZK	31	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	14	God		God (Yahweh)	Implicit			
+EZK	31	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	31	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	31	15	God		God (Yahweh)	Normal			
-EZK	31	16	God		God (Yahweh)	Implicit			
+EZK	31	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	31	17	God		God (Yahweh)	Implicit			
+EZK	31	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	31	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	31	18	God		God (Yahweh)	Normal			
 EZK	31	18	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -13666,72 +13666,72 @@ EZK	32	2	Ezekiel		Ezekiel (Yahweh says)	Normal
 EZK	32	2	God	lament	God (Yahweh)	Alternate			
 EZK	32	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	3	God	lament	God (Yahweh)	Normal			
-EZK	32	4	God	lament	God (Yahweh)	Implicit			
+EZK	32	4	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	5	God	lament	God (Yahweh)	Implicit			
+EZK	32	5	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	6	God	lament	God (Yahweh)	Implicit			
+EZK	32	6	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	7	God	lament	God (Yahweh)	Implicit			
+EZK	32	7	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	8	God	lament	God (Yahweh)	Normal			
 EZK	32	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	32	9	God	lament	God (Yahweh)	Implicit			
-EZK	32	10	God	lament	God (Yahweh)	Implicit			
+EZK	32	9	God	lament	God (Yahweh)	Implicit			EntireVerse
+EZK	32	10	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	11	God	lament	God (Yahweh)	Normal			
-EZK	32	12	God	lament	God (Yahweh)	Implicit			
+EZK	32	12	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	13	God	lament	God (Yahweh)	Implicit			
+EZK	32	13	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	14	God	lament	God (Yahweh)	Normal			
 EZK	32	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	32	15	God	lament	God (Yahweh)	Implicit			
+EZK	32	15	God	lament	God (Yahweh)	Implicit			EntireVerse
 EZK	32	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	16	God	lament	God (Yahweh)	Normal			
 EZK	32	16	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	32	18	God		God (Yahweh)	Implicit			
-EZK	32	19	God		God (Yahweh)	Implicit			
+EZK	32	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	32	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	20	God		God (Yahweh)	Implicit			
+EZK	32	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	21	God		God (Yahweh)	Implicit			
+EZK	32	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	22	God		God (Yahweh)	Implicit			
+EZK	32	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	23	God		God (Yahweh)	Implicit			
+EZK	32	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	24	God		God (Yahweh)	Implicit			
+EZK	32	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	25	God		God (Yahweh)	Implicit			
+EZK	32	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	26	God		God (Yahweh)	Implicit			
+EZK	32	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	27	God		God (Yahweh)	Implicit			
+EZK	32	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	28	God		God (Yahweh)	Implicit			
+EZK	32	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	29	God		God (Yahweh)	Implicit			
+EZK	32	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	32	30	God		God (Yahweh)	Implicit			
+EZK	32	30	God		God (Yahweh)	Implicit			EntireVerse
 EZK	32	30	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	32	31	God		God (Yahweh)	Normal			
 EZK	32	31	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	32	32	God		God (Yahweh)	Normal			
 EZK	32	32	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	33	2	God		God (Yahweh)	Implicit			
+EZK	33	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	3	God		God (Yahweh)	Implicit			
+EZK	33	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	4	God		God (Yahweh)	Implicit			
+EZK	33	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	5	God		God (Yahweh)	Implicit			
+EZK	33	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	6	God		God (Yahweh)	Implicit			
+EZK	33	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	7	God		God (Yahweh)	Implicit			
-EZK	33	8	God		God (Yahweh)	Implicit			
-EZK	33	9	God		God (Yahweh)	Implicit			
+EZK	33	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	8	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	10	God		God (Yahweh)	Normal			
 EZK	33	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	33	10	Israel		house of Israel	Hypothetical			
@@ -13739,41 +13739,41 @@ EZK	33	11	God		God (Yahweh)	Normal
 EZK	33	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	33	12	God		God (Yahweh)	Normal			
 EZK	33	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	13	God		God (Yahweh)	Implicit			
-EZK	33	14	God		God (Yahweh)	Implicit			
-EZK	33	15	God		God (Yahweh)	Implicit			
-EZK	33	16	God		God (Yahweh)	Implicit			
+EZK	33	13	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	14	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	17	God		God (Yahweh)	Normal			
 EZK	33	17	Israel		children of your people (i.e., Israel)	Hypothetical			
-EZK	33	18	God		God (Yahweh)	Implicit			
-EZK	33	19	God		God (Yahweh)	Implicit			
-EZK	33	20	God		God (Yahweh)	Implicit			
+EZK	33	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	21	man escaped from Jerusalem			Indirect			
 EZK	33	24	God		God (Yahweh)	Normal			
 EZK	33	24	Israel		inhabitants of the waste places in Israel	Hypothetical			
 EZK	33	25	God		God (Yahweh)	Normal			
 EZK	33	25	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	33	26	God		God (Yahweh)	Implicit			
+EZK	33	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	33	27	God		God (Yahweh)	Normal			
 EZK	33	27	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	33	28	God		God (Yahweh)	Implicit			
+EZK	33	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	29	God		God (Yahweh)	Implicit			
+EZK	33	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	33	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	33	30	God		God (Yahweh)	Implicit			
-EZK	33	31	God		God (Yahweh)	Implicit			
-EZK	33	32	God		God (Yahweh)	Implicit			
-EZK	33	33	God		God (Yahweh)	Implicit			
+EZK	33	30	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	31	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	32	God		God (Yahweh)	Implicit			EntireVerse
+EZK	33	33	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	2	God		God (Yahweh)	Normal			
 EZK	34	2	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	34	3	God		God (Yahweh)	Implicit			
+EZK	34	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	4	God		God (Yahweh)	Implicit			
+EZK	34	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	5	God		God (Yahweh)	Implicit			
+EZK	34	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	6	God		God (Yahweh)	Implicit			
+EZK	34	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	34	7	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	34	7	God		God (Yahweh)	Alternate			
@@ -13785,72 +13785,72 @@ EZK	34	10	Ezekiel		Ezekiel (Yahweh says)	Potential
 EZK	34	10	God		God (Yahweh)	Normal			
 EZK	34	11	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	34	11	God		God (Yahweh)	Normal			
-EZK	34	12	God		God (Yahweh)	Implicit			
+EZK	34	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	13	God		God (Yahweh)	Implicit			
+EZK	34	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	14	God		God (Yahweh)	Implicit			
+EZK	34	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	34	15	God		God (Yahweh)	Normal			
 EZK	34	15	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	34	16	God		God (Yahweh)	Implicit			
+EZK	34	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	17	God		God (Yahweh)	Normal			
 EZK	34	17	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	34	18	God		God (Yahweh)	Implicit			
+EZK	34	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	18	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	19	God		God (Yahweh)	Implicit			
+EZK	34	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	19	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	34	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	34	20	God		God (Yahweh)	Normal			
-EZK	34	21	God		God (Yahweh)	Implicit			
+EZK	34	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	21	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	22	God		God (Yahweh)	Implicit			
+EZK	34	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	23	God		God (Yahweh)	Implicit			
+EZK	34	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	24	God		God (Yahweh)	Implicit			
+EZK	34	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	25	God		God (Yahweh)	Implicit			
+EZK	34	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	26	God		God (Yahweh)	Implicit			
+EZK	34	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	27	God		God (Yahweh)	Implicit			
+EZK	34	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	28	God		God (Yahweh)	Implicit			
+EZK	34	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	34	29	God		God (Yahweh)	Implicit			
+EZK	34	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	34	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	34	30	God		God (Yahweh)	Normal			
 EZK	34	30	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	34	31	God		God (Yahweh)	Normal			
 EZK	34	31	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	35	2	God		God (Yahweh)	Implicit			
+EZK	35	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	3	God		God (Yahweh)	Normal			
 EZK	35	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	35	4	God		God (Yahweh)	Implicit			
+EZK	35	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	35	5	God		God (Yahweh)	Implicit			
+EZK	35	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	35	6	God		God (Yahweh)	Normal			
 EZK	35	6	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	35	7	God		God (Yahweh)	Implicit			
+EZK	35	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	35	8	God		God (Yahweh)	Implicit			
+EZK	35	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	35	9	God		God (Yahweh)	Implicit			
+EZK	35	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	35	10	God		God (Yahweh)	Normal			
 EZK	35	10	Seir (personified)		Mount Seir	Hypothetical			
 EZK	35	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	35	11	God		God (Yahweh)	Normal			
 EZK	35	11	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	35	12	God		God (Yahweh)	Implicit			
+EZK	35	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	35	13	God		God (Yahweh)	Implicit			
+EZK	35	13	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	35	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	35	14	God		God (Yahweh)	Normal			
-EZK	35	15	God		God (Yahweh)	Implicit			
+EZK	35	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	35	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	36	1	God		God (Yahweh)	Normal			
 EZK	36	1	Ezekiel		Ezekiel (Yahweh says)	Normal			
@@ -13868,13 +13868,13 @@ EZK	36	6	Ezekiel		Ezekiel (Yahweh says)	Normal
 EZK	36	7	God		God (Yahweh)	Normal			
 EZK	36	7	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	36	8	God		God (Yahweh)	Normal			
-EZK	36	9	God		God (Yahweh)	Implicit			
+EZK	36	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	10	God		God (Yahweh)	Implicit			
+EZK	36	10	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	11	God		God (Yahweh)	Implicit			
+EZK	36	11	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	12	God		God (Yahweh)	Implicit			
+EZK	36	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	36	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	36	13	God		God (Yahweh)	Normal			
@@ -13882,30 +13882,30 @@ EZK	36	14	God		God (Yahweh)	Normal
 EZK	36	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	36	15	God		God (Yahweh)	Normal			
 EZK	36	15	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	36	17	God		God (Yahweh)	Implicit			
-EZK	36	18	God		God (Yahweh)	Implicit			
-EZK	36	19	God		God (Yahweh)	Implicit			
-EZK	36	20	God		God (Yahweh)	Implicit			
-EZK	36	21	God		God (Yahweh)	Implicit			
+EZK	36	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	36	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	36	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	36	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	36	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	22	God		God (Yahweh)	Normal			
 EZK	36	22	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	36	23	God		God (Yahweh)	Normal			
 EZK	36	23	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	36	24	God		God (Yahweh)	Implicit			
+EZK	36	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	25	God		God (Yahweh)	Implicit			
+EZK	36	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	26	God		God (Yahweh)	Implicit			
+EZK	36	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	27	God		God (Yahweh)	Implicit			
+EZK	36	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	28	God		God (Yahweh)	Implicit			
+EZK	36	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	29	God		God (Yahweh)	Implicit			
+EZK	36	29	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	29	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	30	God		God (Yahweh)	Implicit			
+EZK	36	30	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	30	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	36	31	God		God (Yahweh)	Implicit			
+EZK	36	31	God		God (Yahweh)	Implicit			EntireVerse
 EZK	36	31	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	36	32	God		God (Yahweh)	Normal			
 EZK	36	32	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -13927,7 +13927,7 @@ EZK	37	4	God		God (Yahweh) (in vision)	Normal
 EZK	37	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	37	5	Ezekiel		Ezekiel (Yahweh says)	Normal			
 EZK	37	5	God		God (Yahweh) (in vision)	Normal			
-EZK	37	6	God		God (Yahweh) (in vision)	Implicit			
+EZK	37	6	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	37	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	37	7	Ezekiel			Potential			
 EZK	37	9	God		God (Yahweh) (in vision)	Normal			
@@ -13937,47 +13937,47 @@ EZK	37	11	God		God (Yahweh) (in vision)	Normal
 EZK	37	11	Israel	lament	whole house of Israel	Hypothetical			
 EZK	37	12	God		God (Yahweh) (in vision)	Normal			
 EZK	37	12	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	37	13	God		God (Yahweh) (in vision)	Implicit			
+EZK	37	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	37	14	God		God (Yahweh) (in vision)	Normal			
 EZK	37	14	Ezekiel		Ezekiel (Yahweh says)	Potential			
 # writing on sticks should be spoken by God
-EZK	37	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
-EZK	37	17	God		God (Yahweh)	Implicit			
-EZK	37	18	God		God (Yahweh)	Implicit			
+EZK	37	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
+EZK	37	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	37	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	18	Israel		whole house of Israel	Hypothetical			
 EZK	37	19	God		God (Yahweh)	Normal			
 EZK	37	19	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	37	20	God		God (Yahweh)	Implicit			
+EZK	37	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	21	God		God (Yahweh)	Normal			
 EZK	37	21	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	37	22	God		God (Yahweh)	Implicit			
+EZK	37	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	23	God		God (Yahweh)	Implicit			
+EZK	37	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	24	God		God (Yahweh)	Implicit			
+EZK	37	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	24	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	25	God		God (Yahweh)	Implicit			
+EZK	37	25	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	26	God		God (Yahweh)	Implicit			
+EZK	37	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	27	God		God (Yahweh)	Implicit			
+EZK	37	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	37	28	God		God (Yahweh)	Implicit			
+EZK	37	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	37	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	2	God		God (Yahweh)	Implicit			
+EZK	38	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	3	God		God (Yahweh)	Normal			
 EZK	38	3	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	38	4	God		God (Yahweh)	Implicit			
+EZK	38	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	5	God		God (Yahweh)	Implicit			
+EZK	38	5	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	5	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	6	God		God (Yahweh)	Implicit			
+EZK	38	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	7	God		God (Yahweh)	Implicit			
+EZK	38	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	8	God		God (Yahweh)	Implicit			
+EZK	38	8	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	8	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	9	God		God (Yahweh)	Implicit			
+EZK	38	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	10	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	10	God		God (Yahweh)	Normal			
@@ -13992,54 +13992,54 @@ EZK	38	13	Sheba, Dedan, and the merchants of Tarshish			Hypothetical
 EZK	38	13	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	14	God		God (Yahweh)	Normal			
 EZK	38	14	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	38	15	God		God (Yahweh)	Implicit			
+EZK	38	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	16	God		God (Yahweh)	Implicit			
+EZK	38	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	17	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	17	God		God (Yahweh)	Normal			
 EZK	38	18	God		God (Yahweh)	Normal			
 EZK	38	18	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	38	19	God		God (Yahweh)	Normal			
-EZK	38	20	God		God (Yahweh)	Implicit			
+EZK	38	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	20	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	38	21	God		God (Yahweh)	Normal			
 EZK	38	21	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	38	22	God		God (Yahweh)	Implicit			
+EZK	38	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	22	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	38	23	God		God (Yahweh)	Implicit			
+EZK	38	23	God		God (Yahweh)	Implicit			EntireVerse
 EZK	38	23	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	1	God		God (Yahweh)	Normal			
 EZK	39	1	Ezekiel		Ezekiel (Yahweh says)	Normal			
-EZK	39	2	God		God (Yahweh)	Implicit			
+EZK	39	2	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	2	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	3	God		God (Yahweh)	Implicit			
+EZK	39	3	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	3	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	4	God		God (Yahweh)	Implicit			
+EZK	39	4	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	4	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	5	God		God (Yahweh)	Normal			
 EZK	39	5	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	39	6	God		God (Yahweh)	Implicit			
+EZK	39	6	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	6	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	7	God		God (Yahweh)	Implicit			
+EZK	39	7	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	7	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	8	God		God (Yahweh)	Normal			
 EZK	39	8	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	39	9	God		God (Yahweh)	Implicit			
+EZK	39	9	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	9	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	10	God		God (Yahweh)	Normal			
 EZK	39	10	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	39	11	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	39	11	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	39	11	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	12	God		God (Yahweh)	Implicit			
+EZK	39	12	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	12	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	13	God		God (Yahweh)	Normal			
 EZK	39	13	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	39	14	God		God (Yahweh)	Implicit			
+EZK	39	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	14	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	15	God		God (Yahweh)	Implicit			
+EZK	39	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	15	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	39	16	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 EZK	39	16	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	17	God		God (Yahweh)	Normal			
 EZK	39	17	Ezekiel		Ezekiel (Yahweh says)	Normal			
@@ -14049,17 +14049,17 @@ EZK	39	19	God		God (Yahweh)	Normal
 EZK	39	19	Ezekiel		Ezekiel (Yahweh says)	Potential			
 EZK	39	20	God		God (Yahweh)	Normal			
 EZK	39	20	Ezekiel		Ezekiel (Yahweh says)	Potential			
-EZK	39	21	God		God (Yahweh)	Implicit			
-EZK	39	22	God		God (Yahweh)	Implicit			
-EZK	39	23	God		God (Yahweh)	Implicit			
-EZK	39	24	God		God (Yahweh)	Implicit			
+EZK	39	21	God		God (Yahweh)	Implicit			EntireVerse
+EZK	39	22	God		God (Yahweh)	Implicit			EntireVerse
+EZK	39	23	God		God (Yahweh)	Implicit			EntireVerse
+EZK	39	24	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	25	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	25	God		God (Yahweh)	Normal			
-EZK	39	26	God		God (Yahweh)	Implicit			
+EZK	39	26	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	26	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	27	God		God (Yahweh)	Implicit			
+EZK	39	27	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	27	Ezekiel		Ezekiel (Yahweh says)	Alternate			
-EZK	39	28	God		God (Yahweh)	Implicit			
+EZK	39	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	39	28	Ezekiel		Ezekiel (Yahweh says)	Alternate			
 EZK	39	29	God		God (Yahweh)	Normal			
 EZK	39	29	Ezekiel		Ezekiel (Yahweh says)	Potential			
@@ -14069,198 +14069,198 @@ EZK	40	46	man like bronze with measuring rod (in vision)			Normal
 EZK	41	4	man like bronze with measuring rod (in vision)			Normal			
 EZK	41	22	man like bronze with measuring rod (in vision)			Normal			
 EZK	42	13	man like bronze with measuring rod (in vision)			Normal			
-EZK	42	14	man like bronze with measuring rod (in vision)			Implicit			
+EZK	42	14	man like bronze with measuring rod (in vision)			Implicit			EntireVerse
 EZK	43	7	God		God (Yahweh) (man in vision)	Normal			
-EZK	43	8	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	9	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	10	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	11	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	12	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	13	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	14	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	15	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	16	God		God (Yahweh) (man in vision)	Implicit			
-EZK	43	17	God		God (Yahweh) (man in vision)	Implicit			
+EZK	43	8	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	9	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	10	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	11	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	12	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	13	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	14	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	15	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	16	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
+EZK	43	17	God		God (Yahweh) (man in vision)	Implicit			EntireVerse
 EZK	43	18	God		God (Yahweh) (in vision)	Normal			
 EZK	43	18	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	43	19	God		God (Yahweh) (in vision)	Normal			
 EZK	43	19	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	20	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	20	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	20	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	21	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	21	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	21	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	22	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	22	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	22	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	23	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	23	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	23	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	24	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	24	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	24	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	25	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	25	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	25	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	43	26	God		God (Yahweh) (in vision)	Implicit			
+EZK	43	26	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	43	26	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	43	27	God		God (Yahweh) (in vision)	Normal			
 EZK	43	27	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
 EZK	44	2	God		God (Yahweh) (in vision)	Normal			
-EZK	44	3	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	3	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	5	God		God (Yahweh) (in vision)	Normal			
 EZK	44	6	God		God (Yahweh) (in vision)	Normal			
 EZK	44	6	Ezekiel		Ezekiel (Yahweh says, in vision)	Normal			
-EZK	44	7	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	7	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	7	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	8	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	8	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	8	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	44	9	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	44	9	God		God (Yahweh) (in vision)	Normal			
-EZK	44	10	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	10	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	10	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	11	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	11	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	11	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	44	12	God		God (Yahweh) (in vision)	Normal			
 EZK	44	12	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
-EZK	44	13	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	13	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	14	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	14	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	44	15	God		God (Yahweh) (in vision)	Normal			
 EZK	44	15	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
-EZK	44	16	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	16	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	16	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	17	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	17	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	17	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	18	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	18	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	18	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	19	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	19	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	19	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	20	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	20	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	20	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	21	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	21	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	21	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	22	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	22	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	22	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	23	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	23	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	23	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	24	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	24	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	24	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	25	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	25	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	25	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	44	26	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	26	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	44	26	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	44	27	God		God (Yahweh) (in vision)	Normal			
 EZK	44	27	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
-EZK	44	28	God		God (Yahweh) (in vision)	Implicit			
-EZK	44	29	God		God (Yahweh) (in vision)	Implicit			
-EZK	44	30	God		God (Yahweh) (in vision)	Implicit			
-EZK	44	31	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	1	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	2	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	3	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	4	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	5	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	6	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	7	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	8	God		God (Yahweh) (in vision)	Implicit			
+EZK	44	28	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	44	29	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	44	30	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	44	31	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	1	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	2	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	3	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	4	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	5	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	6	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	7	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	8	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	9	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	45	9	God		God (Yahweh) (in vision)	Normal			
-EZK	45	10	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	11	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	12	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	13	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	14	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	10	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	11	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	12	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	15	God		God (Yahweh) (in vision)	Normal			
 EZK	45	15	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
-EZK	45	16	God		God (Yahweh) (in vision)	Implicit			
-EZK	45	17	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	16	God		God (Yahweh) (in vision)	Implicit			EntireVerse
+EZK	45	17	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	18	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	45	18	God		God (Yahweh) (in vision)	Normal			
-EZK	45	19	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	19	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	19	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	20	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	20	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	20	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	21	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	21	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	21	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	22	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	22	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	22	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	23	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	23	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	23	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	24	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	24	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	24	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	45	25	God		God (Yahweh) (in vision)	Implicit			
+EZK	45	25	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	45	25	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	46	1	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	46	1	God		God (Yahweh) (in vision)	Normal			
-EZK	46	2	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	2	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	2	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	3	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	3	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	3	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	4	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	4	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	4	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	5	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	5	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	5	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	6	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	6	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	6	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	7	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	7	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	7	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	8	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	8	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	8	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	9	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	9	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	9	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	10	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	10	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	10	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	11	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	11	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	11	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	12	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	12	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	12	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	13	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	13	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	13	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	14	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	14	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	14	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	15	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	15	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	15	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	46	16	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	46	16	God		God (Yahweh) (in vision)	Normal			
-EZK	46	17	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	17	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	17	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	46	18	God		God (Yahweh) (in vision)	Implicit			
+EZK	46	18	God		God (Yahweh) (in vision)	Implicit			EntireVerse
 EZK	46	18	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	46	20	man like bronze with measuring rod (in vision)			Normal			
 EZK	46	24	man like bronze with measuring rod (in vision)			Normal			
 EZK	47	6	man like bronze with measuring rod (in vision)			Normal			
 EZK	47	8	man like bronze with measuring rod (in vision)			Normal			
-EZK	47	9	man like bronze with measuring rod (in vision)			Implicit			
-EZK	47	10	man like bronze with measuring rod (in vision)			Implicit			
-EZK	47	11	man like bronze with measuring rod (in vision)			Implicit			
-EZK	47	12	man like bronze with measuring rod (in vision)			Implicit			
+EZK	47	9	man like bronze with measuring rod (in vision)			Implicit			EntireVerse
+EZK	47	10	man like bronze with measuring rod (in vision)			Implicit			EntireVerse
+EZK	47	11	man like bronze with measuring rod (in vision)			Implicit			EntireVerse
+EZK	47	12	man like bronze with measuring rod (in vision)			Implicit			EntireVerse
 EZK	47	13	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	47	13	God		God (Yahweh)	Normal			
-EZK	47	14	God		God (Yahweh)	Implicit			
+EZK	47	14	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	14	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	15	God		God (Yahweh)	Implicit			
+EZK	47	15	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	15	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	16	God		God (Yahweh)	Implicit			
+EZK	47	16	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	16	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	17	God		God (Yahweh)	Implicit			
+EZK	47	17	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	17	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	18	God		God (Yahweh)	Implicit			
+EZK	47	18	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	18	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	19	God		God (Yahweh)	Implicit			
+EZK	47	19	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	19	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	20	God		God (Yahweh)	Implicit			
+EZK	47	20	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	20	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	21	God		God (Yahweh)	Implicit			
+EZK	47	21	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	21	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
-EZK	47	22	God		God (Yahweh)	Implicit			
+EZK	47	22	God		God (Yahweh)	Implicit			EntireVerse
 EZK	47	22	Ezekiel		Ezekiel (Yahweh says, in vision)	Alternate			
 EZK	47	23	God		God (Yahweh)	Normal			
 EZK	47	23	Ezekiel		Ezekiel (Yahweh says, in vision)	Potential			
-EZK	48	1	God		God (Yahweh)	Implicit			
-EZK	48	2	God		God (Yahweh)	Implicit			
-EZK	48	3	God		God (Yahweh)	Implicit			
-EZK	48	4	God		God (Yahweh)	Implicit			
-EZK	48	5	God		God (Yahweh)	Implicit			
-EZK	48	6	God		God (Yahweh)	Implicit			
-EZK	48	7	God		God (Yahweh)	Implicit			
-EZK	48	8	God		God (Yahweh)	Implicit			
+EZK	48	1	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	2	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	3	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	4	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	5	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	6	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	7	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	8	God		God (Yahweh)	Implicit			EntireVerse
 # Most version have vv. 1-29a in explicit quotes. Just in case they don't do that, I'll leave 9-15 as "Normal" since these
 # verses contain 3rd-person references to God, even though the whole thing is almost certainly to be spoken by God.
 EZK	48	9	God		God (Yahweh)	Normal			
@@ -14269,28 +14269,28 @@ EZK	48	11	God		God (Yahweh)	Normal
 EZK	48	12	God		God (Yahweh)	Normal			
 EZK	48	13	God		God (Yahweh)	Normal			
 EZK	48	14	God		God (Yahweh)	Normal			
-EZK	48	15	God		God (Yahweh)	Implicit			
-EZK	48	16	God		God (Yahweh)	Implicit			
-EZK	48	17	God		God (Yahweh)	Implicit			
-EZK	48	18	God		God (Yahweh)	Implicit			
-EZK	48	19	God		God (Yahweh)	Implicit			
-EZK	48	20	God		God (Yahweh)	Implicit			
-EZK	48	21	God		God (Yahweh)	Implicit			
-EZK	48	22	God		God (Yahweh)	Implicit			
-EZK	48	23	God		God (Yahweh)	Implicit			
-EZK	48	24	God		God (Yahweh)	Implicit			
-EZK	48	25	God		God (Yahweh)	Implicit			
-EZK	48	26	God		God (Yahweh)	Implicit			
-EZK	48	27	God		God (Yahweh)	Implicit			
-EZK	48	28	God		God (Yahweh)	Implicit			
+EZK	48	15	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	16	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	17	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	18	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	19	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	20	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	21	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	22	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	23	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	24	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	25	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	26	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	27	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	28	God		God (Yahweh)	Implicit			EntireVerse
 EZK	48	29	God		God (Yahweh)	Normal			
 EZK	48	29	Ezekiel		Ezekiel (Yahweh says, in vision)	Normal			
-EZK	48	30	God		God (Yahweh)	Implicit			
-EZK	48	31	God		God (Yahweh)	Implicit			
-EZK	48	32	God		God (Yahweh)	Implicit			
-EZK	48	33	God		God (Yahweh)	Implicit			
-EZK	48	34	God		God (Yahweh)	Implicit			
-EZK	48	35	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+EZK	48	30	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	31	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	32	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	33	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	34	God		God (Yahweh)	Implicit			EntireVerse
+EZK	48	35	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 DAN	1	10	chief official			Normal			EndOfVerse
 DAN	1	12	Daniel			Normal			EntireVerse
 DAN	1	13	Daniel			Normal			EntireVerse
@@ -14309,31 +14309,31 @@ DAN	2	16	Daniel			Indirect
 DAN	2	17	Daniel			Potential			
 DAN	2	18	Daniel			Indirect			
 DAN	2	20	Daniel			Normal			Unspecified
-DAN	2	21	Daniel			Implicit			
-DAN	2	22	Daniel			Implicit			
-DAN	2	23	Daniel			Implicit			
+DAN	2	21	Daniel			Implicit			EntireVerse
+DAN	2	22	Daniel			Implicit			EntireVerse
+DAN	2	23	Daniel			Implicit			EntireVerse
 DAN	2	24	Daniel			Normal			EndOfVerse
 DAN	2	25	Arioch			Normal			EndOfVerse
 DAN	2	26	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
 DAN	2	27	Daniel			Normal			EndOfVerse
-DAN	2	28	Daniel			Implicit			
-DAN	2	29	Daniel			Implicit			
-DAN	2	30	Daniel			Implicit			
-DAN	2	31	Daniel			Implicit			
-DAN	2	32	Daniel			Implicit			
-DAN	2	33	Daniel			Implicit			
-DAN	2	34	Daniel			Implicit			
-DAN	2	35	Daniel			Implicit			
-DAN	2	36	Daniel			Implicit			
-DAN	2	37	Daniel			Implicit			
-DAN	2	38	Daniel			Implicit			
-DAN	2	39	Daniel			Implicit			
-DAN	2	40	Daniel			Implicit			
-DAN	2	41	Daniel			Implicit			
-DAN	2	42	Daniel			Implicit			
-DAN	2	43	Daniel			Implicit			
-DAN	2	44	Daniel			Implicit			
-DAN	2	45	Daniel			Implicit			
+DAN	2	28	Daniel			Implicit			EntireVerse
+DAN	2	29	Daniel			Implicit			EntireVerse
+DAN	2	30	Daniel			Implicit			EntireVerse
+DAN	2	31	Daniel			Implicit			EntireVerse
+DAN	2	32	Daniel			Implicit			EntireVerse
+DAN	2	33	Daniel			Implicit			EntireVerse
+DAN	2	34	Daniel			Implicit			EntireVerse
+DAN	2	35	Daniel			Implicit			EntireVerse
+DAN	2	36	Daniel			Implicit			EntireVerse
+DAN	2	37	Daniel			Implicit			EntireVerse
+DAN	2	38	Daniel			Implicit			EntireVerse
+DAN	2	39	Daniel			Implicit			EntireVerse
+DAN	2	40	Daniel			Implicit			EntireVerse
+DAN	2	41	Daniel			Implicit			EntireVerse
+DAN	2	42	Daniel			Implicit			EntireVerse
+DAN	2	43	Daniel			Implicit			EntireVerse
+DAN	2	44	Daniel			Implicit			EntireVerse
+DAN	2	45	Daniel			Implicit			EntireVerse
 DAN	2	46	Nebuchadnezzar, king of Babylon			Indirect			
 DAN	2	47	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
 DAN	2	48	Nebuchadnezzar, king of Babylon			Potential			
@@ -14343,9 +14343,9 @@ DAN	3	4	herald			Normal			EndOfVerse
 DAN	3	5	herald			Normal			EntireVerse
 DAN	3	6	herald			Normal			EntireVerse
 DAN	3	9	astrologers			Normal			Unspecified
-DAN	3	10	astrologers			Implicit			
-DAN	3	11	astrologers			Implicit			
-DAN	3	12	astrologers			Implicit			
+DAN	3	10	astrologers			Implicit			EntireVerse
+DAN	3	11	astrologers			Implicit			EntireVerse
+DAN	3	12	astrologers			Implicit			EntireVerse
 DAN	3	13	Nebuchadnezzar, king of Babylon	commanding		Indirect			
 DAN	3	14	Nebuchadnezzar, king of Babylon			Normal			Unspecified
 DAN	3	15	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
@@ -14360,51 +14360,51 @@ DAN	3	25	Nebuchadnezzar, king of Babylon			Normal			Unspecified
 DAN	3	26	Nebuchadnezzar, king of Babylon			Normal			ContainedWithinVerse
 DAN	3	28	Nebuchadnezzar, king of Babylon			Normal			EndOfVerse
 DAN	3	29	Nebuchadnezzar, king of Babylon			Normal			EntireVerse
-DAN	4	1	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	2	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	3	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	4	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	5	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	6	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	7	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	8	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	9	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	10	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	11	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	12	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	13	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	14	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	1	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	2	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	3	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	4	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	5	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	6	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	7	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	8	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	9	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	10	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	11	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	12	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	13	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	14	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 # Verses 14-33 seem to break out of the letter and switch into 3rd-person narration mode, but presumably the
 # whole account was included in Nebuchadnezzar's letter, so the control file includes Alternate and Potential
 # entries to allow for the whole account to be related as a single letter. See CJB for an example of a Bible
 # that wraps quotes around everything from v. 1b to the end of the chapter (though even then you might not
 # choose to dramatize it that way).
 DAN	4	14	holy one (in vision)		a watcher and a holy one	Alternate			
-DAN	4	15	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	15	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 DAN	4	15	holy one (in vision)		a watcher and a holy one	Alternate			
-DAN	4	16	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	16	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 DAN	4	16	holy one (in vision)		a watcher and a holy one	Alternate			
-DAN	4	17	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	17	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 DAN	4	17	holy one (in vision)		a watcher and a holy one	Alternate			
-DAN	4	18	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	18	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 DAN	4	19	Nebuchadnezzar, king of Babylon	letter		Alternate			
 DAN	4	19	Nebuchadnezzar, king of Babylon			Normal			
 DAN	4	19	Daniel	anxious	Belteshazzar (Daniel)	Normal			
-DAN	4	20	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	20	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	20	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	21	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	21	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	21	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	22	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	22	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	22	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	23	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	23	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	23	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	24	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	24	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	24	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	25	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	25	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	25	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	26	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	26	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	26	Nebuchadnezzar, king of Babylon	letter		Alternate			
-DAN	4	27	Daniel		Belteshazzar (Daniel)	Implicit			
+DAN	4	27	Daniel		Belteshazzar (Daniel)	Implicit			EntireVerse
 DAN	4	27	Nebuchadnezzar, king of Babylon	letter		Alternate			
 DAN	4	28	Nebuchadnezzar, king of Babylon	letter		Potential			
 DAN	4	29	Nebuchadnezzar, king of Babylon	letter		Potential			
@@ -14417,10 +14417,10 @@ DAN	4	32	voice from heaven (angel?)			Normal
 DAN	4	32	God		voice from heaven (God?)	Normal			
 DAN	4	32	Nebuchadnezzar, king of Babylon	letter		Alternate			
 DAN	4	33	Nebuchadnezzar, king of Babylon	letter		Potential			
-DAN	4	34	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	35	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	36	Nebuchadnezzar, king of Babylon	letter		Implicit			
-DAN	4	37	Nebuchadnezzar, king of Babylon	letter		Implicit			
+DAN	4	34	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	35	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	36	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
+DAN	4	37	Nebuchadnezzar, king of Babylon	letter		Implicit			EntireVerse
 DAN	5	2	Belshazzar, king of Babylon	commanding		Indirect			
 DAN	5	4	Belshazzar, king of Babylon/officials of Belshazzar/wives and concubines of Belshazzar	praising (probably drunk)	Belshazzar, his lords, his wives and his concubines	Indirect			
 DAN	5	7	Belshazzar, king of Babylon	commanding loudly (probably drunk)		Indirect			
@@ -14429,21 +14429,21 @@ DAN	5	10	queen of Babylon		queen (Belshazzar's mother)	Normal			EndOfVerse
 DAN	5	11	queen of Babylon		queen (Belshazzar's mother)	Normal			EntireVerse
 DAN	5	12	queen of Babylon		queen (Belshazzar's mother)	Normal			Unspecified
 DAN	5	13	Belshazzar, king of Babylon			Normal			EndOfVerse
-DAN	5	14	Belshazzar, king of Babylon			Implicit			
-DAN	5	15	Belshazzar, king of Babylon			Implicit			
-DAN	5	16	Belshazzar, king of Babylon			Implicit			
+DAN	5	14	Belshazzar, king of Babylon			Implicit			EntireVerse
+DAN	5	15	Belshazzar, king of Babylon			Implicit			EntireVerse
+DAN	5	16	Belshazzar, king of Babylon			Implicit			EntireVerse
 DAN	5	17	Daniel			Normal			Unspecified
-DAN	5	18	Daniel			Implicit			
-DAN	5	19	Daniel			Implicit			
-DAN	5	20	Daniel			Implicit			
-DAN	5	21	Daniel			Implicit			
-DAN	5	22	Daniel			Implicit			
-DAN	5	23	Daniel			Implicit			
-DAN	5	24	Daniel			Implicit			
-DAN	5	25	Daniel			Implicit			
-DAN	5	26	Daniel			Implicit			
-DAN	5	27	Daniel			Implicit			
-DAN	5	28	Daniel			Implicit			
+DAN	5	18	Daniel			Implicit			EntireVerse
+DAN	5	19	Daniel			Implicit			EntireVerse
+DAN	5	20	Daniel			Implicit			EntireVerse
+DAN	5	21	Daniel			Implicit			EntireVerse
+DAN	5	22	Daniel			Implicit			EntireVerse
+DAN	5	23	Daniel			Implicit			EntireVerse
+DAN	5	24	Daniel			Implicit			EntireVerse
+DAN	5	25	Daniel			Implicit			EntireVerse
+DAN	5	26	Daniel			Implicit			EntireVerse
+DAN	5	27	Daniel			Implicit			EntireVerse
+DAN	5	28	Daniel			Implicit			EntireVerse
 DAN	5	29	Belshazzar, king of Babylon	commanding		Indirect			
 DAN	6	5	satraps			Normal			EndOfVerse
 DAN	6	6	satraps/three administrators			Normal	satraps		EndOfVerse
@@ -14460,8 +14460,8 @@ DAN	6	22	Daniel			Normal			EntireVerse
 DAN	6	23	Darius, king of Medes and Persians	commanding (happily)		Indirect			
 DAN	6	24	Darius, king of Medes and Persians	commanding		Indirect			
 DAN	6	25	Darius, king of Medes and Persians	letter		Normal			EndOfVerse
-DAN	6	26	Darius, king of Medes and Persians	letter		Implicit			
-DAN	6	27	Darius, king of Medes and Persians	letter		Implicit			
+DAN	6	26	Darius, king of Medes and Persians	letter		Implicit			EntireVerse
+DAN	6	27	Darius, king of Medes and Persians	letter		Implicit			EntireVerse
 DAN	7	2	Daniel	vision		Normal			
 DAN	7	3	Daniel	vision		Normal			
 DAN	7	4	Daniel	vision		Normal			
@@ -14527,19 +14527,19 @@ DAN	8	17	Daniel	vision		Potential
 DAN	8	18	Daniel	vision		Potential			
 DAN	8	19	Gabriel			Normal			
 DAN	8	19	Daniel	vision		Potential			
-DAN	8	20	Gabriel			Implicit			
+DAN	8	20	Gabriel			Implicit			EntireVerse
 DAN	8	20	Daniel	vision		Alternate			
-DAN	8	21	Gabriel			Implicit			
+DAN	8	21	Gabriel			Implicit			EntireVerse
 DAN	8	21	Daniel	vision		Alternate			
-DAN	8	22	Gabriel			Implicit			
+DAN	8	22	Gabriel			Implicit			EntireVerse
 DAN	8	22	Daniel	vision		Alternate			
-DAN	8	23	Gabriel			Implicit			
+DAN	8	23	Gabriel			Implicit			EntireVerse
 DAN	8	23	Daniel	vision		Alternate			
-DAN	8	24	Gabriel			Implicit			
+DAN	8	24	Gabriel			Implicit			EntireVerse
 DAN	8	24	Daniel	vision		Alternate			
-DAN	8	25	Gabriel			Implicit			
+DAN	8	25	Gabriel			Implicit			EntireVerse
 DAN	8	25	Daniel	vision		Alternate			
-DAN	8	26	Gabriel			Implicit			
+DAN	8	26	Gabriel			Implicit			EntireVerse
 DAN	8	26	Daniel	vision		Alternate			
 DAN	9	1	Daniel	vision		Potential			
 DAN	9	2	Daniel	vision		Potential			
@@ -14550,15 +14550,15 @@ DAN	9	20	Daniel	vision		Potential
 DAN	9	21	Daniel	vision		Potential			
 DAN	9	22	Daniel	vision		Potential			
 DAN	9	22	Gabriel			Normal			
-DAN	9	23	Gabriel			Implicit			
+DAN	9	23	Gabriel			Implicit			EntireVerse
 DAN	9	23	Daniel	vision		Alternate			
-DAN	9	24	Gabriel			Implicit			
+DAN	9	24	Gabriel			Implicit			EntireVerse
 DAN	9	24	Daniel	vision		Alternate			
-DAN	9	25	Gabriel			Implicit			
+DAN	9	25	Gabriel			Implicit			EntireVerse
 DAN	9	25	Daniel	vision		Alternate			
-DAN	9	26	Gabriel			Implicit			
+DAN	9	26	Gabriel			Implicit			EntireVerse
 DAN	9	26	Daniel	vision		Alternate			
-DAN	9	27	Gabriel			Implicit			
+DAN	9	27	Gabriel			Implicit			EntireVerse
 DAN	9	27	Daniel	vision		Alternate			
 DAN	10	2	Daniel	vision		Potential			
 DAN	10	3	Daniel	vision		Potential			
@@ -14584,105 +14584,105 @@ DAN	10	19	Daniel			Normal
 DAN	10	19	man in linen above river			Normal			
 DAN	10	20	man in linen above river			Normal			
 DAN	10	20	Daniel	vision		Potential			
-DAN	10	21	man in linen above river			Implicit			
+DAN	10	21	man in linen above river			Implicit			EntireVerse
 DAN	10	21	Daniel	vision		Alternate			
-DAN	11	1	man in linen above river			Implicit			
+DAN	11	1	man in linen above river			Implicit			EntireVerse
 DAN	11	1	Daniel	vision		Alternate			
-DAN	11	2	man in linen above river			Implicit			
+DAN	11	2	man in linen above river			Implicit			EntireVerse
 DAN	11	2	Daniel	vision		Alternate			
-DAN	11	3	man in linen above river			Implicit			
+DAN	11	3	man in linen above river			Implicit			EntireVerse
 DAN	11	3	Daniel	vision		Alternate			
-DAN	11	4	man in linen above river			Implicit			
+DAN	11	4	man in linen above river			Implicit			EntireVerse
 DAN	11	4	Daniel	vision		Alternate			
-DAN	11	5	man in linen above river			Implicit			
+DAN	11	5	man in linen above river			Implicit			EntireVerse
 DAN	11	5	Daniel	vision		Alternate			
-DAN	11	6	man in linen above river			Implicit			
+DAN	11	6	man in linen above river			Implicit			EntireVerse
 DAN	11	6	Daniel	vision		Alternate			
-DAN	11	7	man in linen above river			Implicit			
+DAN	11	7	man in linen above river			Implicit			EntireVerse
 DAN	11	7	Daniel	vision		Alternate			
-DAN	11	8	man in linen above river			Implicit			
+DAN	11	8	man in linen above river			Implicit			EntireVerse
 DAN	11	8	Daniel	vision		Alternate			
-DAN	11	9	man in linen above river			Implicit			
+DAN	11	9	man in linen above river			Implicit			EntireVerse
 DAN	11	9	Daniel	vision		Alternate			
-DAN	11	10	man in linen above river			Implicit			
+DAN	11	10	man in linen above river			Implicit			EntireVerse
 DAN	11	10	Daniel	vision		Alternate			
-DAN	11	11	man in linen above river			Implicit			
+DAN	11	11	man in linen above river			Implicit			EntireVerse
 DAN	11	11	Daniel	vision		Alternate			
-DAN	11	12	man in linen above river			Implicit			
+DAN	11	12	man in linen above river			Implicit			EntireVerse
 DAN	11	12	Daniel	vision		Alternate			
-DAN	11	13	man in linen above river			Implicit			
+DAN	11	13	man in linen above river			Implicit			EntireVerse
 DAN	11	13	Daniel	vision		Alternate			
-DAN	11	14	man in linen above river			Implicit			
+DAN	11	14	man in linen above river			Implicit			EntireVerse
 DAN	11	14	Daniel	vision		Alternate			
-DAN	11	15	man in linen above river			Implicit			
+DAN	11	15	man in linen above river			Implicit			EntireVerse
 DAN	11	15	Daniel	vision		Alternate			
-DAN	11	16	man in linen above river			Implicit			
+DAN	11	16	man in linen above river			Implicit			EntireVerse
 DAN	11	16	Daniel	vision		Alternate			
-DAN	11	17	man in linen above river			Implicit			
+DAN	11	17	man in linen above river			Implicit			EntireVerse
 DAN	11	17	Daniel	vision		Alternate			
-DAN	11	18	man in linen above river			Implicit			
+DAN	11	18	man in linen above river			Implicit			EntireVerse
 DAN	11	18	Daniel	vision		Alternate			
-DAN	11	19	man in linen above river			Implicit			
+DAN	11	19	man in linen above river			Implicit			EntireVerse
 DAN	11	19	Daniel	vision		Alternate			
-DAN	11	20	man in linen above river			Implicit			
+DAN	11	20	man in linen above river			Implicit			EntireVerse
 DAN	11	20	Daniel	vision		Alternate			
-DAN	11	21	man in linen above river			Implicit			
+DAN	11	21	man in linen above river			Implicit			EntireVerse
 DAN	11	21	Daniel	vision		Alternate			
-DAN	11	22	man in linen above river			Implicit			
+DAN	11	22	man in linen above river			Implicit			EntireVerse
 DAN	11	22	Daniel	vision		Alternate			
-DAN	11	23	man in linen above river			Implicit			
+DAN	11	23	man in linen above river			Implicit			EntireVerse
 DAN	11	23	Daniel	vision		Alternate			
-DAN	11	24	man in linen above river			Implicit			
+DAN	11	24	man in linen above river			Implicit			EntireVerse
 DAN	11	24	Daniel	vision		Alternate			
-DAN	11	25	man in linen above river			Implicit			
+DAN	11	25	man in linen above river			Implicit			EntireVerse
 DAN	11	25	Daniel	vision		Alternate			
-DAN	11	26	man in linen above river			Implicit			
+DAN	11	26	man in linen above river			Implicit			EntireVerse
 DAN	11	26	Daniel	vision		Alternate			
-DAN	11	27	man in linen above river			Implicit			
+DAN	11	27	man in linen above river			Implicit			EntireVerse
 DAN	11	27	Daniel	vision		Alternate			
-DAN	11	28	man in linen above river			Implicit			
+DAN	11	28	man in linen above river			Implicit			EntireVerse
 DAN	11	28	Daniel	vision		Alternate			
-DAN	11	29	man in linen above river			Implicit			
+DAN	11	29	man in linen above river			Implicit			EntireVerse
 DAN	11	29	Daniel	vision		Alternate			
-DAN	11	30	man in linen above river			Implicit			
+DAN	11	30	man in linen above river			Implicit			EntireVerse
 DAN	11	30	Daniel	vision		Alternate			
-DAN	11	31	man in linen above river			Implicit			
+DAN	11	31	man in linen above river			Implicit			EntireVerse
 DAN	11	31	Daniel	vision		Alternate			
-DAN	11	32	man in linen above river			Implicit			
+DAN	11	32	man in linen above river			Implicit			EntireVerse
 DAN	11	32	Daniel	vision		Alternate			
-DAN	11	33	man in linen above river			Implicit			
+DAN	11	33	man in linen above river			Implicit			EntireVerse
 DAN	11	33	Daniel	vision		Alternate			
-DAN	11	34	man in linen above river			Implicit			
+DAN	11	34	man in linen above river			Implicit			EntireVerse
 DAN	11	34	Daniel	vision		Alternate			
-DAN	11	35	man in linen above river			Implicit			
+DAN	11	35	man in linen above river			Implicit			EntireVerse
 DAN	11	35	Daniel	vision		Alternate			
-DAN	11	36	man in linen above river			Implicit			
+DAN	11	36	man in linen above river			Implicit			EntireVerse
 DAN	11	36	Daniel	vision		Alternate			
-DAN	11	37	man in linen above river			Implicit			
+DAN	11	37	man in linen above river			Implicit			EntireVerse
 DAN	11	37	Daniel	vision		Alternate			
-DAN	11	38	man in linen above river			Implicit			
+DAN	11	38	man in linen above river			Implicit			EntireVerse
 DAN	11	38	Daniel	vision		Alternate			
-DAN	11	39	man in linen above river			Implicit			
+DAN	11	39	man in linen above river			Implicit			EntireVerse
 DAN	11	39	Daniel	vision		Alternate			
-DAN	11	40	man in linen above river			Implicit			
+DAN	11	40	man in linen above river			Implicit			EntireVerse
 DAN	11	40	Daniel	vision		Alternate			
-DAN	11	41	man in linen above river			Implicit			
+DAN	11	41	man in linen above river			Implicit			EntireVerse
 DAN	11	41	Daniel	vision		Alternate			
-DAN	11	42	man in linen above river			Implicit			
+DAN	11	42	man in linen above river			Implicit			EntireVerse
 DAN	11	42	Daniel	vision		Alternate			
-DAN	11	43	man in linen above river			Implicit			
+DAN	11	43	man in linen above river			Implicit			EntireVerse
 DAN	11	43	Daniel	vision		Alternate			
-DAN	11	44	man in linen above river			Implicit			
+DAN	11	44	man in linen above river			Implicit			EntireVerse
 DAN	11	44	Daniel	vision		Alternate			
-DAN	11	45	man in linen above river			Implicit			
+DAN	11	45	man in linen above river			Implicit			EntireVerse
 DAN	11	45	Daniel	vision		Alternate			
-DAN	12	1	man in linen above river			Implicit			
+DAN	12	1	man in linen above river			Implicit			EntireVerse
 DAN	12	1	Daniel	vision		Alternate			
-DAN	12	2	man in linen above river			Implicit			
+DAN	12	2	man in linen above river			Implicit			EntireVerse
 DAN	12	2	Daniel	vision		Alternate			
-DAN	12	3	man in linen above river			Implicit			
+DAN	12	3	man in linen above river			Implicit			EntireVerse
 DAN	12	3	Daniel	vision		Alternate			
-DAN	12	4	man in linen above river			Implicit			
+DAN	12	4	man in linen above river			Implicit			EntireVerse
 DAN	12	4	Daniel	vision		Alternate			
 DAN	12	5	Daniel	vision		Potential			
 DAN	12	6	Daniel	vision		Potential			
@@ -14712,159 +14712,159 @@ HOS	1	10	narrator-HOS			Quotation			Unspecified
 HOS	1	11	God		God (Yahweh)	Potential			
 HOS	2	1	God		God (Yahweh)	Normal			
 HOS	2	1	narrator-HOS			Quotation			Unspecified
-HOS	2	2	God		God (Yahweh)	Implicit			
-HOS	2	3	God		God (Yahweh)	Implicit			
-HOS	2	4	God		God (Yahweh)	Implicit			
+HOS	2	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	2	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	2	4	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	5	God		God (Yahweh)	Normal			
 HOS	2	5	prostitute (symbolic of Israel)			Hypothetical			Unspecified
-HOS	2	6	God		God (Yahweh)	Implicit			
+HOS	2	6	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	7	God		God (Yahweh)	Normal			
 HOS	2	7	prostitute (symbolic of Israel)			Hypothetical			Unspecified
-HOS	2	8	God		God (Yahweh)	Implicit			
-HOS	2	9	God		God (Yahweh)	Implicit			
-HOS	2	10	God		God (Yahweh)	Implicit			
-HOS	2	11	God		God (Yahweh)	Implicit			
+HOS	2	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	2	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	2	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	2	11	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	12	God		God (Yahweh)	Normal			
 HOS	2	12	prostitute (symbolic of Israel)			Hypothetical			Unspecified
 HOS	2	13	God		God (Yahweh)	Normal			
 HOS	2	13	Hosea		Hosea (Yahweh says)	Potential			
-HOS	2	14	God		God (Yahweh)	Implicit			
+HOS	2	14	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	14	Hosea		Hosea (Yahweh says)	Alternate			
-HOS	2	15	God		God (Yahweh)	Implicit			
+HOS	2	15	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	15	Hosea		Hosea (Yahweh says)	Alternate			
 HOS	2	16	God		God (Yahweh)	Normal			
 HOS	2	16	Hosea		Hosea (Yahweh says)	Potential			
-HOS	2	17	God		God (Yahweh)	Implicit			
+HOS	2	17	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	17	Hosea		Hosea (Yahweh says)	Alternate			
-HOS	2	18	God		God (Yahweh)	Implicit			
+HOS	2	18	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	18	Hosea		Hosea (Yahweh says)	Alternate			
-HOS	2	19	God		God (Yahweh)	Implicit			
+HOS	2	19	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	19	Hosea		Hosea (Yahweh says)	Alternate			
-HOS	2	20	God		God (Yahweh)	Implicit			
+HOS	2	20	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	20	Hosea		Hosea (Yahweh says)	Alternate			
 HOS	2	21	God		God (Yahweh)	Normal			
 HOS	2	21	Hosea		Hosea (Yahweh says)	Potential			
-HOS	2	22	God		God (Yahweh)	Implicit			
+HOS	2	22	God		God (Yahweh)	Implicit			EntireVerse
 HOS	2	22	Hosea		Hosea (Yahweh says)	Alternate			
-HOS	2	23	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
+HOS	2	23	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
 HOS	2	23	people, God's			Hypothetical			
 HOS	3	1	God		God (Yahweh)	Normal			
 HOS	3	3	narrator-HOS			Quotation			
 HOS	4	1	Hosea			Normal			
 HOS	4	1	God		God (Yahweh)	Normal			
-HOS	4	2	God		God (Yahweh)	Implicit			
-HOS	4	3	God		God (Yahweh)	Implicit			
-HOS	4	4	God		God (Yahweh)	Implicit			
-HOS	4	5	God		God (Yahweh)	Implicit			
-HOS	4	6	God		God (Yahweh)	Implicit			
-HOS	4	7	God		God (Yahweh)	Implicit			
-HOS	4	8	God		God (Yahweh)	Implicit			
-HOS	4	9	God		God (Yahweh)	Implicit			
-HOS	4	10	God		God (Yahweh)	Implicit			
-HOS	4	11	God		God (Yahweh)	Implicit			
-HOS	4	12	God		God (Yahweh)	Implicit			
-HOS	4	13	God		God (Yahweh)	Implicit			
-HOS	4	14	God		God (Yahweh)	Implicit			
+HOS	4	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	12	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	13	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	14	God		God (Yahweh)	Implicit			EntireVerse
 # The quoted text in v.15 could be treated as a Hypothetical quote instead, but since it is not
 # dramatized in the reference text and it is sommething God is saying not to say -- as opposed
 # to something He is explicitly accusing them of saying -- we can just note it as a self-quote
 # and it won't interfere with the treatment of this discourse as implicitly spoken by God.
-HOS	4	15	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			
-HOS	4	16	God		God (Yahweh)	Implicit			
-HOS	4	17	God		God (Yahweh)	Implicit			
-HOS	4	18	God		God (Yahweh)	Implicit			
-HOS	4	19	God		God (Yahweh)	Implicit			
-HOS	5	1	God		God (Yahweh)	Implicit			
-HOS	5	2	God		God (Yahweh)	Implicit			
-HOS	5	3	God		God (Yahweh)	Implicit			
-HOS	5	4	God		God (Yahweh)	Implicit			
-HOS	5	5	God		God (Yahweh)	Implicit			
-HOS	5	6	God		God (Yahweh)	Implicit			
-HOS	5	7	God		God (Yahweh)	Implicit			
-HOS	5	8	God		God (Yahweh)	Implicit			
-HOS	5	9	God		God (Yahweh)	Implicit			
-HOS	5	10	God		God (Yahweh)	Implicit			
-HOS	5	11	God		God (Yahweh)	Implicit			
-HOS	5	12	God		God (Yahweh)	Implicit			
-HOS	5	13	God		God (Yahweh)	Implicit			
-HOS	5	14	God		God (Yahweh)	Implicit			
-HOS	5	15	God		God (Yahweh)	Implicit			
-HOS	6	4	God		God (Yahweh)	Implicit			
-HOS	6	5	God		God (Yahweh)	Implicit			
-HOS	6	6	God		God (Yahweh)	Implicit			
-HOS	6	7	God		God (Yahweh)	Implicit			
-HOS	6	8	God		God (Yahweh)	Implicit			
-HOS	6	9	God		God (Yahweh)	Implicit			
-HOS	6	10	God		God (Yahweh)	Implicit			
-HOS	6	11	God		God (Yahweh)	Implicit			
-HOS	7	1	God		God (Yahweh)	Implicit			
-HOS	7	2	God		God (Yahweh)	Implicit			
-HOS	7	3	God		God (Yahweh)	Implicit			
-HOS	7	4	God		God (Yahweh)	Implicit			
-HOS	7	5	God		God (Yahweh)	Implicit			
-HOS	7	6	God		God (Yahweh)	Implicit			
-HOS	7	7	God		God (Yahweh)	Implicit			
-HOS	7	8	God		God (Yahweh)	Implicit			
-HOS	7	9	God		God (Yahweh)	Implicit			
-HOS	7	10	God		God (Yahweh)	Implicit			
-HOS	7	11	God		God (Yahweh)	Implicit			
-HOS	7	12	God		God (Yahweh)	Implicit			
-HOS	7	13	God		God (Yahweh)	Implicit			
-HOS	7	14	God		God (Yahweh)	Implicit			
-HOS	7	15	God		God (Yahweh)	Implicit			
-HOS	7	16	God		God (Yahweh)	Implicit			
-HOS	8	1	God		God (Yahweh)	Implicit			
-HOS	8	2	God		God (Yahweh)	Implicit			
-HOS	8	3	God		God (Yahweh)	Implicit			
-HOS	8	4	God		God (Yahweh)	Implicit			
-HOS	8	5	God		God (Yahweh)	Implicit			
-HOS	8	6	God		God (Yahweh)	Implicit			
-HOS	8	7	God		God (Yahweh)	Implicit			
-HOS	8	8	God		God (Yahweh)	Implicit			
-HOS	8	9	God		God (Yahweh)	Implicit			
-HOS	8	10	God		God (Yahweh)	Implicit			
-HOS	8	11	God		God (Yahweh)	Implicit			
-HOS	8	12	God		God (Yahweh)	Implicit			
-HOS	8	13	God		God (Yahweh)	Implicit			
-HOS	8	14	God		God (Yahweh)	Implicit			
+HOS	4	15	God		God (Yahweh)	ImplicitWithPotentialSelfQuote			EntireVerse
+HOS	4	16	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	17	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	18	God		God (Yahweh)	Implicit			EntireVerse
+HOS	4	19	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	1	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	12	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	13	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	14	God		God (Yahweh)	Implicit			EntireVerse
+HOS	5	15	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	6	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	1	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	12	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	13	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	14	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	15	God		God (Yahweh)	Implicit			EntireVerse
+HOS	7	16	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	1	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	12	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	13	God		God (Yahweh)	Implicit			EntireVerse
+HOS	8	14	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	1-9	Hosea			Potential			
 HOS	9	1-9	God		God (Yahweh)	Potential			
-HOS	9	10	God		God (Yahweh)	Implicit			
+HOS	9	10	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	10	Hosea			Alternate			
-HOS	9	11	God		God (Yahweh)	Implicit			
+HOS	9	11	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	11	Hosea			Alternate			
-HOS	9	12	God		God (Yahweh)	Implicit			
+HOS	9	12	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	12	Hosea			Alternate			
-HOS	9	13	God		God (Yahweh)	Implicit			
+HOS	9	13	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	13	Hosea			Alternate			
 HOS	9	14	Hosea			Potential			
-HOS	9	15	God		God (Yahweh)	Implicit			
-HOS	9	16	God		God (Yahweh)	Implicit			
+HOS	9	15	God		God (Yahweh)	Implicit			EntireVerse
+HOS	9	16	God		God (Yahweh)	Implicit			EntireVerse
 HOS	9	17	Hosea			Potential			
 HOS	10	3	Israel			Hypothetical			
 HOS	10	8	Israel			Hypothetical			
 HOS	10	9	God		God (Yahweh)	Potential			
-HOS	10	10	God		God (Yahweh)	Implicit			
-HOS	10	11	God		God (Yahweh)	Implicit			
+HOS	10	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	10	11	God		God (Yahweh)	Implicit			EntireVerse
 HOS	10	12	God		God (Yahweh)	Potential			
 HOS	10	13	God		God (Yahweh)	Potential			
 HOS	10	14	God		God (Yahweh)	Potential			
 HOS	10	15	God		God (Yahweh)	Potential			
-HOS	11	1	God		God (Yahweh)	Implicit			
-HOS	11	2	God		God (Yahweh)	Implicit			
-HOS	11	3	God		God (Yahweh)	Implicit			
-HOS	11	4	God		God (Yahweh)	Implicit			
-HOS	11	5	God		God (Yahweh)	Implicit			
-HOS	11	6	God		God (Yahweh)	Implicit			
-HOS	11	7	God		God (Yahweh)	Implicit			
-HOS	11	8	God		God (Yahweh)	Implicit			
-HOS	11	9	God		God (Yahweh)	Implicit			
+HOS	11	1	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	2	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	3	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	11	9	God		God (Yahweh)	Implicit			EntireVerse
 HOS	11	10	God		God (Yahweh)	Normal			
-HOS	11	11	God		God (Yahweh)	Implicit			
+HOS	11	11	God		God (Yahweh)	Implicit			EntireVerse
 HOS	11	12	God		God (Yahweh)	Potential			
 HOS	12	8	Ephraim			Quotation			
-HOS	12	9	God		God (Yahweh)	Implicit			
-HOS	12	10	God		God (Yahweh)	Implicit			
+HOS	12	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	12	10	God		God (Yahweh)	Implicit			EntireVerse
 # FCBH has God speak all the way through 12:14, which seems probable, but some Bibles that use explicit quotes end them at v. 10.
 HOS	12	11	God		God (Yahweh)	Potential			
 HOS	12	12	God		God (Yahweh)	Potential			
@@ -14877,28 +14877,28 @@ HOS	13	2	God		God (Yahweh)	Potential
 #character that covers either case and thereby avoid a disambiguation issue.
 HOS	13	2	saying about (or by) idolaters			Quotation			
 HOS	13	3	God		God (Yahweh)	Potential			
-HOS	13	4	God		God (Yahweh)	Implicit			
-HOS	13	5	God		God (Yahweh)	Implicit			
-HOS	13	6	God		God (Yahweh)	Implicit			
-HOS	13	7	God		God (Yahweh)	Implicit			
-HOS	13	8	God		God (Yahweh)	Implicit			
-HOS	13	9	God		God (Yahweh)	Implicit			
-HOS	13	10	God		God (Yahweh)	Implicit			
-HOS	13	11	God		God (Yahweh)	Implicit			
-HOS	13	12	God		God (Yahweh)	Implicit			
-HOS	13	13	God		God (Yahweh)	Implicit			
-HOS	13	14	God		God (Yahweh)	Implicit			
-HOS	13	15	God		God (Yahweh)	Implicit			
-HOS	13	16	God		God (Yahweh)	Implicit			
+HOS	13	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	8	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	9	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	10	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	11	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	12	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	13	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	14	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	15	God		God (Yahweh)	Implicit			EntireVerse
+HOS	13	16	God		God (Yahweh)	Implicit			EntireVerse
 HOS	14	1	God		God (Yahweh)	Potential			
 HOS	14	2	God		God (Yahweh)	Potential			
 HOS	14	2	Israel			Hypothetical			
 HOS	14	3	Israel			Hypothetical			
-HOS	14	4	God		God (Yahweh)	Implicit			
-HOS	14	5	God		God (Yahweh)	Implicit			
-HOS	14	6	God		God (Yahweh)	Implicit			
-HOS	14	7	God		God (Yahweh)	Implicit			
-HOS	14	8	God		God (Yahweh)	Implicit			
+HOS	14	4	God		God (Yahweh)	Implicit			EntireVerse
+HOS	14	5	God		God (Yahweh)	Implicit			EntireVerse
+HOS	14	6	God		God (Yahweh)	Implicit			EntireVerse
+HOS	14	7	God		God (Yahweh)	Implicit			EntireVerse
+HOS	14	8	God		God (Yahweh)	Implicit			EntireVerse
 JOL	2	12	God		God (Yahweh)	Normal			
 JOL	2	13	God		God (Yahweh)	Potential			
 JOL	2	17	priests	weeping, pleading		Hypothetical			
@@ -14909,22 +14909,22 @@ JOL	2	21	God		God (Yahweh)	Potential
 JOL	2	22	God		God (Yahweh)	Potential			
 JOL	2	23	God		God (Yahweh)	Potential			
 JOL	2	24	God		God (Yahweh)	Potential			
-JOL	2	25	God		God (Yahweh)	Implicit			
-JOL	2	26	God		God (Yahweh)	Implicit			
-JOL	2	27	God		God (Yahweh)	Implicit			
-JOL	2	28	God		God (Yahweh)	Implicit			
-JOL	2	29	God		God (Yahweh)	Implicit			
-JOL	2	30	God		God (Yahweh)	Implicit			
-JOL	2	31	God		God (Yahweh)	Implicit			
+JOL	2	25	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	26	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	27	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	28	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	29	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	30	God		God (Yahweh)	Implicit			EntireVerse
+JOL	2	31	God		God (Yahweh)	Implicit			EntireVerse
 JOL	2	32	God		God (Yahweh)	Normal			
-JOL	3	1	God		God (Yahweh)	Implicit			
-JOL	3	2	God		God (Yahweh)	Implicit			
-JOL	3	3	God		God (Yahweh)	Implicit			
-JOL	3	4	God		God (Yahweh)	Implicit			
-JOL	3	5	God		God (Yahweh)	Implicit			
-JOL	3	6	God		God (Yahweh)	Implicit			
-JOL	3	7	God		God (Yahweh)	Implicit			
-JOL	3	8	God		God (Yahweh)	Implicit			
+JOL	3	1	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	2	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	3	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	4	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	5	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	6	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	7	God		God (Yahweh)	Implicit			EntireVerse
+JOL	3	8	God		God (Yahweh)	Implicit			EntireVerse
 JOL	3	9	God		God (Yahweh)	Potential			
 JOL	3	9	Joel			Potential			
 JOL	3	9	you (hypothetical)			Hypothetical			
@@ -14937,7 +14937,7 @@ JOL	3	11	God		God (Yahweh)	Potential
 JOL	3	11	Joel			Potential			
 JOL	3	12	God		God (Yahweh)	Normal			
 JOL	3	13	God		God (Yahweh)	Normal			
-JOL	3	17	God		God (Yahweh)	Implicit			
+JOL	3	17	God		God (Yahweh)	Implicit			EntireVerse
 JOL	3	18	God		God (Yahweh)	Potential			
 JOL	3	19	God		God (Yahweh)	Potential			
 JOL	3	20	God		God (Yahweh)	Potential			
@@ -14945,62 +14945,62 @@ JOL	3	21	God		God (Yahweh)	Normal
 AMO	1	2	Amos			Normal			
 AMO	1	3	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	3	God		God (Yahweh)	Normal			
-AMO	1	4	God		God (Yahweh)	Implicit			
+AMO	1	4	God		God (Yahweh)	Implicit			EntireVerse
 AMO	1	4	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	5	God		God (Yahweh)	Normal			
 AMO	1	5	Amos		Amos (Yahweh says)	Potential			
 AMO	1	6	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	6	God		God (Yahweh)	Normal			
-AMO	1	7	God		God (Yahweh)	Implicit			
+AMO	1	7	God		God (Yahweh)	Implicit			EntireVerse
 AMO	1	7	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	8	God		God (Yahweh)	Normal			
 AMO	1	8	Amos		Amos (Yahweh says)	Potential			
 AMO	1	9	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	9	God		God (Yahweh)	Normal			
-AMO	1	10	God		God (Yahweh)	Implicit			
+AMO	1	10	God		God (Yahweh)	Implicit			EntireVerse
 AMO	1	10	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	11	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	11	God		God (Yahweh)	Normal			
-AMO	1	12	God		God (Yahweh)	Implicit			
+AMO	1	12	God		God (Yahweh)	Implicit			EntireVerse
 AMO	1	12	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	13	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	13	God		God (Yahweh)	Normal			
-AMO	1	14	God		God (Yahweh)	Implicit			
+AMO	1	14	God		God (Yahweh)	Implicit			EntireVerse
 AMO	1	14	Amos		Amos (Yahweh says)	Alternate			
 AMO	1	15	God		God (Yahweh)	Normal			
 AMO	1	15	Amos		Amos (Yahweh says)	Potential			
 AMO	2	1	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	1	God		God (Yahweh)	Normal			
-AMO	2	2	God		God (Yahweh)	Implicit			
+AMO	2	2	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	2	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	3	God		God (Yahweh)	Normal			
 AMO	2	3	Amos		Amos (Yahweh says)	Potential			
 AMO	2	4	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	4	God		God (Yahweh)	Normal			
-AMO	2	5	God		God (Yahweh)	Implicit			
+AMO	2	5	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	5	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	6	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	6	God		God (Yahweh)	Normal			
-AMO	2	7	God		God (Yahweh)	Implicit			
+AMO	2	7	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	7	Amos		Amos (Yahweh says)	Alternate			
-AMO	2	8	God		God (Yahweh)	Implicit			
+AMO	2	8	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	8	Amos		Amos (Yahweh says)	Alternate			
-AMO	2	9	God		God (Yahweh)	Implicit			
+AMO	2	9	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	9	Amos		Amos (Yahweh says)	Alternate			
-AMO	2	10	God		God (Yahweh)	Implicit			
+AMO	2	10	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	10	Amos		Amos (Yahweh says)	Alternate			
 AMO	2	11	God		God (Yahweh)	Normal			
 AMO	2	11	Amos		Amos (Yahweh says)	Potential			
-AMO	2	12	God		God (Yahweh)	Implicit			
+AMO	2	12	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	12	Israel		you (Israel)	Hypothetical			
-AMO	2	13	God		God (Yahweh)	Implicit			
-AMO	2	14	God		God (Yahweh)	Implicit			
-AMO	2	15	God		God (Yahweh)	Implicit			
+AMO	2	13	God		God (Yahweh)	Implicit			EntireVerse
+AMO	2	14	God		God (Yahweh)	Implicit			EntireVerse
+AMO	2	15	God		God (Yahweh)	Implicit			EntireVerse
 AMO	2	16	God		God (Yahweh)	Normal			
 AMO	2	16	Amos		Amos (Yahweh says)	Potential			
 AMO	3	1	Amos			Potential			
 AMO	3	1	God		God (Yahweh)	Potential			
-AMO	3	2	God		God (Yahweh)	Implicit			
+AMO	3	2	God		God (Yahweh)	Implicit			EntireVerse
 AMO	3	3	God		God (Yahweh)	Potential			
 AMO	3	4	God		God (Yahweh)	Potential			
 AMO	3	5	God		God (Yahweh)	Potential			
@@ -15009,17 +15009,17 @@ AMO	3	7	God		God (Yahweh)	Potential
 AMO	3	8	God		God (Yahweh)	Potential			
 AMO	3	9	God		God (Yahweh)	Normal			
 AMO	3	9	Amos			Normal			
-AMO	3	9	Needs Review			Implicit			
+AMO	3	9	Needs Review			Implicit			EntireVerse
 AMO	3	10	God		God (Yahweh)	Normal			
 AMO	3	10	Amos		Amos (Yahweh says)	Potential			
-AMO	3	10	Needs Review			Implicit			
+AMO	3	10	Needs Review			Implicit			EntireVerse
 AMO	3	11	Amos		Amos (Yahweh says)	Alternate			
 AMO	3	11	God		God (Yahweh)	Normal			
 AMO	3	12	Amos		Amos (Yahweh says)	Alternate			
 AMO	3	12	God		God (Yahweh)	Normal			
 AMO	3	13	God		God (Yahweh)	Normal			
 AMO	3	13	Amos		Amos (Yahweh says)	Potential			
-AMO	3	14	God		God (Yahweh)	Implicit			
+AMO	3	14	God		God (Yahweh)	Implicit			EntireVerse
 AMO	3	14	Amos		Amos (Yahweh says)	Alternate			
 AMO	3	15	God		God (Yahweh)	Normal			
 AMO	3	15	Amos		Amos (Yahweh says)	Potential			
@@ -15029,13 +15029,13 @@ AMO	4	2	Amos		Amos (Yahweh says)	Alternate
 AMO	4	2	God		God (Yahweh)	Normal			
 AMO	4	3	God		God (Yahweh)	Normal			
 AMO	4	3	Amos		Amos (Yahweh says)	Potential			
-AMO	4	4	God		God (Yahweh)	Implicit			
+AMO	4	4	God		God (Yahweh)	Implicit			EntireVerse
 AMO	4	4	Amos		Amos (Yahweh says)	Alternate			
 AMO	4	5	God		God (Yahweh)	Normal			
 AMO	4	5	Amos		Amos (Yahweh says)	Potential			
 AMO	4	6	God		God (Yahweh)	Normal			
 AMO	4	6	Amos		Amos (Yahweh says)	Potential			
-AMO	4	7	God		God (Yahweh)	Implicit			
+AMO	4	7	God		God (Yahweh)	Implicit			EntireVerse
 AMO	4	7	Amos		Amos (Yahweh says)	Alternate			
 AMO	4	8	God		God (Yahweh)	Normal			
 AMO	4	8	Amos		Amos (Yahweh says)	Potential			
@@ -15079,17 +15079,17 @@ AMO	5	17	Amos		Amos (Yahweh says)	Potential
 AMO	5	18	God		God (Yahweh)	Potential			
 AMO	5	19	God		God (Yahweh)	Potential			
 AMO	5	20	God		God (Yahweh)	Potential			
-AMO	5	21	God		God (Yahweh)	Implicit			
+AMO	5	21	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	21	Amos		Amos (Yahweh says)	Alternate			
-AMO	5	22	God		God (Yahweh)	Implicit			
+AMO	5	22	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	22	Amos		Amos (Yahweh says)	Alternate			
-AMO	5	23	God		God (Yahweh)	Implicit			
+AMO	5	23	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	23	Amos		Amos (Yahweh says)	Alternate			
-AMO	5	24	God		God (Yahweh)	Implicit			
+AMO	5	24	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	24	Amos		Amos (Yahweh says)	Alternate			
-AMO	5	25	God		God (Yahweh)	Implicit			
+AMO	5	25	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	25	Amos		Amos (Yahweh says)	Alternate			
-AMO	5	26	God		God (Yahweh)	Implicit			
+AMO	5	26	God		God (Yahweh)	Implicit			EntireVerse
 AMO	5	26	Amos		Amos (Yahweh says)	Alternate			
 AMO	5	27	God		God (Yahweh)	Normal			
 AMO	5	27	Amos		Amos (Yahweh says)	Potential			
@@ -15110,7 +15110,7 @@ AMO	7	2	Amos			Quotation
 AMO	7	3	God		God (Yahweh)	Normal			
 AMO	7	3	Amos		Amos (Yahweh says)	Alternate			
 AMO	7	4	God		God (Yahweh)	Potential			
-AMO	7	5	narrator-AMO			ImplicitWithPotentialSelfQuote			
+AMO	7	5	narrator-AMO			ImplicitWithPotentialSelfQuote			EntireVerse
 AMO	7	6	God		God (Yahweh)	Normal			
 AMO	7	6	Amos		Amos (Yahweh says)	Alternate			
 AMO	7	8	Amos			Quotation			
@@ -15138,67 +15138,67 @@ AMO	8	6	oppressors of poor			Hypothetical
 AMO	8	6	God		God (Yahweh)	Potential			
 AMO	8	7	God		God (Yahweh)	Normal			
 AMO	8	7	Amos		Amos (Yahweh says)	Alternate			
-AMO	8	8	God		God (Yahweh)	Implicit			
+AMO	8	8	God		God (Yahweh)	Implicit			EntireVerse
 AMO	8	8	Amos		Amos (Yahweh says)	Alternate			
 AMO	8	9	God		God (Yahweh)	Normal			
 AMO	8	9	Amos		Amos (Yahweh says)	Potential			
-AMO	8	10	God		God (Yahweh)	Implicit			
+AMO	8	10	God		God (Yahweh)	Implicit			EntireVerse
 AMO	8	10	Amos		Amos (Yahweh says)	Alternate			
 AMO	8	11	God		God (Yahweh)	Normal			
 AMO	8	11	Amos		Amos (Yahweh says)	Potential			
-AMO	8	12	God		God (Yahweh)	Implicit			
+AMO	8	12	God		God (Yahweh)	Implicit			EntireVerse
 AMO	8	12	Amos		Amos (Yahweh says)	Alternate			
-AMO	8	13	God		God (Yahweh)	Implicit			
+AMO	8	13	God		God (Yahweh)	Implicit			EntireVerse
 AMO	8	13	Amos		Amos (Yahweh says)	Alternate			
 AMO	8	14	God		God (Yahweh)	Normal			
 AMO	8	14	virgin/young man		beautiful virgins/young men	Hypothetical			
 AMO	8	14	Amos		Amos (Yahweh says)	Alternate			
 AMO	9	1	God		God (Yahweh)	Normal			
-AMO	9	2	God		God (Yahweh)	Implicit			
-AMO	9	3	God		God (Yahweh)	Implicit			
-AMO	9	4	God		God (Yahweh)	Implicit			
+AMO	9	2	God		God (Yahweh)	Implicit			EntireVerse
+AMO	9	3	God		God (Yahweh)	Implicit			EntireVerse
+AMO	9	4	God		God (Yahweh)	Implicit			EntireVerse
 AMO	9	5	God		God (Yahweh)	Potential			
 AMO	9	6	God		God (Yahweh)	Potential			
 AMO	9	7	God		God (Yahweh)	Normal			
 AMO	9	7	Amos		Amos (Yahweh says)	Potential			
 AMO	9	8	God		God (Yahweh)	Normal			
 AMO	9	8	Amos		Amos (Yahweh says)	Potential			
-AMO	9	9	God		God (Yahweh)	Implicit			
+AMO	9	9	God		God (Yahweh)	Implicit			EntireVerse
 AMO	9	9	Amos		Amos (Yahweh says)	Alternate			
 AMO	9	10	God		God (Yahweh)	Normal			
 AMO	9	10	sinners		sinners among God's people	Hypothetical			
 AMO	9	10	Amos		Amos (Yahweh says)	Alternate			
-AMO	9	11	God		God (Yahweh)	Implicit			
+AMO	9	11	God		God (Yahweh)	Implicit			EntireVerse
 AMO	9	11	Amos		Amos (Yahweh says)	Alternate			
 AMO	9	12	God		God (Yahweh)	Normal			
 AMO	9	12	Amos		Amos (Yahweh says)	Potential			
 AMO	9	13	God		God (Yahweh)	Normal			
 AMO	9	13	Amos		Amos (Yahweh says)	Potential			
-AMO	9	14	God		God (Yahweh)	Implicit			
+AMO	9	14	God		God (Yahweh)	Implicit			EntireVerse
 AMO	9	14	Amos		Amos (Yahweh says)	Alternate			
 AMO	9	15	God		God (Yahweh)	Normal			
 AMO	9	15	Amos		Amos (Yahweh says)	Potential			
 OBA	1	1	ambassador			Alternate			
 OBA	1	1	God		God (Yahweh)	Potential			
-OBA	1	2	God		God (Yahweh)	Implicit			
-OBA	1	3	God		God (Yahweh)	Implicit			
+OBA	1	2	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	3	God		God (Yahweh)	Implicit			EntireVerse
 OBA	1	3	Edom			Hypothetical			
 OBA	1	4	God		God (Yahweh)	Normal			
 OBA	1	4	Obadiah, prophet		Obadiah (Yahweh says)	Potential			
-OBA	1	5	God		God (Yahweh)	Implicit			
-OBA	1	6	God		God (Yahweh)	Implicit			
-OBA	1	7	God		God (Yahweh)	Implicit			
+OBA	1	5	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	6	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	7	God		God (Yahweh)	Implicit			EntireVerse
 OBA	1	8	God		God (Yahweh)	Normal			
 OBA	1	8	Obadiah, prophet		Obadiah (Yahweh says)	Potential			
-OBA	1	9	God		God (Yahweh)	Implicit			
-OBA	1	10	God		God (Yahweh)	Implicit			
-OBA	1	11	God		God (Yahweh)	Implicit			
-OBA	1	12	God		God (Yahweh)	Implicit			
-OBA	1	13	God		God (Yahweh)	Implicit			
-OBA	1	14	God		God (Yahweh)	Implicit			
-OBA	1	15	God		God (Yahweh)	Implicit			
-OBA	1	16	God		God (Yahweh)	Implicit			
-OBA	1	17	God		God (Yahweh)	Implicit			
+OBA	1	9	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	10	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	11	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	12	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	13	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	14	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	15	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	16	God		God (Yahweh)	Implicit			EntireVerse
+OBA	1	17	God		God (Yahweh)	Implicit			EntireVerse
 OBA	1	18	God		God (Yahweh)	Normal			
 OBA	1	18	Obadiah, prophet		Obadiah (Yahweh says)	Potential			
 OBA	1	19	God		God (Yahweh)	Potential			
@@ -15252,9 +15252,9 @@ MIC	1	4	God		God (Yahweh)	Potential
 MIC	1	4	Micah, prophet			Potential			
 MIC	1	5	God		God (Yahweh)	Potential			
 MIC	1	5	Micah, prophet			Potential			
-MIC	1	6	God		God (Yahweh)	Implicit			
+MIC	1	6	God		God (Yahweh)	Implicit			EntireVerse
 MIC	1	6	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	1	7	God		God (Yahweh)	Implicit			
+MIC	1	7	God		God (Yahweh)	Implicit			EntireVerse
 MIC	1	7	Micah, prophet		Micah (Yahweh says)	Alternate			
 MIC	1	8	Micah, prophet			Potential			
 MIC	1	8	God		God (Yahweh)	Alternate			
@@ -15292,16 +15292,16 @@ MIC	2	7	Micah, prophet			Potential
 MIC	2	7	false prophets			Hypothetical			
 MIC	2	7	Israel		house of Jacob	Hypothetical			
 MIC	2	7	Needs Review			Potential			
-MIC	2	8	God		God (Yahweh)	Implicit			
+MIC	2	8	God		God (Yahweh)	Implicit			EntireVerse
 MIC	2	8	Micah, prophet			Alternate			
-MIC	2	9	God		God (Yahweh)	Implicit			
+MIC	2	9	God		God (Yahweh)	Implicit			EntireVerse
 MIC	2	9	Micah, prophet			Alternate			
-MIC	2	10	God		God (Yahweh)	Implicit			
+MIC	2	10	God		God (Yahweh)	Implicit			EntireVerse
 MIC	2	10	Micah, prophet			Alternate			
 MIC	2	11	God		God (Yahweh)	Normal			
 MIC	2	11	false prophets			Hypothetical			
 MIC	2	11	Micah, prophet			Alternate			
-MIC	2	12	God		God (Yahweh)	Implicit			
+MIC	2	12	God		God (Yahweh)	Implicit			EntireVerse
 MIC	2	12	Micah, prophet			Alternate			
 MIC	2	13	God		God (Yahweh)	Potential			
 MIC	2	13	Micah, prophet			Alternate			
@@ -15323,11 +15323,11 @@ MIC	3	12	God		God (Yahweh)	Potential
 MIC	4	2	nations		nations, many	Hypothetical			
 MIC	4	6	God		God (Yahweh)	Normal			
 MIC	4	6	Micah, prophet			Potential			
-MIC	4	7	God		God (Yahweh)	Implicit			
+MIC	4	7	God		God (Yahweh)	Implicit			EntireVerse
 MIC	4	8	God		God (Yahweh)	Potential			
 MIC	4	11	nations		nations, many	Quotation			
 MIC	4	13	God		God (Yahweh)	Potential			
-MIC	4	13	Needs Review			Implicit			
+MIC	4	13	Needs Review			Implicit			EntireVerse
 MIC	5	1	God		God (Yahweh)	Potential			
 MIC	5	1	Micah, prophet			Potential			
 MIC	5	2	God		God (Yahweh)	Potential			
@@ -15336,38 +15336,38 @@ MIC	5	3	God		God (Yahweh)	Potential
 MIC	5	3	Micah, prophet			Potential			
 MIC	5	10	God		God (Yahweh)	Normal			
 MIC	5	10	Micah, prophet			Potential			
-MIC	5	11	God		God (Yahweh)	Implicit			
+MIC	5	11	God		God (Yahweh)	Implicit			EntireVerse
 MIC	5	11	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	5	12	God		God (Yahweh)	Implicit			
+MIC	5	12	God		God (Yahweh)	Implicit			EntireVerse
 MIC	5	12	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	5	13	God		God (Yahweh)	Implicit			
+MIC	5	13	God		God (Yahweh)	Implicit			EntireVerse
 MIC	5	13	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	5	14	God		God (Yahweh)	Implicit			
+MIC	5	14	God		God (Yahweh)	Implicit			EntireVerse
 MIC	5	14	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	5	15	God		God (Yahweh)	Implicit			
+MIC	5	15	God		God (Yahweh)	Implicit			EntireVerse
 MIC	5	15	Micah, prophet		Micah (Yahweh says)	Alternate			
 MIC	6	1	Micah, prophet		Micah (Yahweh says)	Potential			
 MIC	6	1	God		God (Yahweh)	Normal			
-MIC	6	2	God		God (Yahweh)	Implicit			
+MIC	6	2	God		God (Yahweh)	Implicit			EntireVerse
 MIC	6	2	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	6	3	God		God (Yahweh)	Implicit			
+MIC	6	3	God		God (Yahweh)	Implicit			EntireVerse
 MIC	6	3	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	6	4	God		God (Yahweh)	Implicit			
+MIC	6	4	God		God (Yahweh)	Implicit			EntireVerse
 MIC	6	4	Micah, prophet		Micah (Yahweh says)	Alternate			
-MIC	6	5	God		God (Yahweh)	Implicit			
+MIC	6	5	God		God (Yahweh)	Implicit			EntireVerse
 MIC	6	5	Micah, prophet		Micah (Yahweh says)	Alternate			
 MIC	6	6	Micah, prophet			Potential			
 MIC	6	7	Micah, prophet			Potential			
 MIC	6	8	Micah, prophet			Potential			
 MIC	6	9	Micah, prophet			Potential			
 MIC	6	9	God		God (Yahweh)	Normal			
-MIC	6	10	God		God (Yahweh)	Implicit			
-MIC	6	11	God		God (Yahweh)	Implicit			
-MIC	6	12	God		God (Yahweh)	Implicit			
-MIC	6	13	God		God (Yahweh)	Implicit			
-MIC	6	14	God		God (Yahweh)	Implicit			
-MIC	6	15	God		God (Yahweh)	Implicit			
-MIC	6	16	God		God (Yahweh)	Implicit			
+MIC	6	10	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	11	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	12	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	13	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	14	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	15	God		God (Yahweh)	Implicit			EntireVerse
+MIC	6	16	God		God (Yahweh)	Implicit			EntireVerse
 MIC	7	3	leaders/judge (corrupt)			Hypothetical			
 MIC	7	9	God		God (Yahweh)	Hypothetical			
 MIC	7	10	enemy (female)			Hypothetical			
@@ -15375,7 +15375,7 @@ MIC	7	15	God		God (Yahweh)	Potential
 #NAM	1	1-11	Nahum			Potential		
 NAM	1	12	Nahum		Nahum (Yahweh says)	Potential			
 NAM	1	12	God		God (Yahweh)	Normal			
-NAM	1	13	God		God (Yahweh)	Implicit			
+NAM	1	13	God		God (Yahweh)	Implicit			EntireVerse
 NAM	1	13	Nahum		Nahum (Yahweh says)	Alternate			
 NAM	1	14	Nahum			Potential			
 NAM	1	14	God		God (Yahweh)	Normal			
@@ -15400,13 +15400,13 @@ HAB	1	2	Habakkuk	crying		Hypothetical
 HAB	1	2	Habakkuk	complaining		Hypothetical			
 HAB	1	3	Habakkuk	complaining		Potential			
 HAB	1	4	Habakkuk	complaining		Potential			
-HAB	1	5	God			Implicit			
-HAB	1	6	God			Implicit			
-HAB	1	7	God			Implicit			
-HAB	1	8	God			Implicit			
-HAB	1	9	God			Implicit			
-HAB	1	10	God			Implicit			
-HAB	1	11	God			Implicit			
+HAB	1	5	God			Implicit			EntireVerse
+HAB	1	6	God			Implicit			EntireVerse
+HAB	1	7	God			Implicit			EntireVerse
+HAB	1	8	God			Implicit			EntireVerse
+HAB	1	9	God			Implicit			EntireVerse
+HAB	1	10	God			Implicit			EntireVerse
+HAB	1	11	God			Implicit			EntireVerse
 HAB	1	12	Habakkuk	complaining		Potential			
 HAB	1	13	Habakkuk	complaining		Potential			
 HAB	1	14	Habakkuk	complaining		Potential			
@@ -15415,8 +15415,8 @@ HAB	1	16	Habakkuk	complaining		Potential
 HAB	1	17	Habakkuk	complaining		Potential			
 HAB	2	1	Habakkuk			Potential			
 HAB	2	2	God		God (Yahweh)	Normal			
-HAB	2	3	God		God (Yahweh)	Implicit			
-HAB	2	4	God		God (Yahweh)	Implicit			
+HAB	2	3	God		God (Yahweh)	Implicit			EntireVerse
+HAB	2	4	God		God (Yahweh)	Implicit			EntireVerse
 HAB	2	5	God		God (Yahweh)	Normal			
 HAB	2	6	God		God (Yahweh)	Normal			
 HAB	2	6	people	taunting proverb	all these (people)	Hypothetical			
@@ -15455,24 +15455,24 @@ ZEP	1	2	God		God (Yahweh)	Normal
 ZEP	1	2	Zephaniah, prophet		Zephaniah (Yahweh says)	Potential			
 ZEP	1	3	God		God (Yahweh)	Normal			
 ZEP	1	3	Zephaniah, prophet		Zephaniah (Yahweh says)	Potential			
-ZEP	1	4	God		God (Yahweh)	Implicit			
+ZEP	1	4	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	4	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	1	5	God		God (Yahweh)	Implicit			
+ZEP	1	5	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	5	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	1	6	God		God (Yahweh)	Implicit			
+ZEP	1	6	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	6	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	1	7	God		God (Yahweh)	Implicit			
+ZEP	1	7	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	7	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	1	8	God		God (Yahweh)	Implicit			
+ZEP	1	8	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	8	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	1	9	God		God (Yahweh)	Implicit			
+ZEP	1	9	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	9	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
 ZEP	1	10	God		God (Yahweh)	Normal			
 ZEP	1	10	Zephaniah, prophet		Zephaniah (Yahweh says)	Potential			
-ZEP	1	11	God		God (Yahweh)	Implicit			
+ZEP	1	11	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	12	God		God (Yahweh)	Potential			
 ZEP	1	12	men who are complacent	thinking (saying in their hearts)		Hypothetical			
-ZEP	1	13	God		God (Yahweh)	Implicit			
+ZEP	1	13	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	1	14	God		God (Yahweh)	Potential			
 ZEP	1	15	God		God (Yahweh)	Potential			
 ZEP	1	16	God		God (Yahweh)	Potential			
@@ -15486,7 +15486,7 @@ ZEP	2	10	Zephaniah, prophet			Alternate
 ZEP	2	10	God		God (Yahweh)	Potential			
 ZEP	2	11	Zephaniah, prophet			Alternate			
 ZEP	2	11	God		God (Yahweh)	Potential			
-ZEP	2	12	God		God (Yahweh)	Implicit			
+ZEP	2	12	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	2	12	Zephaniah, prophet			Alternate			
 ZEP	2	13	Zephaniah, prophet			Alternate			
 ZEP	2	13	God		God (Yahweh)	Potential			
@@ -15496,13 +15496,13 @@ ZEP	2	15	Zephaniah, prophet			Alternate
 ZEP	2	15	God		God (Yahweh)	Potential			
 ZEP	2	15	Nineveh		Nineveh, the city of revelry	Hypothetical			
 ZEP	3	6	God		God (Yahweh)	Normal			
-ZEP	3	7	God		God (Yahweh)	Implicit			
+ZEP	3	7	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	3	8	God		God (Yahweh)	Normal			
 ZEP	3	8	Zephaniah, prophet		Zephaniah (Yahweh says)	Potential			
-ZEP	3	9	God		God (Yahweh)	Implicit			
-ZEP	3	10	God		God (Yahweh)	Implicit			
-ZEP	3	11	God		God (Yahweh)	Implicit			
-ZEP	3	12	God		God (Yahweh)	Implicit			
+ZEP	3	9	God		God (Yahweh)	Implicit			EntireVerse
+ZEP	3	10	God		God (Yahweh)	Implicit			EntireVerse
+ZEP	3	11	God		God (Yahweh)	Implicit			EntireVerse
+ZEP	3	12	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	3	13	God		God (Yahweh)	Normal			
 ZEP	3	14	Zephaniah, prophet			Potential			
 ZEP	3	14	God		God (Yahweh)	Potential			
@@ -15516,10 +15516,10 @@ ZEP	3	16	Needs Review			Normal
 ZEP	3	17	God	encouraging	God (Yahweh)	Hypothetical			
 ZEP	3	17	daughter of Zion	encouraging		Hypothetical			
 ZEP	3	17	person encouraging Jerusalem	encouraging		Hypothetical			
-ZEP	3	17	Needs Review			Implicit			
-ZEP	3	18	God		God (Yahweh)	Implicit			
+ZEP	3	17	Needs Review			Implicit			EntireVerse
+ZEP	3	18	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	3	18	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
-ZEP	3	19	God		God (Yahweh)	Implicit			
+ZEP	3	19	God		God (Yahweh)	Implicit			EntireVerse
 ZEP	3	19	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
 ZEP	3	20	God		God (Yahweh)	Normal			
 ZEP	3	20	Zephaniah, prophet		Zephaniah (Yahweh says)	Alternate			
@@ -15530,7 +15530,7 @@ HAG	1	4	God		God (Yahweh)	Normal			Unspecified
 HAG	1	4	Haggai			Alternate			
 HAG	1	5	Haggai			Potential			
 HAG	1	5	God		God (Yahweh)	Normal			
-HAG	1	6	God		God (Yahweh)	Implicit			
+HAG	1	6	God		God (Yahweh)	Implicit			EntireVerse
 HAG	1	6	Haggai			Alternate			
 HAG	1	7	Haggai			Potential			
 HAG	1	7	God		God (Yahweh)	Normal			
@@ -15538,20 +15538,20 @@ HAG	1	8	Haggai			Potential
 HAG	1	8	God		God (Yahweh)	Normal			
 HAG	1	9	Haggai			Potential			
 HAG	1	9	God		God (Yahweh)	Normal			
-HAG	1	10	God		God (Yahweh)	Implicit			
+HAG	1	10	God		God (Yahweh)	Implicit			EntireVerse
 HAG	1	10	Haggai			Alternate			
-HAG	1	11	God		God (Yahweh)	Implicit			
+HAG	1	11	God		God (Yahweh)	Implicit			EntireVerse
 HAG	1	11	Haggai			Alternate			
 HAG	1	13	Haggai		Haggai (Yahweh says)	Normal			
 HAG	1	13	God		God (Yahweh)	Potential			
 HAG	1	13	Needs Review			Normal			
-HAG	2	2	God		God (Yahweh)	Implicit			
+HAG	2	2	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	2	Haggai			Alternate			
-HAG	2	3	Haggai			Implicit			
+HAG	2	3	Haggai			Implicit			EntireVerse
 HAG	2	3	God		God (Yahweh)	Alternate			
 HAG	2	4	God		God (Yahweh)	Normal			
 HAG	2	4	Haggai			Potential			
-HAG	2	5	God		God (Yahweh)	Implicit			
+HAG	2	5	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	5	Haggai			Alternate			
 HAG	2	6	God		God (Yahweh)	Normal			
 HAG	2	6	Haggai			Potential			
@@ -15570,15 +15570,15 @@ HAG	2	13	Haggai			Normal
 HAG	2	13	priests			Normal			
 HAG	2	14	God		God (Yahweh)	Normal			
 HAG	2	14	Haggai			Normal			
-HAG	2	15	God		God (Yahweh)	Implicit			
+HAG	2	15	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	15	Haggai			Alternate			
-HAG	2	16	God		God (Yahweh)	Implicit			
+HAG	2	16	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	16	Haggai			Alternate			
 HAG	2	17	God		God (Yahweh)	Normal			
 HAG	2	17	Haggai			Potential			
-HAG	2	18	God		God (Yahweh)	Implicit			
+HAG	2	18	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	18	Haggai			Alternate			
-HAG	2	19	God		God (Yahweh)	Implicit			
+HAG	2	19	God		God (Yahweh)	Implicit			EntireVerse
 HAG	2	19	Haggai			Alternate			
 HAG	2	21	God		God (Yahweh)	Normal			
 HAG	2	21	Haggai			Normal			
@@ -15617,12 +15617,12 @@ ZEC	1	14	angel who talked with Zechariah		angel who talked with Zechariah (in vi
 ZEC	1	14	God	angry	God (Yahweh)	Normal			
 ZEC	1	14	Needs Review			Normal			
 ZEC	1	15	God	angry	God (Yahweh)	Alternate			
-ZEC	1	15	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			
+ZEC	1	15	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			EntireVerse
 ZEC	1	15	Zechariah the prophet, son of Berechiah	proclamation	Zechariah (in vision)	Alternate			
 ZEC	1	16	God		God (Yahweh)	Alternate			
 ZEC	1	16	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Normal			
 ZEC	1	16	Zechariah the prophet, son of Berechiah		Zechariah (in vision)	Potential			
-ZEC	1	17	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			
+ZEC	1	17	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			EntireVerse
 ZEC	1	17	Zechariah the prophet, son of Berechiah	proclamation	Zechariah (in vision)	Alternate			
 ZEC	1	17	God		God (Yahweh)	Alternate			
 ZEC	1	18	Zechariah the prophet, son of Berechiah		Zechariah (in vision)	Potential			
@@ -15678,15 +15678,15 @@ ZEC	2	10	Zechariah the prophet, son of Berechiah		Zechariah (in vision)	Potentia
 ZEC	2	11	Yahweh's angel		angel, another (in vision)	Normal			
 ZEC	2	11	God		God (Yahweh) (in vision)	Alternate			
 ZEC	2	11	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
-ZEC	2	11	Needs Review			Implicit			
+ZEC	2	11	Needs Review			Implicit			EntireVerse
 ZEC	2	12	Yahweh's angel		angel, another (in vision)	Normal			
 ZEC	2	12	God		God (Yahweh) (in vision)	Alternate			
 ZEC	2	12	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
-ZEC	2	12	Needs Review			Implicit			
+ZEC	2	12	Needs Review			Implicit			EntireVerse
 ZEC	2	13	Yahweh's angel		angel, another (in vision)	Normal			
 ZEC	2	13	God		God (Yahweh) (in vision)	Alternate			
 ZEC	2	13	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
-ZEC	2	13	Needs Review			Implicit			
+ZEC	2	13	Needs Review			Implicit			EntireVerse
 # Some translations say the angel of the LORD speaks this rebuke. Even though God is the best option,
 # making them both Alternates will force a review.
 ZEC	3	2	God	rebuking	God (Yahweh) (in vision)	Alternate			
@@ -15714,11 +15714,11 @@ ZEC	4	6	God		God (Yahweh) (in vision)	Normal
 ZEC	4	7	God		God (Yahweh) (in vision)	Normal			
 ZEC	4	7	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
 ZEC	4	7	Zerubbabel			Hypothetical			
-ZEC	4	9	Needs Review			Implicit			
+ZEC	4	9	Needs Review			Implicit			EntireVerse
 ZEC	4	9	God		God (Yahweh)	Alternate			
 ZEC	4	9	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
 ZEC	4	9	Zechariah the prophet, son of Berechiah		Zechariah (in vision)	Alternate			
-ZEC	4	10	Needs Review			Implicit			
+ZEC	4	10	Needs Review			Implicit			EntireVerse
 ZEC	4	10	God		God (Yahweh)	Alternate			
 ZEC	4	10	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Alternate			
 ZEC	4	10	Zechariah the prophet, son of Berechiah		Zechariah (in vision)	Alternate			
@@ -15742,11 +15742,11 @@ ZEC	5	10	narrator-ZEC			Quotation
 ZEC	5	11	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Normal			
 ZEC	6	4	narrator-ZEC			Quotation			
 ZEC	6	5	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Normal			
-ZEC	6	6	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			
+ZEC	6	6	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Implicit			EntireVerse
 ZEC	6	7	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Normal			
 ZEC	6	8	angel who talked with Zechariah		angel who talked with Zechariah (in vision)	Normal			
-ZEC	6	10	God		God (Yahweh)	Implicit			
-ZEC	6	11	God		God (Yahweh)	Implicit			
+ZEC	6	10	God		God (Yahweh)	Implicit			EntireVerse
+ZEC	6	11	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	6	12	God		God (Yahweh)	Normal			
 ZEC	6	12	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	6	13	God		God (Yahweh)	Normal			
@@ -15758,14 +15758,14 @@ ZEC	6	15	Zechariah the prophet, son of Berechiah			Potential
 ZEC	7	3	Sharezer/Regem-Melech/men of Bethel			Normal			EndOfVerse
 ZEC	7	5	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Normal			
 ZEC	7	5	God			Normal			
-ZEC	7	6	God			Implicit			
+ZEC	7	6	God			Implicit			EntireVerse
 ZEC	7	6	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	7	7	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	7	7	God			Potential			
 ZEC	7	8	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	7	9	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	7	9	God			Normal			
-ZEC	7	10	God			Implicit			
+ZEC	7	10	God			Implicit			EntireVerse
 ZEC	7	10	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	7	11	God			Normal			
 ZEC	7	11	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
@@ -15773,7 +15773,7 @@ ZEC	7	12	God			Normal
 ZEC	7	12	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	7	13	God			Normal			
 ZEC	7	13	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
-ZEC	7	14	God			Implicit			
+ZEC	7	14	God			Implicit			EntireVerse
 ZEC	7	14	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	8	2	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	2	God		God (Yahweh)	Normal			
@@ -15781,29 +15781,29 @@ ZEC	8	3	Zechariah the prophet, son of Berechiah			Potential
 ZEC	8	3	God		God (Yahweh)	Normal			
 ZEC	8	4	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	4	God		God (Yahweh)	Normal			
-ZEC	8	5	God		God (Yahweh)	Implicit			
+ZEC	8	5	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	5	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	6	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	6	God		God (Yahweh)	Normal			
 ZEC	8	7	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	7	God		God (Yahweh)	Normal			
-ZEC	8	8	God		God (Yahweh)	Implicit			
+ZEC	8	8	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	8	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	9	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	9	God		God (Yahweh)	Normal			
-ZEC	8	10	God		God (Yahweh)	Implicit			
+ZEC	8	10	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	10	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	11	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	11	God		God (Yahweh)	Normal			
-ZEC	8	12	God		God (Yahweh)	Implicit			
+ZEC	8	12	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	12	Zechariah the prophet, son of Berechiah			Alternate			
-ZEC	8	13	God		God (Yahweh)	Implicit			
+ZEC	8	13	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	13	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	14	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	8	14	God		God (Yahweh)	Normal			
-ZEC	8	15	God		God (Yahweh)	Implicit			
+ZEC	8	15	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	15	Zechariah the prophet, son of Berechiah			Alternate			
-ZEC	8	16	God		God (Yahweh)	Implicit			
+ZEC	8	16	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	16	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	17	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Potential			
 ZEC	8	17	God			Normal			
@@ -15814,7 +15814,7 @@ ZEC	8	20	God			Normal
 ZEC	8	21	God		God (Yahweh)	Normal			
 ZEC	8	21	nations		inhabitants of one city	Hypothetical			
 ZEC	8	21	Zechariah the prophet, son of Berechiah			Alternate			
-ZEC	8	22	God		God (Yahweh)	Implicit			
+ZEC	8	22	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	8	22	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	8	23	God		God (Yahweh)	Normal			
 ZEC	8	23	nations		ten men out of all the languages of the nations	Hypothetical			
@@ -15863,15 +15863,15 @@ ZEC	10	4	Zechariah the prophet, son of Berechiah		Zechariah	Potential
 ZEC	10	4	God		God (Yahweh)	Alternate			
 ZEC	10	5	Zechariah the prophet, son of Berechiah		Zechariah	Potential			
 ZEC	10	5	God		God (Yahweh)	Alternate			
-ZEC	10	6	God		God (Yahweh)	Implicit			
+ZEC	10	6	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	10	6	Zechariah the prophet, son of Berechiah		Zechariah	Alternate			
 ZEC	10	7	Zechariah the prophet, son of Berechiah		Zechariah	Potential			
 ZEC	10	7	God		God (Yahweh)	Potential			
-ZEC	10	8	God		God (Yahweh)	Implicit			
+ZEC	10	8	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	10	8	Zechariah the prophet, son of Berechiah		Zechariah	Alternate			
-ZEC	10	9	God		God (Yahweh)	Implicit			
+ZEC	10	9	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	10	9	Zechariah the prophet, son of Berechiah		Zechariah	Alternate			
-ZEC	10	10	God		God (Yahweh)	Implicit			
+ZEC	10	10	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	10	10	Zechariah the prophet, son of Berechiah		Zechariah	Alternate			
 ZEC	10	11	Zechariah the prophet, son of Berechiah		Zechariah	Potential			
 ZEC	10	11	God		God (Yahweh)	Potential			
@@ -15885,7 +15885,7 @@ ZEC	11	3	God		God (Yahweh)	Potential
 ZEC	11	3	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	11	4	God		God (Yahweh)	Normal			
 ZEC	11	4	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
-ZEC	11	5	God		God (Yahweh)	Implicit			
+ZEC	11	5	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	11	5	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	11	6	God		God (Yahweh)	Normal			
 ZEC	11	6	Zechariah the prophet, son of Berechiah		Zechariah	Potential			
@@ -15902,22 +15902,22 @@ ZEC	12	1	God		God (Yahweh)	Potential
 ZEC	12	1	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	12	2	God		God (Yahweh)	Normal			
 ZEC	12	2	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
-ZEC	12	3	God		God (Yahweh)	Implicit			
+ZEC	12	3	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	12	3	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	12	4	God		God (Yahweh)	Normal			
 ZEC	12	4	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	12	5	God		God (Yahweh)	Normal			
 ZEC	12	5	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	12	5	Judah, leaders of		chieftains of Judah	Hypothetical			
-ZEC	12	6	God		God (Yahweh)	Implicit			
+ZEC	12	6	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	12	6	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	12	7	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	12	7	God		God (Yahweh)	Potential			
 ZEC	12	8	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	12	8	God		God (Yahweh)	Potential			
-ZEC	12	9	God		God (Yahweh)	Implicit			
+ZEC	12	9	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	12	9	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
-ZEC	12	10	God		God (Yahweh)	Implicit			
+ZEC	12	10	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	12	10	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	12	11	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	12	11	God		God (Yahweh)	Potential			
@@ -15927,14 +15927,14 @@ ZEC	12	13	Zechariah the prophet, son of Berechiah			Alternate
 ZEC	12	13	God		God (Yahweh)	Potential			
 ZEC	12	14	Zechariah the prophet, son of Berechiah			Alternate			
 ZEC	12	14	God		God (Yahweh)	Potential			
-ZEC	13	1	God		God (Yahweh)	Implicit			
+ZEC	13	1	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	13	1	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	13	2	God		God (Yahweh)	Normal			
 ZEC	13	2	Zechariah the prophet, son of Berechiah			Potential			
 ZEC	13	3	God		God (Yahweh)	Normal			
 ZEC	13	3	father of false prophet/mother of false prophet		father/mother	Hypothetical			
 ZEC	13	3	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
-ZEC	13	4	God		God (Yahweh)	Implicit			
+ZEC	13	4	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	13	4	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
 ZEC	13	5	God		God (Yahweh)	Normal			
 ZEC	13	5	false prophets	lying	prophet (lying)	Hypothetical			
@@ -15950,7 +15950,7 @@ ZEC	13	8	Zechariah the prophet, son of Berechiah			Potential
 ZEC	13	9	God			Normal			
 ZEC	13	9	people, God's			Hypothetical			
 ZEC	13	9	Zechariah the prophet, son of Berechiah		Zechariah (Yahweh says)	Alternate			
-ZEC	14	2	God		God (Yahweh)	Implicit			
+ZEC	14	2	God		God (Yahweh)	Implicit			EntireVerse
 ZEC	14	20	narrator-ZEC			Potential			
 MAL	1	2	God		God (Yahweh)	Normal			
 MAL	1	2	Israel			Hypothetical			
@@ -15979,9 +15979,9 @@ MAL	2	1	God		God (Yahweh)	Potential
 MAL	2	2	God		God (Yahweh)	Normal			
 MAL	2	3	God		God (Yahweh)	Normal			
 MAL	2	4	God		God (Yahweh)	Normal			
-MAL	2	5	God		God (Yahweh)	Implicit			
-MAL	2	6	God		God (Yahweh)	Implicit			
-MAL	2	7	God		God (Yahweh)	Implicit			
+MAL	2	5	God		God (Yahweh)	Implicit			EntireVerse
+MAL	2	6	God		God (Yahweh)	Implicit			EntireVerse
+MAL	2	7	God		God (Yahweh)	Implicit			EntireVerse
 MAL	2	8	God		God (Yahweh)	Normal			
 MAL	2	9	God		God (Yahweh)	Normal			
 MAL	2	10	God		God (Yahweh)	Potential			
@@ -16018,11 +16018,11 @@ MAL	3	16	God		God (Yahweh)	Potential
 MAL	3	17	God		God (Yahweh)	Normal			
 MAL	3	18	God		God (Yahweh)	Normal			
 MAL	4	1	God		God (Yahweh)	Normal			
-MAL	4	2	God		God (Yahweh)	Implicit			
+MAL	4	2	God		God (Yahweh)	Implicit			EntireVerse
 MAL	4	3	God		God (Yahweh)	Normal			
-MAL	4	4	God		God (Yahweh)	Implicit			
-MAL	4	5	God		God (Yahweh)	Implicit			
-MAL	4	6	God		God (Yahweh)	Implicit			
+MAL	4	4	God		God (Yahweh)	Implicit			EntireVerse
+MAL	4	5	God		God (Yahweh)	Implicit			EntireVerse
+MAL	4	6	God		God (Yahweh)	Implicit			EntireVerse
 MAT	1	1	narrator-MAT			Quotation			Unspecified
 MAT	1	16	narrator-MAT			Quotation			Unspecified
 MAT	1	19	Joseph, the carpenter	thinking		Rare			
@@ -16081,113 +16081,113 @@ MAT	4	16	scripture			Quotation	Isaiah		EntireVerse
 MAT	4	17	Jesus	preaching		Normal			ContainedWithinVerse
 MAT	4	19	Jesus	inviting		Dialogue			Unspecified
 MAT	4	21	Jesus	inviting		Indirect			
-MAT	5	3	Jesus	preaching		Implicit			
-MAT	5	4	Jesus	preaching		Implicit			
-MAT	5	5	Jesus	preaching		Implicit			
-MAT	5	6	Jesus	preaching		Implicit			
-MAT	5	7	Jesus	preaching		Implicit			
-MAT	5	8	Jesus	preaching		Implicit			
-MAT	5	9	Jesus	preaching		Implicit			
-MAT	5	10	Jesus	preaching		Implicit			
-MAT	5	11	Jesus	preaching		Implicit			
-MAT	5	12	Jesus	preaching		Implicit			
-MAT	5	13	Jesus	preaching		Implicit			
-MAT	5	14	Jesus	preaching		Implicit			
-MAT	5	15	Jesus	preaching		Implicit			
-MAT	5	16	Jesus	preaching		Implicit			
-MAT	5	17	Jesus	preaching		Implicit			
-MAT	5	18	Jesus	preaching		Implicit			
-MAT	5	19	Jesus	preaching		Implicit			
-MAT	5	20	Jesus	preaching		Implicit			
-MAT	5	21	Jesus	preaching		Implicit			
-MAT	5	22	Jesus	preaching		Implicit			
-MAT	5	23	Jesus	preaching		Implicit			
-MAT	5	24	Jesus	preaching		Implicit			
-MAT	5	25	Jesus	preaching		Implicit			
-MAT	5	26	Jesus	preaching		Implicit			
-MAT	5	27	Jesus	preaching		Implicit			
-MAT	5	28	Jesus	preaching		Implicit			
-MAT	5	29	Jesus	preaching		Implicit			
-MAT	5	30	Jesus	preaching		Implicit			
-MAT	5	31	Jesus	preaching		Implicit			
-MAT	5	32	Jesus	preaching		Implicit			
-MAT	5	33	Jesus	preaching		Implicit			
-MAT	5	34	Jesus	preaching		Implicit			
-MAT	5	35	Jesus	preaching		Implicit			
-MAT	5	36	Jesus	preaching		Implicit			
-MAT	5	37	Jesus	preaching		Implicit			
-MAT	5	38	Jesus	preaching		Implicit			
-MAT	5	39	Jesus	preaching		Implicit			
-MAT	5	40	Jesus	preaching		Implicit			
-MAT	5	41	Jesus	preaching		Implicit			
-MAT	5	42	Jesus	preaching		Implicit			
-MAT	5	43	Jesus	preaching		Implicit			
-MAT	5	44	Jesus	preaching		Implicit			
-MAT	5	45	Jesus	preaching		Implicit			
-MAT	5	46	Jesus	preaching		Implicit			
-MAT	5	47	Jesus	preaching		Implicit			
-MAT	5	48	Jesus	preaching		Implicit			
-MAT	6	1	Jesus	preaching		Implicit			
-MAT	6	2	Jesus	preaching		Implicit			
-MAT	6	3	Jesus	preaching		Implicit			
-MAT	6	4	Jesus	preaching		Implicit			
-MAT	6	5	Jesus	preaching		Implicit			
-MAT	6	6	Jesus	preaching		Implicit			
-MAT	6	7	Jesus	preaching		Implicit			
-MAT	6	8	Jesus	preaching		Implicit			
-MAT	6	9	Jesus	preaching		Implicit			
-MAT	6	10	Jesus	preaching		Implicit			
-MAT	6	11	Jesus	preaching		Implicit			
-MAT	6	12	Jesus	preaching		Implicit			
-MAT	6	13	Jesus	preaching		Implicit			
-MAT	6	14	Jesus	preaching		Implicit			
-MAT	6	15	Jesus	preaching		Implicit			
-MAT	6	16	Jesus	preaching		Implicit			
-MAT	6	17	Jesus	preaching		Implicit			
-MAT	6	18	Jesus	preaching		Implicit			
-MAT	6	19	Jesus	preaching		Implicit			
-MAT	6	20	Jesus	preaching		Implicit			
-MAT	6	21	Jesus	preaching		Implicit			
-MAT	6	22	Jesus	preaching		Implicit			
-MAT	6	23	Jesus	preaching		Implicit			
-MAT	6	24	Jesus	preaching		Implicit			
-MAT	6	25	Jesus	preaching		Implicit			
-MAT	6	26	Jesus	preaching		Implicit			
-MAT	6	27	Jesus	preaching		Implicit			
-MAT	6	28	Jesus	preaching		Implicit			
-MAT	6	29	Jesus	preaching		Implicit			
-MAT	6	30	Jesus	preaching		Implicit			
-MAT	6	31	Jesus	preaching		Implicit			
-MAT	6	32	Jesus	preaching		Implicit			
-MAT	6	33	Jesus	preaching		Implicit			
-MAT	6	34	Jesus	preaching		Implicit			
-MAT	7	1	Jesus	preaching		Implicit			
-MAT	7	2	Jesus	preaching		Implicit			
-MAT	7	3	Jesus	preaching		Implicit			
-MAT	7	4	Jesus	preaching		Implicit			
-MAT	7	5	Jesus	preaching		Implicit			
-MAT	7	6	Jesus	preaching		Implicit			
-MAT	7	7	Jesus	preaching		Implicit			
-MAT	7	8	Jesus	preaching		Implicit			
-MAT	7	9	Jesus	preaching		Implicit			
-MAT	7	10	Jesus	preaching		Implicit			
-MAT	7	11	Jesus	preaching		Implicit			
-MAT	7	12	Jesus	preaching		Implicit			
-MAT	7	13	Jesus	preaching		Implicit			
-MAT	7	14	Jesus	preaching		Implicit			
-MAT	7	15	Jesus	preaching		Implicit			
-MAT	7	16	Jesus	preaching		Implicit			
-MAT	7	17	Jesus	preaching		Implicit			
-MAT	7	18	Jesus	preaching		Implicit			
-MAT	7	19	Jesus	preaching		Implicit			
-MAT	7	20	Jesus	preaching		Implicit			
-MAT	7	21	Jesus	preaching		Implicit			
-MAT	7	22	Jesus	preaching		Implicit			
-MAT	7	23	Jesus	preaching		Implicit			
-MAT	7	24	Jesus	preaching		Implicit			
-MAT	7	25	Jesus	preaching		Implicit			
-MAT	7	26	Jesus	preaching		Implicit			
-MAT	7	27	Jesus	preaching		Implicit			
+MAT	5	3	Jesus	preaching		Implicit			EntireVerse
+MAT	5	4	Jesus	preaching		Implicit			EntireVerse
+MAT	5	5	Jesus	preaching		Implicit			EntireVerse
+MAT	5	6	Jesus	preaching		Implicit			EntireVerse
+MAT	5	7	Jesus	preaching		Implicit			EntireVerse
+MAT	5	8	Jesus	preaching		Implicit			EntireVerse
+MAT	5	9	Jesus	preaching		Implicit			EntireVerse
+MAT	5	10	Jesus	preaching		Implicit			EntireVerse
+MAT	5	11	Jesus	preaching		Implicit			EntireVerse
+MAT	5	12	Jesus	preaching		Implicit			EntireVerse
+MAT	5	13	Jesus	preaching		Implicit			EntireVerse
+MAT	5	14	Jesus	preaching		Implicit			EntireVerse
+MAT	5	15	Jesus	preaching		Implicit			EntireVerse
+MAT	5	16	Jesus	preaching		Implicit			EntireVerse
+MAT	5	17	Jesus	preaching		Implicit			EntireVerse
+MAT	5	18	Jesus	preaching		Implicit			EntireVerse
+MAT	5	19	Jesus	preaching		Implicit			EntireVerse
+MAT	5	20	Jesus	preaching		Implicit			EntireVerse
+MAT	5	21	Jesus	preaching		Implicit			EntireVerse
+MAT	5	22	Jesus	preaching		Implicit			EntireVerse
+MAT	5	23	Jesus	preaching		Implicit			EntireVerse
+MAT	5	24	Jesus	preaching		Implicit			EntireVerse
+MAT	5	25	Jesus	preaching		Implicit			EntireVerse
+MAT	5	26	Jesus	preaching		Implicit			EntireVerse
+MAT	5	27	Jesus	preaching		Implicit			EntireVerse
+MAT	5	28	Jesus	preaching		Implicit			EntireVerse
+MAT	5	29	Jesus	preaching		Implicit			EntireVerse
+MAT	5	30	Jesus	preaching		Implicit			EntireVerse
+MAT	5	31	Jesus	preaching		Implicit			EntireVerse
+MAT	5	32	Jesus	preaching		Implicit			EntireVerse
+MAT	5	33	Jesus	preaching		Implicit			EntireVerse
+MAT	5	34	Jesus	preaching		Implicit			EntireVerse
+MAT	5	35	Jesus	preaching		Implicit			EntireVerse
+MAT	5	36	Jesus	preaching		Implicit			EntireVerse
+MAT	5	37	Jesus	preaching		Implicit			EntireVerse
+MAT	5	38	Jesus	preaching		Implicit			EntireVerse
+MAT	5	39	Jesus	preaching		Implicit			EntireVerse
+MAT	5	40	Jesus	preaching		Implicit			EntireVerse
+MAT	5	41	Jesus	preaching		Implicit			EntireVerse
+MAT	5	42	Jesus	preaching		Implicit			EntireVerse
+MAT	5	43	Jesus	preaching		Implicit			EntireVerse
+MAT	5	44	Jesus	preaching		Implicit			EntireVerse
+MAT	5	45	Jesus	preaching		Implicit			EntireVerse
+MAT	5	46	Jesus	preaching		Implicit			EntireVerse
+MAT	5	47	Jesus	preaching		Implicit			EntireVerse
+MAT	5	48	Jesus	preaching		Implicit			EntireVerse
+MAT	6	1	Jesus	preaching		Implicit			EntireVerse
+MAT	6	2	Jesus	preaching		Implicit			EntireVerse
+MAT	6	3	Jesus	preaching		Implicit			EntireVerse
+MAT	6	4	Jesus	preaching		Implicit			EntireVerse
+MAT	6	5	Jesus	preaching		Implicit			EntireVerse
+MAT	6	6	Jesus	preaching		Implicit			EntireVerse
+MAT	6	7	Jesus	preaching		Implicit			EntireVerse
+MAT	6	8	Jesus	preaching		Implicit			EntireVerse
+MAT	6	9	Jesus	preaching		Implicit			EntireVerse
+MAT	6	10	Jesus	preaching		Implicit			EntireVerse
+MAT	6	11	Jesus	preaching		Implicit			EntireVerse
+MAT	6	12	Jesus	preaching		Implicit			EntireVerse
+MAT	6	13	Jesus	preaching		Implicit			EntireVerse
+MAT	6	14	Jesus	preaching		Implicit			EntireVerse
+MAT	6	15	Jesus	preaching		Implicit			EntireVerse
+MAT	6	16	Jesus	preaching		Implicit			EntireVerse
+MAT	6	17	Jesus	preaching		Implicit			EntireVerse
+MAT	6	18	Jesus	preaching		Implicit			EntireVerse
+MAT	6	19	Jesus	preaching		Implicit			EntireVerse
+MAT	6	20	Jesus	preaching		Implicit			EntireVerse
+MAT	6	21	Jesus	preaching		Implicit			EntireVerse
+MAT	6	22	Jesus	preaching		Implicit			EntireVerse
+MAT	6	23	Jesus	preaching		Implicit			EntireVerse
+MAT	6	24	Jesus	preaching		Implicit			EntireVerse
+MAT	6	25	Jesus	preaching		Implicit			EntireVerse
+MAT	6	26	Jesus	preaching		Implicit			EntireVerse
+MAT	6	27	Jesus	preaching		Implicit			EntireVerse
+MAT	6	28	Jesus	preaching		Implicit			EntireVerse
+MAT	6	29	Jesus	preaching		Implicit			EntireVerse
+MAT	6	30	Jesus	preaching		Implicit			EntireVerse
+MAT	6	31	Jesus	preaching		Implicit			EntireVerse
+MAT	6	32	Jesus	preaching		Implicit			EntireVerse
+MAT	6	33	Jesus	preaching		Implicit			EntireVerse
+MAT	6	34	Jesus	preaching		Implicit			EntireVerse
+MAT	7	1	Jesus	preaching		Implicit			EntireVerse
+MAT	7	2	Jesus	preaching		Implicit			EntireVerse
+MAT	7	3	Jesus	preaching		Implicit			EntireVerse
+MAT	7	4	Jesus	preaching		Implicit			EntireVerse
+MAT	7	5	Jesus	preaching		Implicit			EntireVerse
+MAT	7	6	Jesus	preaching		Implicit			EntireVerse
+MAT	7	7	Jesus	preaching		Implicit			EntireVerse
+MAT	7	8	Jesus	preaching		Implicit			EntireVerse
+MAT	7	9	Jesus	preaching		Implicit			EntireVerse
+MAT	7	10	Jesus	preaching		Implicit			EntireVerse
+MAT	7	11	Jesus	preaching		Implicit			EntireVerse
+MAT	7	12	Jesus	preaching		Implicit			EntireVerse
+MAT	7	13	Jesus	preaching		Implicit			EntireVerse
+MAT	7	14	Jesus	preaching		Implicit			EntireVerse
+MAT	7	15	Jesus	preaching		Implicit			EntireVerse
+MAT	7	16	Jesus	preaching		Implicit			EntireVerse
+MAT	7	17	Jesus	preaching		Implicit			EntireVerse
+MAT	7	18	Jesus	preaching		Implicit			EntireVerse
+MAT	7	19	Jesus	preaching		Implicit			EntireVerse
+MAT	7	20	Jesus	preaching		Implicit			EntireVerse
+MAT	7	21	Jesus	preaching		Implicit			EntireVerse
+MAT	7	22	Jesus	preaching		Implicit			EntireVerse
+MAT	7	23	Jesus	preaching		Implicit			EntireVerse
+MAT	7	24	Jesus	preaching		Implicit			EntireVerse
+MAT	7	25	Jesus	preaching		Implicit			EntireVerse
+MAT	7	26	Jesus	preaching		Implicit			EntireVerse
+MAT	7	27	Jesus	preaching		Implicit			EntireVerse
 MAT	7	28	crowd			Rare			
 MAT	7	28	Needs Review			Potential			
 MAT	7	29	crowd			Rare			
@@ -16258,43 +16258,43 @@ MAT	10	1	Jesus			Indirect
 MAT	10	2	narrator-MAT			Quotation			Unspecified
 MAT	10	4	narrator-MAT			Quotation			Unspecified
 MAT	10	5	Jesus	instructing		Normal			EndOfVerse
-MAT	10	6	Jesus	instructing		Implicit			
-MAT	10	7	Jesus	instructing		Implicit			
-MAT	10	8	Jesus	instructing		Implicit			
-MAT	10	9	Jesus	instructing		Implicit			
-MAT	10	10	Jesus	instructing		Implicit			
-MAT	10	11	Jesus	instructing		Implicit			
-MAT	10	12	Jesus	instructing		Implicit			
-MAT	10	13	Jesus	instructing		Implicit			
-MAT	10	14	Jesus	instructing		Implicit			
-MAT	10	15	Jesus	instructing		Implicit			
-MAT	10	16	Jesus	instructing		Implicit			
-MAT	10	17	Jesus	instructing		Implicit			
-MAT	10	18	Jesus	instructing		Implicit			
-MAT	10	19	Jesus	instructing		Implicit			
-MAT	10	20	Jesus	instructing		Implicit			
-MAT	10	21	Jesus	instructing		Implicit			
-MAT	10	22	Jesus	instructing		Implicit			
-MAT	10	23	Jesus	instructing		Implicit			
-MAT	10	24	Jesus	instructing		Implicit			
-MAT	10	25	Jesus	instructing		Implicit			
-MAT	10	26	Jesus	instructing		Implicit			
-MAT	10	27	Jesus	instructing		Implicit			
-MAT	10	28	Jesus	instructing		Implicit			
-MAT	10	29	Jesus	instructing		Implicit			
-MAT	10	30	Jesus	instructing		Implicit			
-MAT	10	31	Jesus	instructing		Implicit			
-MAT	10	32	Jesus	instructing		Implicit			
-MAT	10	33	Jesus	instructing		Implicit			
-MAT	10	34	Jesus	instructing		Implicit			
-MAT	10	35	Jesus	instructing		Implicit			
-MAT	10	36	Jesus	instructing		Implicit			
-MAT	10	37	Jesus	instructing		Implicit			
-MAT	10	38	Jesus	instructing		Implicit			
-MAT	10	39	Jesus	instructing		Implicit			
-MAT	10	40	Jesus	instructing		Implicit			
-MAT	10	41	Jesus	instructing		Implicit			
-MAT	10	42	Jesus	instructing		Implicit			
+MAT	10	6	Jesus	instructing		Implicit			EntireVerse
+MAT	10	7	Jesus	instructing		Implicit			EntireVerse
+MAT	10	8	Jesus	instructing		Implicit			EntireVerse
+MAT	10	9	Jesus	instructing		Implicit			EntireVerse
+MAT	10	10	Jesus	instructing		Implicit			EntireVerse
+MAT	10	11	Jesus	instructing		Implicit			EntireVerse
+MAT	10	12	Jesus	instructing		Implicit			EntireVerse
+MAT	10	13	Jesus	instructing		Implicit			EntireVerse
+MAT	10	14	Jesus	instructing		Implicit			EntireVerse
+MAT	10	15	Jesus	instructing		Implicit			EntireVerse
+MAT	10	16	Jesus	instructing		Implicit			EntireVerse
+MAT	10	17	Jesus	instructing		Implicit			EntireVerse
+MAT	10	18	Jesus	instructing		Implicit			EntireVerse
+MAT	10	19	Jesus	instructing		Implicit			EntireVerse
+MAT	10	20	Jesus	instructing		Implicit			EntireVerse
+MAT	10	21	Jesus	instructing		Implicit			EntireVerse
+MAT	10	22	Jesus	instructing		Implicit			EntireVerse
+MAT	10	23	Jesus	instructing		Implicit			EntireVerse
+MAT	10	24	Jesus	instructing		Implicit			EntireVerse
+MAT	10	25	Jesus	instructing		Implicit			EntireVerse
+MAT	10	26	Jesus	instructing		Implicit			EntireVerse
+MAT	10	27	Jesus	instructing		Implicit			EntireVerse
+MAT	10	28	Jesus	instructing		Implicit			EntireVerse
+MAT	10	29	Jesus	instructing		Implicit			EntireVerse
+MAT	10	30	Jesus	instructing		Implicit			EntireVerse
+MAT	10	31	Jesus	instructing		Implicit			EntireVerse
+MAT	10	32	Jesus	instructing		Implicit			EntireVerse
+MAT	10	33	Jesus	instructing		Implicit			EntireVerse
+MAT	10	34	Jesus	instructing		Implicit			EntireVerse
+MAT	10	35	Jesus	instructing		Implicit			EntireVerse
+MAT	10	36	Jesus	instructing		Implicit			EntireVerse
+MAT	10	37	Jesus	instructing		Implicit			EntireVerse
+MAT	10	38	Jesus	instructing		Implicit			EntireVerse
+MAT	10	39	Jesus	instructing		Implicit			EntireVerse
+MAT	10	40	Jesus	instructing		Implicit			EntireVerse
+MAT	10	41	Jesus	instructing		Implicit			EntireVerse
+MAT	10	42	Jesus	instructing		Implicit			EntireVerse
 MAT	11	2	disciples of John the Baptist			Rare		MAT 11.2;LUK 7.18	
 MAT	11	2	John the Baptist			Rare			
 MAT	11	2	Needs Review			Potential			
@@ -16303,22 +16303,22 @@ MAT	11	4	Jesus			Normal			EndOfVerse
 MAT	11	5	Jesus			Normal			EntireVerse
 MAT	11	6	Jesus			Normal			EntireVerse
 MAT	11	7	Jesus			Normal			EndOfVerse
-MAT	11	8	Jesus			Implicit			
-MAT	11	9	Jesus			Implicit			
-MAT	11	10	Jesus			Implicit			
-MAT	11	11	Jesus			Implicit			
-MAT	11	12	Jesus			Implicit			
-MAT	11	13	Jesus			Implicit			
-MAT	11	14	Jesus			Implicit			
-MAT	11	15	Jesus			Implicit			
-MAT	11	16	Jesus			Implicit			
-MAT	11	17	Jesus			Implicit			
-MAT	11	18	Jesus			Implicit			
-MAT	11	19	Jesus			Implicit			
-MAT	11	21	Jesus	rebuking		Implicit			
-MAT	11	22	Jesus	rebuking		Implicit			
-MAT	11	23	Jesus	rebuking		Implicit			
-MAT	11	24	Jesus	rebuking		Implicit			
+MAT	11	8	Jesus			Implicit			EntireVerse
+MAT	11	9	Jesus			Implicit			EntireVerse
+MAT	11	10	Jesus			Implicit			EntireVerse
+MAT	11	11	Jesus			Implicit			EntireVerse
+MAT	11	12	Jesus			Implicit			EntireVerse
+MAT	11	13	Jesus			Implicit			EntireVerse
+MAT	11	14	Jesus			Implicit			EntireVerse
+MAT	11	15	Jesus			Implicit			EntireVerse
+MAT	11	16	Jesus			Implicit			EntireVerse
+MAT	11	17	Jesus			Implicit			EntireVerse
+MAT	11	18	Jesus			Implicit			EntireVerse
+MAT	11	19	Jesus			Implicit			EntireVerse
+MAT	11	21	Jesus	rebuking		Implicit			EntireVerse
+MAT	11	22	Jesus	rebuking		Implicit			EntireVerse
+MAT	11	23	Jesus	rebuking		Implicit			EntireVerse
+MAT	11	24	Jesus	rebuking		Implicit			EntireVerse
 MAT	11	25	Jesus	praying		Normal			EndOfVerse
 MAT	11	26	Jesus	praying		Normal			EntireVerse
 MAT	11	27	Jesus			Normal			EntireVerse
@@ -16327,11 +16327,11 @@ MAT	11	29	Jesus	compassionately		Normal			EntireVerse
 MAT	11	30	Jesus	compassionately		Normal			EntireVerse
 MAT	12	2	Pharisees, some	angry		Dialogue			EndOfVerse
 MAT	12	3	Jesus			Normal			EndOfVerse
-MAT	12	4	Jesus			Implicit			
-MAT	12	5	Jesus			Implicit			
-MAT	12	6	Jesus			Implicit			
-MAT	12	7	Jesus			Implicit			
-MAT	12	8	Jesus			Implicit			
+MAT	12	4	Jesus			Implicit			EntireVerse
+MAT	12	5	Jesus			Implicit			EntireVerse
+MAT	12	6	Jesus			Implicit			EntireVerse
+MAT	12	7	Jesus			Implicit			EntireVerse
+MAT	12	8	Jesus			Implicit			EntireVerse
 MAT	12	10	Pharisees, some	testing		Dialogue			Unspecified
 MAT	12	11	Jesus			Dialogue			EndOfVerse
 MAT	12	12	Jesus			Normal			EntireVerse
@@ -16344,26 +16344,26 @@ MAT	12	21	scripture			Quotation	God		StartOfVerse
 MAT	12	23	people who saw healing of demon-possessed man who was blind and mute	astonished	all the people	Normal			EndOfVerse
 MAT	12	24	Pharisees			Normal			EndOfVerse
 MAT	12	25	Jesus			Normal			EndOfVerse
-MAT	12	26	Jesus			Implicit			
-MAT	12	27	Jesus			Implicit			
-MAT	12	28	Jesus			Implicit			
-MAT	12	29	Jesus			Implicit			
-MAT	12	30	Jesus			Implicit			
-MAT	12	31	Jesus			Implicit			
-MAT	12	32	Jesus			Implicit			
-MAT	12	33	Jesus			Implicit			
-MAT	12	34	Jesus			Implicit			
-MAT	12	35	Jesus			Implicit			
-MAT	12	36	Jesus			Implicit			
-MAT	12	37	Jesus			Implicit			
+MAT	12	26	Jesus			Implicit			EntireVerse
+MAT	12	27	Jesus			Implicit			EntireVerse
+MAT	12	28	Jesus			Implicit			EntireVerse
+MAT	12	29	Jesus			Implicit			EntireVerse
+MAT	12	30	Jesus			Implicit			EntireVerse
+MAT	12	31	Jesus			Implicit			EntireVerse
+MAT	12	32	Jesus			Implicit			EntireVerse
+MAT	12	33	Jesus			Implicit			EntireVerse
+MAT	12	34	Jesus			Implicit			EntireVerse
+MAT	12	35	Jesus			Implicit			EntireVerse
+MAT	12	36	Jesus			Implicit			EntireVerse
+MAT	12	37	Jesus			Implicit			EntireVerse
 MAT	12	38	Pharisees/teachers of religious law	challenging		Dialogue			EndOfVerse
 MAT	12	39	Jesus	rebuking		Dialogue			Unspecified
 MAT	12	40	Jesus	rebuking		Normal			Unspecified
 MAT	12	41	Jesus	rebuking		Normal			Unspecified
 MAT	12	42	Jesus	rebuking		Normal			Unspecified
-MAT	12	43	Jesus			Implicit			
-MAT	12	44	Jesus			Implicit			
-MAT	12	45	Jesus			Implicit			
+MAT	12	43	Jesus			Implicit			EntireVerse
+MAT	12	44	Jesus			Implicit			EntireVerse
+MAT	12	45	Jesus			Implicit			EntireVerse
 MAT	12	46	Jesus			Indirect			
 MAT	12	46	Jesus' family		Jesus' mother and brothers	Indirect	Mary, Jesus' mother		
 # MAT 12:47 is not contained in early manuscripts.
@@ -16372,32 +16372,32 @@ MAT	12	48	Jesus	questioning		Dialogue			Unspecified
 MAT	12	49	Jesus			Dialogue			EndOfVerse
 MAT	12	50	Jesus			Normal			EntireVerse
 MAT	13	3	Jesus			Normal			EndOfVerse
-MAT	13	4	Jesus			Implicit			
-MAT	13	5	Jesus			Implicit			
-MAT	13	6	Jesus			Implicit			
-MAT	13	7	Jesus			Implicit			
-MAT	13	8	Jesus			Implicit			
-MAT	13	9	Jesus			Implicit			
+MAT	13	4	Jesus			Implicit			EntireVerse
+MAT	13	5	Jesus			Implicit			EntireVerse
+MAT	13	6	Jesus			Implicit			EntireVerse
+MAT	13	7	Jesus			Implicit			EntireVerse
+MAT	13	8	Jesus			Implicit			EntireVerse
+MAT	13	9	Jesus			Implicit			EntireVerse
 MAT	13	10	disciples	questioning		Dialogue			Unspecified
 MAT	13	11	Jesus			Normal			Unspecified
 MAT	13	12	Jesus			Normal			EntireVerse
 MAT	13	13	Jesus			Normal			EntireVerse
 MAT	13	14	Jesus			Normal			EntireVerse
 MAT	13	15	Jesus			Normal			Unspecified
-MAT	13	16	Jesus			Implicit			
-MAT	13	17	Jesus			Implicit			
-MAT	13	18	Jesus			Implicit			
-MAT	13	19	Jesus			Implicit			
-MAT	13	20	Jesus			Implicit			
-MAT	13	21	Jesus			Implicit			
-MAT	13	22	Jesus			Implicit			
-MAT	13	23	Jesus			Implicit			
+MAT	13	16	Jesus			Implicit			EntireVerse
+MAT	13	17	Jesus			Implicit			EntireVerse
+MAT	13	18	Jesus			Implicit			EntireVerse
+MAT	13	19	Jesus			Implicit			EntireVerse
+MAT	13	20	Jesus			Implicit			EntireVerse
+MAT	13	21	Jesus			Implicit			EntireVerse
+MAT	13	22	Jesus			Implicit			EntireVerse
+MAT	13	23	Jesus			Implicit			EntireVerse
 MAT	13	24	Jesus			Normal			EndOfVerse
-MAT	13	25	Jesus			Implicit			
-MAT	13	26	Jesus			Implicit			
-MAT	13	27	Jesus			Implicit			
-MAT	13	28	Jesus			Implicit			
-MAT	13	29	Jesus			Implicit			
+MAT	13	25	Jesus			Implicit			EntireVerse
+MAT	13	26	Jesus			Implicit			EntireVerse
+MAT	13	27	Jesus			Implicit			EntireVerse
+MAT	13	28	Jesus			Implicit			EntireVerse
+MAT	13	29	Jesus			Implicit			EntireVerse
 MAT	13	30	Jesus			Normal			StartOfVerse
 MAT	13	31	Jesus			Normal			EndOfVerse
 MAT	13	32	Jesus			Normal			EntireVerse
@@ -16405,19 +16405,19 @@ MAT	13	33	Jesus			Normal			Unspecified
 MAT	13	35	scripture			Quotation	Asaph		Unspecified
 MAT	13	36	disciples			Normal			EndOfVerse
 MAT	13	37	Jesus			Normal			Unspecified
-MAT	13	38	Jesus			Implicit			
-MAT	13	39	Jesus			Implicit			
-MAT	13	40	Jesus			Implicit			
-MAT	13	41	Jesus			Implicit			
-MAT	13	42	Jesus			Implicit			
-MAT	13	43	Jesus			Implicit			
-MAT	13	44	Jesus			Implicit			
-MAT	13	45	Jesus			Implicit			
-MAT	13	46	Jesus			Implicit			
-MAT	13	47	Jesus			Implicit			
-MAT	13	48	Jesus			Implicit			
-MAT	13	49	Jesus			Implicit			
-MAT	13	50	Jesus			Implicit			
+MAT	13	38	Jesus			Implicit			EntireVerse
+MAT	13	39	Jesus			Implicit			EntireVerse
+MAT	13	40	Jesus			Implicit			EntireVerse
+MAT	13	41	Jesus			Implicit			EntireVerse
+MAT	13	42	Jesus			Implicit			EntireVerse
+MAT	13	43	Jesus			Implicit			EntireVerse
+MAT	13	44	Jesus			Implicit			EntireVerse
+MAT	13	45	Jesus			Implicit			EntireVerse
+MAT	13	46	Jesus			Implicit			EntireVerse
+MAT	13	47	Jesus			Implicit			EntireVerse
+MAT	13	48	Jesus			Implicit			EntireVerse
+MAT	13	49	Jesus			Implicit			EntireVerse
+MAT	13	50	Jesus			Implicit			EntireVerse
 MAT	13	51	disciples			Dialogue			Unspecified
 MAT	13	51	Jesus	questioning		Dialogue			Unspecified
 MAT	13	52	Jesus			Dialogue			Unspecified
@@ -17665,8 +17665,8 @@ LUK	1	58	neighbors and relatives of Elizabeth and Zacharias (Zechariah)	rejoicin
 LUK	1	58	Needs Review			Rare			
 # There is a potential speaking part in v. 59 because some translations will render this using direct
 # speech instead of indirect. Something like:
-# The neighbors and relatives of Elizabeth and Zachariah said, «He should be called ‹Zachariah› like his father.»
-# Of course, if only the name «Zachariah» is in quotes, it should just be spoken by the narrator, but
+# The neighbors and relatives of Elizabeth and Zachariah said, Â«He should be called â€¹Zachariahâ€º like his father.Â»
+# Of course, if only the name Â«ZachariahÂ» is in quotes, it should just be spoken by the narrator, but
 # the quote parser isn't smart enough to automatically distinguish between those two cases.
 LUK	1	59	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Indirect			
 LUK	1	59	narrator-LUK			Quotation			Unspecified
@@ -17676,7 +17676,7 @@ LUK	1	61	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Dialog
 # they were making signs m(as opposed to speaking), it most likely should be spoken by the narrator.
 # Also, including a "Needs Review" option, since a scripter who does not know the vernacular would
 # likely be unable to detect a case where it was translated something like: The neighbors asked,
-# “What is his name?” and they made signs to his father to inquire of him.
+# â€œWhat is his name?â€ and they made signs to his father to inquire of him.
 LUK	1	62	neighbors and relatives of Elizabeth and Zacharias (Zechariah)			Indirect			
 LUK	1	62	narrator-LUK			Quotation			Unspecified
 LUK	1	62	Needs Review			Potential			
@@ -17712,10 +17712,10 @@ LUK	2	22	Needs Review			Potential
 LUK	2	23	scripture			Quotation	God		EndOfVerse
 LUK	2	24	scripture			Quotation	God		Unspecified
 LUK	2	26	Holy Spirit, the			Indirect			
-LUK	2	29	Simeon, devout man in Jerusalem			Implicit			
-LUK	2	30	Simeon, devout man in Jerusalem			Implicit			
-LUK	2	31	Simeon, devout man in Jerusalem			Implicit			
-LUK	2	32	Simeon, devout man in Jerusalem			Implicit			
+LUK	2	29	Simeon, devout man in Jerusalem			Implicit			EntireVerse
+LUK	2	30	Simeon, devout man in Jerusalem			Implicit			EntireVerse
+LUK	2	31	Simeon, devout man in Jerusalem			Implicit			EntireVerse
+LUK	2	32	Simeon, devout man in Jerusalem			Implicit			EntireVerse
 LUK	2	33	Joseph, the carpenter/Mary, Jesus' mother	amazed		Rare			
 LUK	2	33	Needs Review			Potential			
 LUK	2	34	Simeon, devout man in Jerusalem			Normal			EndOfVerse
@@ -18830,34 +18830,34 @@ JHN	6	32	Jesus			Dialogue			Unspecified
 JHN	6	33	Jesus			Normal			EntireVerse
 JHN	6	34	people in crowd by Sea of Galilee	polite		Dialogue			Unspecified
 JHN	6	35	Jesus			Dialogue			Unspecified
-JHN	6	36	Jesus			Implicit			
-JHN	6	37	Jesus			Implicit			
-JHN	6	38	Jesus			Implicit			
-JHN	6	39	Jesus			Implicit			
-JHN	6	40	Jesus			Implicit			
+JHN	6	36	Jesus			Implicit			EntireVerse
+JHN	6	37	Jesus			Implicit			EntireVerse
+JHN	6	38	Jesus			Implicit			EntireVerse
+JHN	6	39	Jesus			Implicit			EntireVerse
+JHN	6	40	Jesus			Implicit			EntireVerse
 JHN	6	41	Jesus			Quotation			Unspecified
 JHN	6	41	narrator-JHN			Quotation			Unspecified
 JHN	6	42	Jews, the	grumbling		Normal			Unspecified
 JHN	6	43	Jesus			Dialogue			Unspecified
-JHN	6	44	Jesus			Implicit			
-JHN	6	45	Jesus			Implicit			
-JHN	6	46	Jesus			Implicit			
-JHN	6	47	Jesus			Implicit			
-JHN	6	48	Jesus			Implicit			
-JHN	6	49	Jesus			Implicit			
-JHN	6	50	Jesus			Implicit			
-JHN	6	51	Jesus			Implicit			
+JHN	6	44	Jesus			Implicit			EntireVerse
+JHN	6	45	Jesus			Implicit			EntireVerse
+JHN	6	46	Jesus			Implicit			EntireVerse
+JHN	6	47	Jesus			Implicit			EntireVerse
+JHN	6	48	Jesus			Implicit			EntireVerse
+JHN	6	49	Jesus			Implicit			EntireVerse
+JHN	6	50	Jesus			Implicit			EntireVerse
+JHN	6	51	Jesus			Implicit			EntireVerse
 JHN	6	52	Jews, the			Normal			Unspecified
 JHN	6	53	Jesus			Dialogue			Unspecified
-JHN	6	54	Jesus			Implicit			
-JHN	6	55	Jesus			Implicit			
-JHN	6	56	Jesus			Implicit			
-JHN	6	57	Jesus			Implicit			
-JHN	6	58	Jesus			Implicit			
+JHN	6	54	Jesus			Implicit			EntireVerse
+JHN	6	55	Jesus			Implicit			EntireVerse
+JHN	6	56	Jesus			Implicit			EntireVerse
+JHN	6	57	Jesus			Implicit			EntireVerse
+JHN	6	58	Jesus			Implicit			EntireVerse
 JHN	6	60	disciples	grumbling	disciples, many of His	Normal			Unspecified
 JHN	6	61	Jesus			Dialogue			EndOfVerse
-JHN	6	62	Jesus			Implicit			
-JHN	6	63	Jesus			Implicit			
+JHN	6	62	Jesus			Implicit			EntireVerse
+JHN	6	63	Jesus			Implicit			EntireVerse
 JHN	6	64	Jesus			Normal			StartOfVerse
 JHN	6	65	Jesus			Dialogue			Unspecified
 JHN	6	67	Jesus	questioning		Dialogue			Unspecified
@@ -20255,21 +20255,21 @@ ROM	3	5	Jews, the	speaking ironically		Hypothetical			Unspecified
 ROM	3	7	someone	arguing		Hypothetical			Unspecified
 ROM	3	8	Paul		we (the Apostles, including Paul)	Hypothetical			Unspecified
 ROM	3	10	scripture			Quotation	David		EndOfVerse
-ROM	3	11	scripture			Implicit	David		
-ROM	3	12	scripture			Implicit	David		
-ROM	3	13	scripture			Implicit	David		
+ROM	3	11	scripture			Implicit	David		EntireVerse
+ROM	3	12	scripture			Implicit	David		EntireVerse
+ROM	3	13	scripture			Implicit	David		EntireVerse
 # ROM 3:14 is a quote from PSA 10:7. While the Septuigint combines PSA 10 with 9 (The Hebrew has them separate)
 # and therefore attributes the whole thing to David, Davidic authorship is disputed by some. We used to just
 # default to psalmist, but since Psalm 10 now overrides to David, it makes more sense to go with the more
 # popular position that this is indeed Davidic.
-ROM	3	14	scripture			Implicit	David		
-ROM	3	15	scripture			Implicit	Isaiah		
-ROM	3	16	scripture			Implicit	Isaiah		
-ROM	3	17	scripture			Implicit	Isaiah		
-ROM	3	18	scripture			Implicit	David		
+ROM	3	14	scripture			Implicit	David		EntireVerse
+ROM	3	15	scripture			Implicit	Isaiah		EntireVerse
+ROM	3	16	scripture			Implicit	Isaiah		EntireVerse
+ROM	3	17	scripture			Implicit	Isaiah		EntireVerse
+ROM	3	18	scripture			Implicit	David		EntireVerse
 ROM	4	3	scripture			Quotation			EndOfVerse
-ROM	4	7	scripture			Implicit	David		
-ROM	4	8	scripture			Implicit	David		
+ROM	4	7	scripture			Implicit	David		EntireVerse
+ROM	4	8	scripture			Implicit	David		EntireVerse
 ROM	4	9	scripture			Quotation			Unspecified
 ROM	4	17	scripture			Quotation	God		Unspecified
 ROM	4	18	scripture			Quotation	God		Unspecified
@@ -20342,7 +20342,7 @@ ROM	15	10	scripture			Quotation	Moses		EndOfVerse
 ROM	15	11	scripture			Quotation	psalmist		EndOfVerse
 ROM	15	12	scripture			Quotation	Isaiah		EndOfVerse
 ROM	15	21	scripture			Quotation	Isaiah		Unspecified
-ROM	16	22	Tertius			Implicit			
+ROM	16	22	Tertius			Implicit			EntireVerse
 1CO	1	12	follower of Apollos	boasting		Hypothetical			Unspecified
 1CO	1	12	follower of Cephas (Peter)	boasting		Hypothetical			Unspecified
 1CO	1	12	follower of Paul	boasting		Hypothetical			Unspecified
@@ -20843,11 +20843,11 @@ REV	17	18	angel (one of the seven)			Normal			EntireVerse
 REV	18	2	angel, another, coming down from heaven	shouting		Normal			EndOfVerse
 REV	18	3	angel, another, coming down from heaven	shouting		Normal			EntireVerse
 REV	18	4	voice from heaven, another			Normal			EndOfVerse
-REV	18	5	voice from heaven, another			Implicit			
-REV	18	6	voice from heaven, another			Implicit			
+REV	18	5	voice from heaven, another			Implicit			EntireVerse
+REV	18	6	voice from heaven, another			Implicit			EntireVerse
 REV	18	7	Babylon (personified as adulteress)			Hypothetical			Unspecified
-REV	18	7	voice from heaven, another			Implicit			
-REV	18	8	voice from heaven, another			Implicit			
+REV	18	7	voice from heaven, another			Implicit			EntireVerse
+REV	18	8	voice from heaven, another			Implicit			EntireVerse
 REV	18	9	voice from heaven, another			Normal			Unspecified
 REV	18	10	kings of the earth	weeping		Normal			
 REV	18	10	voice from heaven, another			Normal			
@@ -20931,4 +20931,5 @@ REV	22	17	Holy Spirit, the/bride, the (referring to the Church)		Holy Spirit and
 REV	22	18	narrator-REV			Potential			
 REV	22	19	narrator-REV			Potential			
 REV	22	20	Jesus			Normal			ContainedWithinVerse
+
 


### PR DESCRIPTION
We realized that the change to mark so many verses as Implicit did not really reflect the intention of that type, and actually made it harder for a user distinguish between normal and implicit for the purpose of deciding when it was appropriate to use quotation marks.
Also marked a couple longer discourses in GEN (ch 24 & ch 44) as Implicit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/848)
<!-- Reviewable:end -->
