### PR TITLE
PG-1494/PG-1495: Do not allow an interruption ID to be assigned to a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [6.1.0] - 2023-05-09
+
+### Changed
+- In CharacterVerseData (and in its concrete implementations with overrides: ControlCharacterVerseData and CombinedCharacterVerseData), GetUniqueCharacterDeliveryAliasInfo and GetUniqueCharacterDeliveryInfo fixed so that they always excludes interruptions (since they are intended only for use in compiling a list of characters for user assignment).
+- AssignCharacterViewModel.GetUniqueCharacters(string filterText) fixed to exclude interruptions
+
+### Added
+- Added the following static methods to CharacterVerseData: IsUserAssignable, IsInterruption
+
 ## [6.0.0] - 2023-01-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [6.1.0] - 2023-05-09
 
 ### Changed
-- In CharacterVerseData (and in its concrete implementations with overrides: ControlCharacterVerseData and CombinedCharacterVerseData), GetUniqueCharacterDeliveryAliasInfo and GetUniqueCharacterDeliveryInfo fixed so that they always excludes interruptions (since they are intended only for use in compiling a list of characters for user assignment).
+- In CharacterVerseData (and in its concrete implementations with overrides: ControlCharacterVerseData and CombinedCharacterVerseData), GetUniqueCharacterDeliveryAliasInfo and GetUniqueCharacterDeliveryInfo fixed so that they always exclude interruptions (since they are intended only for use in compiling a list of characters for user assignment).
 - AssignCharacterViewModel.GetUniqueCharacters(string filterText) fixed to exclude interruptions
 
 ### Added

--- a/Glyssen/Dialogs/AddCharacterDlg.cs
+++ b/Glyssen/Dialogs/AddCharacterDlg.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using Glyssen.Controls;
+using GlyssenCharacters;
 using GlyssenEngine.Script;
 using static System.String;
 using AssignCharacterViewModel = GlyssenEngine.ViewModels.AssignCharacterViewModel<System.Drawing.Font>;
@@ -68,7 +69,7 @@ namespace Glyssen.Dialogs
 
 		private void AddNewCharacter(string character)
 		{
-			if (IsNullOrWhiteSpace(character))
+			if (IsNullOrWhiteSpace(character) || !CharacterVerseData.IsUserAssignable(character))
 				return;
 
 			var existingItem = CurrentContextCharacters.FirstOrDefault(c => c.ToString().Equals(character, StringComparison.OrdinalIgnoreCase));

--- a/GlyssenCharacters/CharacterVerseData.cs
+++ b/GlyssenCharacters/CharacterVerseData.cs
@@ -116,7 +116,7 @@ namespace GlyssenCharacters
 
 		public static bool IsCharacterExtraBiblical(string characterId)
 		{
-			// See comment in IsCharacterStandard regarding checking the length first as a the speed optimization
+			// See comment in IsCharacterStandard regarding checking the length first as a speed optimization
 			switch (characterId?.Length)
 			{
 				case 6: return characterId.StartsWith(kBookOrChapterPrefix, StringComparison.Ordinal);
@@ -127,7 +127,7 @@ namespace GlyssenCharacters
 
 		public static bool IsInterruption(string characterId)
 		{
-			// See comment in IsCharacterStandard regarding checking the length first as a the speed optimization
+			// See comment in IsCharacterStandard regarding checking the length first as a speed optimization
 			return characterId?.Length == 16 && characterId.StartsWith(kInterruptionPrefix, StringComparison.Ordinal);
 		}
 

--- a/GlyssenCharacters/CharacterVerseData.cs
+++ b/GlyssenCharacters/CharacterVerseData.cs
@@ -124,6 +124,12 @@ namespace GlyssenCharacters
 			}
 		}
 
+		public static bool IsUserAssignable(string characterId)
+		{
+			return !IsCharacterExtraBiblical(characterId) &&
+				(characterId?.Length != 16 || !characterId.StartsWith(kInterruptionPrefix, StringComparison.Ordinal));
+		}
+
 		// This above code could be replaced with the following slightly more readable/maintainable version, but because
 		// this is speed-critical, I optimized for performance based on extensive comparative testing. If you want to tweak
 		// this, be sure to use the commented-out IsCharacterExtraBiblical_SpeedComparison_EnsureFastestVersion,
@@ -220,6 +226,8 @@ namespace GlyssenCharacters
 		protected const string kExtraBiblicalPrefix = "extra-";
 		/// <summary>Character ID prefix for intro material (not for UI)</summary>
 		protected const string kIntroPrefix = "intro-";
+		/// <summary>Character ID prefix for interruptions (not for UI or for assignment)</summary>
+		protected const string kInterruptionPrefix = "interruption-";
 
 		private static readonly Regex s_narratorRegex = new Regex($"{kNarratorPrefix}(?<bookId>...)");
 
@@ -308,6 +316,11 @@ namespace GlyssenCharacters
 			return m_data.Any();
 		}
 
