### PR TITLE
Fixed UX edge cases when project books contain no Scripture data

### DIFF
--- a/Glyssen.sln.DotSettings
+++ b/Glyssen.sln.DotSettings
@@ -54,6 +54,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=matchups/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Moabites/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multivoice/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Narr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nonpublishable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Omissible/@EntryIndexedValue">True</s:Boolean>

--- a/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
+++ b/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
@@ -545,8 +545,8 @@ namespace Glyssen.Dialogs
 			else
 			{
 				correspondingMultiVoiceCell.ReadOnly = true;
-				m_btnOk.Enabled = m_otBooksGrid.Rows.Cast<DataGridViewRow>().Any(row => row.Index != rowIndex && (bool)((DataGridViewCheckBoxCell)row.Cells[m_includeInScriptColumnIndex]).Value) ||
-				                  m_ntBooksGrid.Rows.Cast<DataGridViewRow>().Any(row => row.Index != rowIndex && (bool)((DataGridViewCheckBoxCell)row.Cells[m_includeInScriptColumnIndex]).Value);
+				m_btnOk.Enabled = m_otBooksGrid.Rows.Cast<DataGridViewRow>().Any(row => (row.Index != rowIndex || m_otBooksGrid != grid) && (bool)((DataGridViewCheckBoxCell)row.Cells[m_includeInScriptColumnIndex]).Value) ||
+				                  m_ntBooksGrid.Rows.Cast<DataGridViewRow>().Any(row => (row.Index != rowIndex || m_ntBooksGrid != grid) && (bool)((DataGridViewCheckBoxCell)row.Cells[m_includeInScriptColumnIndex]).Value);
 			}
 			grid.EndEdit();
 			grid.InvalidateCell(correspondingMultiVoiceCell);

