### PR TITLE
PG-1502: Use patched version of L10nSharp

### DIFF
--- a/DevTools/DevTools.csproj
+++ b/DevTools/DevTools.csproj
@@ -73,8 +73,8 @@
     <Reference Include="icu.net, Version=2.9.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
       <HintPath>..\packages\icu.net.2.9.0\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=6.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\packages\L10NSharp.6.0.0\lib\net461\L10NSharp.dll</HintPath>
+    <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
+      <HintPath>..\packages\L10NSharp.7.0.0-beta0011\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/DevTools/DevTools.csproj
+++ b/DevTools/DevTools.csproj
@@ -74,7 +74,7 @@
       <HintPath>..\packages\icu.net.2.9.0\lib\net451\icu.net.dll</HintPath>
     </Reference>
     <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\packages\L10NSharp.7.0.0-beta0011\lib\net461\L10NSharp.dll</HintPath>
+      <HintPath>..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/DevTools/packages.config
+++ b/DevTools/packages.config
@@ -6,7 +6,7 @@
   <package id="EPPlus.System.Drawing" version="6.0.0" targetFramework="net472" />
   <package id="icu.net" version="2.9.0" targetFramework="net472" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net472" />
-  <package id="L10NSharp" version="6.0.0" targetFramework="net472" />
+  <package id="L10NSharp" version="7.0.0-beta0011" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net472" />

--- a/DevTools/packages.config
+++ b/DevTools/packages.config
@@ -6,7 +6,7 @@
   <package id="EPPlus.System.Drawing" version="6.0.0" targetFramework="net472" />
   <package id="icu.net" version="2.9.0" targetFramework="net472" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net472" />
-  <package id="L10NSharp" version="7.0.0-beta0011" targetFramework="net472" />
+  <package id="L10NSharp" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="3.1.6" targetFramework="net472" />

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -585,7 +585,7 @@
       <Version>59.1.7</Version>
     </PackageReference>
     <PackageReference Include="L10NSharp">
-      <Version>7.0.0-beta0011</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/Glyssen/Glyssen.csproj
+++ b/Glyssen/Glyssen.csproj
@@ -585,7 +585,7 @@
       <Version>59.1.7</Version>
     </PackageReference>
     <PackageReference Include="L10NSharp">
-      <Version>6.0.0</Version>
+      <Version>7.0.0-beta0011</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/GlyssenTests/App.config
+++ b/GlyssenTests/App.config
@@ -59,7 +59,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="L10NSharp" publicKeyToken="fd0b3e309a5b7c28" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyModel" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -107,8 +107,8 @@
     <Reference Include="icu.net, Version=2.9.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
       <HintPath>..\packages\icu.net.2.9.0\lib\net451\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=6.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\packages\L10NSharp.6.0.0\lib\net461\L10NSharp.dll</HintPath>
+    <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
+      <HintPath>..\packages\L10NSharp.7.0.0-beta0011\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Markdig.Signed, Version=0.33.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.Signed.0.33.0\lib\net462\Markdig.Signed.dll</HintPath>

--- a/GlyssenTests/GlyssenTests.csproj
+++ b/GlyssenTests/GlyssenTests.csproj
@@ -108,7 +108,7 @@
       <HintPath>..\packages\icu.net.2.9.0\lib\net451\icu.net.dll</HintPath>
     </Reference>
     <Reference Include="L10NSharp, Version=7.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
-      <HintPath>..\packages\L10NSharp.7.0.0-beta0011\lib\net461\L10NSharp.dll</HintPath>
+      <HintPath>..\packages\L10NSharp.7.0.0\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="Markdig.Signed, Version=0.33.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
       <HintPath>..\packages\Markdig.Signed.0.33.0\lib\net462\Markdig.Signed.dll</HintPath>

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -13,7 +13,7 @@
   <package id="ibusdotnet" version="2.0.3" targetFramework="net472" />
   <package id="icu.net" version="2.9.0" targetFramework="net472" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net472" />
-  <package id="L10NSharp" version="7.0.0-beta0011" targetFramework="net472" />
+  <package id="L10NSharp" version="7.0.0" targetFramework="net472" />
   <package id="Markdig.Signed" version="0.33.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />

--- a/GlyssenTests/packages.config
+++ b/GlyssenTests/packages.config
@@ -13,7 +13,7 @@
   <package id="ibusdotnet" version="2.0.3" targetFramework="net472" />
   <package id="icu.net" version="2.9.0" targetFramework="net472" />
   <package id="Icu4c.Win.Min" version="59.1.7" targetFramework="net472" />
-  <package id="L10NSharp" version="6.0.0" targetFramework="net472" />
+  <package id="L10NSharp" version="7.0.0-beta0011" targetFramework="net472" />
   <package id="Markdig.Signed" version="0.33.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />

--- a/Reference Text Utility/Reference Text Utility.csproj
+++ b/Reference Text Utility/Reference Text Utility.csproj
@@ -171,7 +171,7 @@
       <Version>2.9.0</Version>
     </PackageReference>
     <PackageReference Include="L10NSharp">
-      <Version>6.0.0</Version>
+      <Version>7.0.0-beta0011</Version>
     </PackageReference>
     <PackageReference Include="Markdig.Signed">
       <Version>0.33.0</Version>

--- a/Reference Text Utility/Reference Text Utility.csproj
+++ b/Reference Text Utility/Reference Text Utility.csproj
@@ -171,7 +171,7 @@
       <Version>2.9.0</Version>
     </PackageReference>
     <PackageReference Include="L10NSharp">
-      <Version>7.0.0-beta0011</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Markdig.Signed">
       <Version>0.33.0</Version>


### PR DESCRIPTION
 This prevents NullReferenceException because of MarkDig.Signed version mismatch between Glyssen and ParatextData

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/871)
<!-- Reviewable:end -->