+		/// <summary>
+		/// Gets a set of all unique character/delivery/alias entries. Since this is intended only
+		/// for use in compiling a list of characters for user assignment, it always excludes
+		/// interruptions and extra-biblical IDs.
+		/// </summary>
 		public IReadOnlySet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryAliasInfo()
 		{
 			return m_uniqueCharacterDeliverAliasEntries ??
@@ -316,12 +329,19 @@ namespace GlyssenCharacters
 
 		protected virtual HashSet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryAliasSet()
 		{
-			return new HashSet<ICharacterDeliveryInfo>(m_data, m_characterDeliveryAliasEqualityComparer);
+			return new HashSet<ICharacterDeliveryInfo>(m_data.Where(c => IsUserAssignable(c.Character)),
+				m_characterDeliveryAliasEqualityComparer);
 		}
 
+		/// <summary>
+		/// Gets all unique character/delivery information for the given book. Since this is
+		/// intended only for use in compiling a list of characters for assignment, it always
+		/// excludes interruptions (which should never be assigned).
+		/// </summary>
 		public virtual ISet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryInfo(string bookCode)
 		{
-			return new HashSet<ICharacterDeliveryInfo>(m_data.Where(cv => cv.BookCode == bookCode), m_characterDeliveryEqualityComparer);
+			return new HashSet<ICharacterDeliveryInfo>(m_data.Where(cv => cv.BookCode == bookCode && cv.QuoteType != QuoteType.Interruption),
+				m_characterDeliveryEqualityComparer);
 		}
 
 		public ISet<string> GetUniqueDeliveries()

--- a/GlyssenCharacters/CharacterVerseData.cs
+++ b/GlyssenCharacters/CharacterVerseData.cs
@@ -125,12 +125,14 @@ namespace GlyssenCharacters
 			}
 		}
 
-		public static bool IsUserAssignable(string characterId)
+		public static bool IsInterruption(string characterId)
 		{
 			// See comment in IsCharacterStandard regarding checking the length first as a the speed optimization
-			return !IsCharacterExtraBiblical(characterId) &&
-				(characterId?.Length != 16 || !characterId.StartsWith(kInterruptionPrefix, StringComparison.Ordinal));
+			return characterId?.Length == 16 && characterId.StartsWith(kInterruptionPrefix, StringComparison.Ordinal);
 		}
+
+		public static bool IsUserAssignable(string characterId) =>
+			!IsCharacterExtraBiblical(characterId) && !IsInterruption(characterId);
 
 		// This above code could be replaced with the following slightly more readable/maintainable version, but because
 		// this is speed-critical, I optimized for performance based on extensive comparative testing. If you want to tweak
@@ -313,15 +315,12 @@ namespace GlyssenCharacters
 			return false;
 		}
 
-		public bool Any()
-		{
-			return m_data.Any();
-		}
+		public bool Any() => m_data.Any();
 
 		/// <summary>
 		/// Gets a set of all unique character/delivery/alias entries. Since this is intended only
 		/// for use in compiling a list of characters for user assignment, it always excludes