--- a/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
+++ b/Glyssen/Dialogs/ScriptureRangeSelectionDlg.cs
@@ -344,12 +344,13 @@ namespace Glyssen.Dialogs
 
 		private bool UserWantsUpdatedContent(BookScript bookScriptFromExistingFile)
 		{
+			var bookNum = bookScriptFromExistingFile.BookNumber;
 			// If there is a newer version ask user if they want to get the updated version.
-			if (!GetParatextScrTextWrapperIfNeeded(true) || m_paratextScrTextWrapper.GetBookChecksum(bookScriptFromExistingFile.BookNumber) == bookScriptFromExistingFile.ParatextChecksum)
+			if (!GetParatextScrTextWrapperIfNeeded(true) || m_paratextScrTextWrapper.GetBookChecksum(bookNum) == bookScriptFromExistingFile.ParatextChecksum)
 				return false;
 			// If the updated version does NOT pass tests but the existing version does (i.e., user didn't override the checking status),
 			// we'll just stick with the version we have. If they want to update it manually later, they can.
-			if (m_paratextScrTextWrapper.DoesBookPassChecks(bookScriptFromExistingFile.BookNumber) && !bookScriptFromExistingFile.CheckStatusOverridden)
+			if (m_paratextScrTextWrapper.DoesBookPassChecks(bookNum) && !bookScriptFromExistingFile.CheckStatusOverridden)
 				return false;
 
 			var result = m_userDecisionAboutUpdatedBookContent;

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -1075,7 +1075,7 @@ namespace Glyssen
 		private void ProjectStateChangedAfterSelectingBooks(object sender, Project.ProjectStateChangedEventArgs e)
 		{
 			if (m_project != sender /* This probably can't happen. */ ||
-			    (m_project.ProjectState & ProjectState.FullyInitialized) == 0)
+			    (m_project.ProjectState & ProjectState.ReadyForUserInteraction) == 0)
 				return;
 
 			if (!m_project.IncludedBooks.Any())

--- a/Glyssen/MainForm.cs
+++ b/Glyssen/MainForm.cs
@@ -1054,19 +1054,23 @@ namespace Glyssen
 		{
 			using (var dlg = new ScriptureRangeSelectionDlg(m_project, m_paratextScrTextWrapperForRecentlyCreatedProject))
 			{
+				m_project.ProjectStateChanged += ProjectStateChangedAfterSelectingBooks;
+
 				if (ShowModalDialogWithWaitCursor(dlg) == DialogResult.OK)
 				{
 					m_project.ClearAssignCharacterStatus();
-					if ((m_project.ProjectState & ProjectState.FullyInitialized) > 0)
+					if ((m_project.ProjectState & ProjectState.ReadyForUserInteraction) > 0)
 					{
+						m_project.ProjectStateChanged -= ProjectStateChangedAfterSelectingBooks;
+
 						m_project.Analyze();
 						UpdateDisplayOfProjectInfo();
 						SaveCurrentProject(true);
 					}
-					else
-					{
-						m_project.ProjectStateChanged += ProjectStateChangedAfterSelectingBooks;
-					}
+				}
+				else
+				{
+					m_project.ProjectStateChanged -= ProjectStateChangedAfterSelectingBooks;
 				}
 			}
 			m_paratextScrTextWrapperForRecentlyCreatedProject = null;

--- a/GlyssenEngine/Paratext/ParatextProjectBookInfo.cs
+++ b/GlyssenEngine/Paratext/ParatextProjectBookInfo.cs
@@ -58,7 +58,12 @@ namespace GlyssenEngine.Paratext
 
 		public BookState GetState(int bookNum)
 		{
-			return m_books[bookNum].State;
+			if (m_books.TryGetValue(bookNum, out var status))
+				return status.State;
+
+			// I think this should never happen now, but to avoid a crash, if we don't have a
+			// status for this book, treat it like not passing.
+			return BookState.FailedCheck;
 		}
 
 		public IEnumerable<string> GetFailedChecks(int bookNum)

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -1570,13 +1570,6 @@ namespace GlyssenEngine
 				bookScript.Initialize(Versification);
 			}
 
-			if (bookScripts.All(b => !b.GetScriptBlocks().Any()))
-			{
-				// This is really unlikely for a real user.
-				Save();
-				return;
-			}
-
 			if (m_books.Any())
 			{
 				foreach (var book in bookScripts)
@@ -1593,7 +1586,9 @@ namespace GlyssenEngine
 				AddMissingAvailableBooks();
 			}
 
-			if (QuoteSystem == null)
+			if (!bookScripts.Any() || bookScripts.All(b => !b.GetScriptBlocks().Any())) // This is really unlikely for a real user (second part is probably impossible)
+				Save();
+			else if (QuoteSystem == null)
 				GuessAtQuoteSystem();
 			else if (IsQuoteSystemReadyForParse)
 				DoQuoteParse(bookScripts.Select(b => b.BookId));

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -1149,7 +1149,7 @@ namespace GlyssenEngine
 
 					existingAvailable.Remove(bookCode);
 				}
-				else
+				else if (newlyAvailableChecksPass != null || newlyAvailableChecksFail != null)
 				{
 					// New available book.
 					if (scrTextWrapper.DoesBookPassChecks(bookNum))

--- a/GlyssenEngine/Project.cs
+++ b/GlyssenEngine/Project.cs
@@ -1570,7 +1570,12 @@ namespace GlyssenEngine
 				bookScript.Initialize(Versification);
 			}
 
-			Debug.Assert(bookScripts.All(b => b.GetScriptBlocks().Any()));
+			if (bookScripts.All(b => !b.GetScriptBlocks().Any()))
+			{
+				// This is really unlikely for a real user.
+				Save();
+				return;
+			}
 
 			if (m_books.Any())
 			{


### PR DESCRIPTION
Fixed bug in ScriptureRangeSelectionDlg where OK button could be incorrectly disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/Glyssen/878)
<!-- Reviewable:end -->
