### PR TITLE
PTX-23350: Added b marker to list of follow-on paragraph styles

### DIFF
--- a/GlyssenEngine/Script/Block.cs
+++ b/GlyssenEngine/Script/Block.cs
@@ -63,7 +63,7 @@ namespace GlyssenEngine.Script
 			// might be added to the USFM standard, this regex matches only the known allowed poetry markers. It specifically prevents matching
 			// "qa", which is an acrostic header and should not be treated like other poetry markers. As the standard is changed in the future,
 			// any new markers that should be treated as "follow on" paragraphs will need to be added here.
-			s_regexFollowOnParagraphStyles = new Regex("^((q((m?\\d?)|[rc])?)|m|mi|(pi\\d?)|(l(f|(i(m?)\\d?))))$", RegexOptions.Compiled);
+			s_regexFollowOnParagraphStyles = new Regex("^((q((m?\\d?)|[rc])?)|b|m|mi|(pi\\d?)|(l(f|(i(m?)\\d?))))$", RegexOptions.Compiled);
 		}
 
 		internal Block()

--- a/GlyssenEngineTests/Script/BlockTests.cs
+++ b/GlyssenEngineTests/Script/BlockTests.cs
@@ -226,6 +226,7 @@ namespace GlyssenEngineTests.Script
 		[TestCase("pi2")]
 		[TestCase("qr")] // Right-aligned poetic line: https://ubsicap.github.io/usfm/poetry/index.html#qr
 		[TestCase("qc")] // Centered poetic line: https://ubsicap.github.io/usfm/poetry/index.html#qc
+		[TestCase("b")] // Blank line: https://ubsicap.github.io/usfm/paragraphs/index.html#b
 		public void IsFollowOnParagraphStyle_LineBreakingUsfmTag_ReturnsTrue(string tag)
 		{
 			var block = new Block(tag);


### PR DESCRIPTION
 This keeps Glyssen's logic in sync with Paratext (until that regex is actually available in ParatextDall.DLL anfd we can just use the "official" version).