-		/// interruptions and extra-biblical IDs.
+		/// interruptions.
 		/// </summary>
 		public IReadOnlySet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryAliasInfo()
 		{
@@ -331,7 +330,7 @@ namespace GlyssenCharacters
 
 		protected virtual HashSet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryAliasSet()
 		{
-			return new HashSet<ICharacterDeliveryInfo>(m_data.Where(c => IsUserAssignable(c.Character)),
+			return new HashSet<ICharacterDeliveryInfo>(m_data.Where(c => c.QuoteType != QuoteType.Interruption),
 				m_characterDeliveryAliasEqualityComparer);
 		}
 

--- a/GlyssenCharacters/CharacterVerseData.cs
+++ b/GlyssenCharacters/CharacterVerseData.cs
@@ -116,6 +116,7 @@ namespace GlyssenCharacters
 
 		public static bool IsCharacterExtraBiblical(string characterId)
 		{
+			// See comment in IsCharacterStandard regarding checking the length first as a the speed optimization
 			switch (characterId?.Length)
 			{
 				case 6: return characterId.StartsWith(kBookOrChapterPrefix, StringComparison.Ordinal);
@@ -126,6 +127,7 @@ namespace GlyssenCharacters
 
 		public static bool IsUserAssignable(string characterId)
 		{
+			// See comment in IsCharacterStandard regarding checking the length first as a the speed optimization
 			return !IsCharacterExtraBiblical(characterId) &&
 				(characterId?.Length != 16 || !characterId.StartsWith(kInterruptionPrefix, StringComparison.Ordinal));
 		}

--- a/GlyssenCharacters/ControlCharacterVerseData.cs
+++ b/GlyssenCharacters/ControlCharacterVerseData.cs
@@ -232,6 +232,11 @@ namespace GlyssenCharacters
 			throw new ApplicationException("The control file cannot be modified programmatically.");
 		}
 
+		/// <summary>
+		/// Gets a set of all unique character/delivery/alias entries. Since this is intended only
+		/// for use in compiling a list of characters for user assignment, it always excludes
+		/// interruptions.
+		/// </summary>
 		protected override HashSet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryAliasSet()
 		{
 			var set = base.GetUniqueCharacterDeliveryAliasSet();
@@ -240,6 +245,11 @@ namespace GlyssenCharacters
 			return set;
 		}
 
+		/// <summary>
+		/// Gets all unique character/delivery information for the given book. Since this is
+		/// intended only for use in compiling a list of characters for assignment, it always
+		/// excludes interruptions (which should never be assigned).
+		/// </summary>
 		public override ISet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryInfo(string bookCode)
 		{
 			var set = base.GetUniqueCharacterDeliveryInfo(bookCode);

--- a/GlyssenCharacters/Resources/CharacterVerse.txt
+++ b/GlyssenCharacters/Resources/CharacterVerse.txt
@@ -1,4 +1,4 @@
-Control File Version	170
+Control File Version	171
 #	C	V	Character ID	Delivery	Alias	Quote Type	Default Character	Parallel Passage	Quote Position
 # DEU Almost the whole book is by Moses -- In some Bibles, first level quotes are actually 2nd level -- see DEU 1.5
 GEN	1	3	God		God (Yahweh)	Normal			ContainedWithinVerse

--- a/GlyssenCharactersTests/CharacterVerseDataTests.cs
+++ b/GlyssenCharactersTests/CharacterVerseDataTests.cs
@@ -46,6 +46,48 @@ namespace GlyssenCharactersTests
 			Assert.IsFalse(CharacterVerseData.IsCharacterStandard(characterId));
 		}
 
+		[TestCase("intro-REV")]
+		[TestCase("BC-MAT")]
+		[TestCase("extra-JHN")]
+		[TestCase("interruption-JHN")]
+		public void IsUserAssignable_ExtraBiblicalOrInterruption_ReturnsFalse(string characterId)
+		{
+			Assert.IsFalse(CharacterVerseData.IsUserAssignable(characterId));
+		}
+
+		[TestCase("intro-REVELATION")]
+		[TestCase("BC-matthew")]
+		[TestCase("extraJHN")]
+		[TestCase("interruption")]
+		[TestCase("interruption-")]
+		[TestCase("interruption-Whatever")]
+		[TestCase("frog man")]
+		[TestCase("narrator-JHN")]
+		public void IsUserAssignable_NotExtraBiblicalOrInterruption_ReturnsTrue(string characterId)
+		{
+			Assert.IsTrue(CharacterVerseData.IsUserAssignable(characterId));
+		}
+
+		[TestCase("interruption-MAT")]
+		[TestCase("interruption-JHN")]
+		[TestCase("interruption-FRG")]
+		public void IsInterruption_Interruption_ReturnsFalse(string characterId)
+		{
+			Assert.IsTrue(CharacterVerseData.IsInterruption(characterId));
+		}
+
+		[TestCase("intro-REV")]
+		[TestCase("BC-MAT")]
+		[TestCase("extra-JHN")]
+		[TestCase("interruption")]
+		[TestCase("interruption-")]
+		[TestCase("interruption-Whatever")]
+		[TestCase("frog man")]
+		[TestCase("narrator-JHN")]
+		public void IsInterruption_NotInterruption_ReturnsFalse(string characterId)
+		{
+			Assert.IsFalse(CharacterVerseData.IsInterruption(characterId));
+		}
 
 		// If IsCharacterStandard and/or IsCharacterExtraBiblical need to be tweaked, the following test can be used (and adjusted as needed)
 		// to provide a good head-to-head comparison to make sure performance is optimized, since these methods are performance-critical.

--- a/GlyssenCharactersTests/CharacterVerseDataTests.cs
+++ b/GlyssenCharactersTests/CharacterVerseDataTests.cs
@@ -71,7 +71,7 @@ namespace GlyssenCharactersTests
 		[TestCase("interruption-MAT")]
 		[TestCase("interruption-JHN")]
 		[TestCase("interruption-FRG")]
-		public void IsInterruption_Interruption_ReturnsFalse(string characterId)
+		public void IsInterruption_Interruption_ReturnsTrue(string characterId)
 		{
 			Assert.IsTrue(CharacterVerseData.IsInterruption(characterId));
 		}

--- a/GlyssenCharactersTests/ControlCharacterVerseDataTests.cs
+++ b/GlyssenCharactersTests/ControlCharacterVerseDataTests.cs
@@ -286,5 +286,19 @@ namespace GlyssenCharactersTests
 			// Every line in the control file for LEV 1 is Implicit.
 			Assert.True(ControlCharacterVerseData.Singleton.ExpectedQuotes[BCVRef.BookToNumber("LEV")].ContainsKey(1));
 		}
+
+		[Test]
+		public void GetUniqueCharacterDeliveryAliasInfo_DoesNotContainInterruption()
+		{
+			Assert.IsFalse(ControlCharacterVerseData.Singleton.GetUniqueCharacterDeliveryAliasInfo()
+				.Any(c => c.Character.StartsWith("interruption-")));
+		}
+
+		[Test]
+		public void GetUniqueCharacterDeliveryInfo_DoesNotContainInterruption()
+		{
+			Assert.IsFalse(ControlCharacterVerseData.Singleton.GetUniqueCharacterDeliveryInfo("JHN")
+				.Any(c => c.Character.StartsWith("interruption-")));
+		}
 	}
 }

