### PR TITLE
PG-1493: Rolled back MarkDig.Signed to v. 0.30.4

### DIFF
--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -115,8 +115,8 @@
     <Reference Include="L10NSharp, Version=6.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\packages\L10NSharp.6.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig.Signed, Version=0.31.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.Signed.0.31.0\lib\net462\Markdig.Signed.dll</HintPath>
+    <Reference Include="Markdig.Signed, Version=0.30.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.Signed.0.30.4\lib\net452\Markdig.Signed.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -15,7 +15,7 @@
   <package id="icu.net" version="2.9.0" targetFramework="net472" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net472" />
   <package id="L10NSharp" version="6.0.0" targetFramework="net472" />
-  <package id="Markdig.Signed" version="0.31.0" targetFramework="net472" />
+  <package id="Markdig.Signed" version="0.30.4" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net472" />

--- a/Reference Text Utility/Reference Text Utility.csproj
+++ b/Reference Text Utility/Reference Text Utility.csproj
@@ -170,7 +170,7 @@
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Markdig.Signed">
-      <Version>0.31.0</Version>
+      <Version>0.30.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
       <Version>7.0.0</Version>


### PR DESCRIPTION
This DLL is referenced explicitly only in tests and and Reference Text Utility, but that causes the referenced version to end up in the output folder, where it is picked up by the installer. ParatextData.DLL references the slightly older version, which causes a FileLoadException when doing string extraction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/852)
<!-- Reviewable:end -->