--- a/GlyssenEngine/Character/CombinedCharacterVerseData.cs
+++ b/GlyssenEngine/Character/CombinedCharacterVerseData.cs
@@ -74,6 +74,11 @@ namespace GlyssenEngine.Character
 			return result;
 		}
 
+		/// <summary>
+		/// Gets all unique character/delivery information for the given book. Since this is
+		/// intended only for use in compiling a list of characters for assignment, it always
+		/// excludes interruptions (which should never be assigned).
+		/// </summary>
 		public ISet<ICharacterDeliveryInfo> GetUniqueCharacterDeliveryInfo(string bookCode)
 		{
 			var result = ControlCharacterVerseData.Singleton.GetUniqueCharacterDeliveryInfo(bookCode);

--- a/GlyssenEngine/ProjectDataMigrator.cs
+++ b/GlyssenEngine/ProjectDataMigrator.cs
@@ -280,9 +280,9 @@ namespace GlyssenEngine
 
 							// PG-1494: There was a bug that made it possible for the user to set the id to an interruption,
 							// rather than just setting it to narrator.
-							// Testing length first improves performance.
-							if (block.CharacterId.Length == 16 && block.CharacterId.StartsWith("interruption-"))
+							if (CharacterVerseData.IsInterruption(block.CharacterId))
 							{
+	                            project.ProjectCharacterVerseData.RemoveAllEntriesForBlock(bookNum, block);
 								block.SetNonDramaticCharacterId(CharacterVerseData.GetStandardCharacterId(book.BookId, CharacterVerseData.StandardCharacter.Narrator));
 								numberOfChangesMade++;
 								break;

--- a/GlyssenEngine/ProjectDataMigrator.cs
+++ b/GlyssenEngine/ProjectDataMigrator.cs
@@ -278,7 +278,17 @@ namespace GlyssenEngine
 							if (CharacterVerseData.IsCharacterStandard(block.CharacterId))
 								break;
 
-	                        var knownFactoryCharacter = characterDetailDictionary.ContainsKey(block.CharacterIdInScript);
+							// PG-1494: There was a bug that made it possible for the user to set the id to an interruption,
+							// rather than just setting it to narrator.
+							// Testing length first improves performance.
+							if (block.CharacterId.Length == 16 && block.CharacterId.StartsWith("interruption-"))
+							{
+								block.SetNonDramaticCharacterId(CharacterVerseData.GetStandardCharacterId(book.BookId, CharacterVerseData.StandardCharacter.Narrator));
+								numberOfChangesMade++;
+								break;
+							}
+
+							var knownFactoryCharacter = characterDetailDictionary.ContainsKey(block.CharacterIdInScript);
 	                        var unknownCharacter = !knownFactoryCharacter && !project.IsProjectSpecificCharacter(block.CharacterIdInScript);
 	                        if (unknownCharacter && project.ProjectCharacterVerseData.GetCharacters(bookNum, block.ChapterNumber, block.AllVerses)
 	                            .Any(c => c.Character == block.CharacterId && c.Delivery == (block.Delivery ?? "")))

--- a/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
+++ b/GlyssenEngine/ViewModels/AssignCharacterViewModel.cs
@@ -220,7 +220,8 @@ namespace GlyssenEngine.ViewModels
 		private HashSet<CharacterSpeakingMode> GetUniqueCharacterVerseObjectsForBlock(Block block)
 		{
 			return new HashSet<CharacterSpeakingMode>(m_combinedCharacterVerseData.GetCharacters(CurrentBookNumber,
-				block.ChapterNumber, (Block.VerseRangeFromBlock)block, Versification, true, true));
+				block.ChapterNumber, (Block.VerseRangeFromBlock)block, Versification, true, true)
+				.Where(cv => cv.QuoteType != QuoteType.Interruption));
 		}
 
 		public IEnumerable<Character> GetCharactersForCurrentReferenceTextMatchup()
@@ -263,7 +264,7 @@ namespace GlyssenEngine.ViewModels
 				// This will get any expected characters from other verses in the current block.
 				var block = CurrentBlock;
 				CollectionExtensions.AddRange(m_currentCharacters, m_combinedCharacterVerseData.GetCharacters(CurrentBookNumber, block.ChapterNumber,
-					new[] { (Block.VerseRangeFromBlock)block }, Versification, true));
+					new[] { (Block.VerseRangeFromBlock)block }, Versification, true).Where(cv => cv.QuoteType != QuoteType.Interruption));
 
 				var listToAdd = new SortedSet<Character>(m_currentCharacters.Select(cv =>
 					new Character(cv.Character, cv.LocalizedCharacter, cv.Alias, cv.LocalizedAlias)), m_characterComparer).Where(c => !listToReturn.Contains(c)).ToList();
@@ -277,7 +278,7 @@ namespace GlyssenEngine.ViewModels
 				foreach (var block in ContextBlocksBackward.Union(ContextBlocksForward))
 				{
 					m_currentCharacters.UnionWith(m_combinedCharacterVerseData.GetCharacters(CurrentBookNumber, block.ChapterNumber,
-						(Block.VerseRangeFromBlock)block, Versification, true));
+						(Block.VerseRangeFromBlock)block, Versification, true).Where(c => c.QuoteType != QuoteType.Interruption));
 				}
 
 				var listToAdd = new SortedSet<Character>(m_currentCharacters.Select(cv =>
@@ -306,7 +307,8 @@ namespace GlyssenEngine.ViewModels
 					.Where(c => c.LocalizedAlias == null && c.LocalizedCharacter.Contains(filterText, StringComparison.OrdinalIgnoreCase)),
 					new CharacterDeliveryEqualityComparer());
 				m_currentCharacters.AddRange(CharacterDetailData.Singleton.GetAll()
-					.Where(c => c.CharacterId.Contains(filterText, StringComparison.OrdinalIgnoreCase))
+					.Where(c => CharacterVerseData.IsUserAssignable(c.CharacterId) &&
+						c.CharacterId.Contains(filterText, StringComparison.OrdinalIgnoreCase))
 					.Select(c => new CharacterSpeakingMode(c.CharacterId, null, null, false)));
 				m_currentCharacters.UnionWith(uniqueEntries.Where(c => c.LocalizedAlias != null &&
 					(c.LocalizedCharacter.Contains(filterText, StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
Also, prevent the user from assigning or adding any ID that would be considered extra-biblical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/854)
<!-- Reviewable:end -->
